### PR TITLE
Overhaul how character encoding is handled. 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
       - run: pip install .
       - run: pip uninstall -y montepy
       - run: pip install --user dist/*.whl
+        # run scripts
+      - run: change_to_ascii -h
       - run: pip uninstall -y montepy
       - run: pip install --user dist/*.tar.gz
       - run: pip install --user montepy[test]

--- a/doc/source/api/montepy.input_parser.input_file.rst
+++ b/doc/source/api/montepy.input_parser.input_file.rst
@@ -1,0 +1,9 @@
+montepy.input\_parser.input\_file module
+========================================
+
+
+.. automodule:: montepy.input_parser.input_file
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members: _convert_to_int, _convert_to_enum

--- a/doc/source/api/montepy.input_parser.rst
+++ b/doc/source/api/montepy.input_parser.rst
@@ -16,6 +16,7 @@ Submodules
    montepy.input_parser.block_type
    montepy.input_parser.cell_parser
    montepy.input_parser.data_parser
+   montepy.input_parser.input_file
    montepy.input_parser.input_reader
    montepy.input_parser.input_syntax_reader
    montepy.input_parser.mcnp_input

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -1,0 +1,2 @@
+Frequently Asked Questions
+==========================

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -1,2 +1,70 @@
 Frequently Asked Questions
 ==========================
+
+Or more likely Frequent Error Debugging.
+
+Encoding Errors: UnicodeDecodeError
+-----------------------------------
+
+If you received the error below while opening a file in MontePy,
+there is like a non-ASCII character in your input file.
+You can read more about :ref:`Character Encoding here <encoding_background>`.
+
+To solve this problem you can:
+
+1. Try another encoding such as ``'utf8'`` or ``'cp1252'``. Pass it as an argument to :func:`~montepy.input_parser.input_reader.read_input`.
+2. Remove all non-ASCII characters with :ref:`the change_to_ascii utility <convert_ascii>`
+
+.. code-block:: python
+
+      ---------------------------------------------------------------------------
+        UnicodeDecodeError                        Traceback (most recent call last)
+        Cell In[2], line 1
+        ----> 1 problem = montepy.read_input("tests/inputs/bad_encoding.imcnp")
+
+        File ~/dev/montepy/montepy/input_parser/input_reader.py:35, in read_input(input_file, mcnp_version, encoding)
+             33 problem = mcnp_problem.MCNP_Problem(input_file)
+             34 problem.mcnp_version = mcnp_version
+        ---> 35 problem.parse_input(encoding=encoding)
+             36 return problem
+
+        File ~/dev/montepy/montepy/mcnp_problem.py:262, in MCNP_Problem.parse_input(self, check_input, encoding)
+            253 OBJ_MATCHER = {
+            254     block_type.BlockType.CELL: (Cell, self._cells),
+            255     block_type.BlockType.SURFACE: (
+           (...)
+            259     block_type.BlockType.DATA: (parse_data, self._data_inputs),
+            260 }
+            261 try:
+        --> 262     for i, input in enumerate(
+            263         input_syntax_reader.read_input_syntax(
+            264             self._input_file, self.mcnp_version, encoding=encoding
+            265         )
+            266     ):
+            267         self._original_inputs.append(input)
+            268         if i == 0 and isinstance(input, mcnp_input.Message):
+
+        File ~/dev/montepy/montepy/input_parser/input_syntax_reader.py:48, in read_input_syntax(input_file, mcnp_version, encoding)
+             46 reading_queue = deque()
+             47 with input_file.open("r", encoding=encoding) as fh:
+        ---> 48     yield from read_front_matters(fh, mcnp_version)
+             49     yield from read_data(fh, mcnp_version)
+
+        File ~/dev/montepy/montepy/input_parser/input_syntax_reader.py:79, in read_front_matters(fh, mcnp_version)
+             77 lines = []
+             78 raw_lines = []
+        ---> 79 for i, line in enumerate(fh):
+             80     if i == 0 and line.upper().startswith("MESSAGE:"):
+             81         is_in_message_block = True
+
+        File ~/dev/montepy/montepy/input_parser/input_file.py:95, in MCNP_InputFile.__iter__(self)
+             94 def __iter__(self):
+        ---> 95     for lineno, line in enumerate(self._fh):
+             96         self._lineno = lineno + 1
+             97         yield line
+
+        File ~/mambaforge/lib/python3.10/encodings/ascii.py:26, in IncrementalDecoder.decode(self, input, final)
+             25 def decode(self, input, final=False):
+        ---> 26     return codecs.ascii_decode(input, self.errors)[0]
+
+        UnicodeDecodeError: 'ascii' codec can't decode byte 0xff in position 159: ordinal not in range(128)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -12,7 +12,11 @@ Welcome to MontePy's documentation!
 
    starting
 
+   utilities
+
    tricks
+
+   faq
 
    developing
 

--- a/doc/source/utilities.rst
+++ b/doc/source/utilities.rst
@@ -32,6 +32,8 @@ To use this run:
 
    python -m montepy -c [files]
 
+.. _convert_ascii:
+
 Converting Encoding to ASCII
 ----------------------------
 
@@ -54,6 +56,8 @@ Command Line Options
           -d, --delete      Delete any non-ascii characters. This is the default.
           -w, --whitespace  Replace non-ascii characters with a space.
 
+
+.. _encoding_background:
 
 Background
 ++++++++++

--- a/doc/source/utilities.rst
+++ b/doc/source/utilities.rst
@@ -1,0 +1,111 @@
+Utility Scripts
+===============
+
+Package Level Execution Options
+-------------------------------
+.. code-block:: console
+
+        usage: montepy [-h] [-c [input_file ...]]
+
+        Tool for editing and working with MCNP input files.
+
+        options:
+          -h, --help            show this help message and exit
+          -c [input_file ...], --check [input_file ...]
+                                Check the given input file(s) for errors. Accepts globs, and multiple arguments.
+
+Checking Input Files for Errors
+-------------------------------
+MontePy can be used to check for errors that it will check for.
+MontePy will check for:
+
+* general syntax errors
+* syntax errors for all MCNP Objects supported (e.g., cells, surfaces, materials, etc.)
+* Bad references to other object when the object referring to another object is supported.
+* Bad mode options
+
+It will print all errors it found in the input to the terminal.
+
+To use this run:
+
+.. code-block:: console
+
+   python -m montepy -c [files]
+
+Converting Encoding to ASCII
+----------------------------
+
+.. _ascii_command:
+
+Command Line Options
+++++++++++++++++++++
+.. code-block:: console
+
+        usage: Change_to_ascii [-h] [-d | -w] in_file out_file
+
+        Change the encoding of a file to strict ASCII. Everything not compliant will be removed.
+
+        positional arguments:
+          in_file           The input file to convert
+          out_file          The input file to convert
+
+        options:
+          -h, --help        show this help message and exit
+          -d, --delete      Delete any non-ascii characters. This is the default.
+          -w, --whitespace  Replace non-ascii characters with a space.
+
+
+Background
+++++++++++
+`Character encoding <https://en.wikipedia.org/wiki/Character_encoding>`_ is the process of representing all characters as numbers,
+so they may be used by a computer.
+It is the bane of almost all programmers.
+
+The `American Standard Code for Information Interchange (ASCII) <https://en.wikipedia.org/wiki/ASCII>`_ is one of the oldest,
+and simplest encoding standards.
+It uses one byte per character, 
+and only goes from 0 – 127.
+This has some issues, being very American-centric,
+and also only allowing 128 characters, 
+52 of them being the English alphabet.
+One solution to this was `"Extended ASCII" <https://en.wikipedia.org/wiki/Extended_ASCII>`_,
+which used the final bit, and allowed the encoding system
+to include 0 – 255.
+There isn't one "Extended ASCII",
+but one of the most popular encodings is Windows CP-1252.
+This isn't great.
+
+The most commonly used encoding now is `UTF-8 <https://en.wikipedia.org/wiki/UTF-8>`_, or "unicode".
+UTF-8 can support almost any printable character in any language, including emojis.
+The complexity is that each character is a variable-length of bytes.
+This means that older software, like fortran, may get confused by it.
+
+As far as I can tell MCNP does not document what encoding it uses.
+ASCII is the most conservative bet, 
+so MontePy by default tries to read input files in strict ASCII.
+
+Dealing with Encoding Issues
+++++++++++++++++++++++++++++
+
+You are likely here because you got an error message something like this:
+
+>>> montepy.read_input("example.imcnp")
+UnicodeDecodeError                        Traceback (most recent call last)
+<snip>
+UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 1132: ordinal not in range(128)
+
+You can either change the encoding used by :func:`~montepy.input_parser.input_reader.read_input`,
+or just force the entire file to be strictly ASCII.
+
+MontePY offers the ``change_to_ascii`` script. 
+The options are listed above: :ref:`ascii_command`.
+For any non-ASCII character it will either remove
+the character or replace it with a space (``' '``).
+It defaults to deleting.
+To replace it with a space instead use ``-w``. 
+Otherwise the arguments are the input file to correct,
+and the path to write the output file to.
+
+.. code-block:: console
+
+   change_to_ascii -w unicode_input.imcnp ascii_input.imcnp

--- a/montepy/__init__.py
+++ b/montepy/__init__.py
@@ -23,7 +23,7 @@ from montepy.surfaces.surface_type import SurfaceType
 from montepy.universe import Universe
 import sys
 
-__version__ = "0.2.5"
+__version__ = "0.3.0dev1"
 
 # enable deprecated warnings for users
 if not sys.warnoptions:

--- a/montepy/_scripts/change_to_ascii.py
+++ b/montepy/_scripts/change_to_ascii.py
@@ -3,6 +3,14 @@ import sys
 
 
 def define_args(args):
+    """
+    Parses the arguments from the command line.
+
+    :param args: the arguments from the command line.
+    :type args: list
+    :returns: the parsed arguments (with argparse)
+    :rtype: argparse.Namespace
+    """
     parser = argparse.ArgumentParser(
         prog="Change_to_ascii",
         description="Change the encoding of a file to strict ASCII. Everything not compliant will be removed.",
@@ -29,6 +37,12 @@ def define_args(args):
 
 
 def strip_characters(args):
+    """
+    Strips non-ascii characters from the input file, and writes out the output file.
+
+    :param args: the parsed command line arguments.
+    :type args: argparse.Namespace
+    """
     if args.whitespace:
         replacer = " "
     elif args.delete:
@@ -57,6 +71,12 @@ def strip_characters(args):
 
 
 def main(args=None):
+    """
+    Main runner function.
+
+    :param args: The arguments passed from the command line.
+    :type args: list
+    """
     if args is None:
         args = sys.argv[1:]
     args = define_args(args)

--- a/montepy/_scripts/change_to_ascii.py
+++ b/montepy/_scripts/change_to_ascii.py
@@ -56,7 +56,9 @@ def strip_characters(args):
                 )
 
 
-def main(args):
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     args = define_args(args)
     strip_characters(args)
 

--- a/montepy/constants.py
+++ b/montepy/constants.py
@@ -40,6 +40,13 @@ TABSIZE = 8
 How many spaces a tab is expand to.
 """
 
+ASCII_CEILING = 127
+"""
+The maximum allowed code point allowed by ASCII.
+
+Source: `Wikipedia <https://en.wikipedia.org/wiki/ASCII>`_
+"""
+
 
 def get_max_line_length(mcnp_version=DEFAULT_VERSION):
     """

--- a/montepy/input_parser/input_file.py
+++ b/montepy/input_parser/input_file.py
@@ -79,7 +79,7 @@ class MCNP_InputFile:
         :type encoding: str
         :returns: self
         """
-        self._fh = open(self.path, mode, encoding="ascii")
+        self._fh = open(self.path, mode, encoding=encoding)
         return self
 
     def __enter__(self):

--- a/montepy/input_parser/input_file.py
+++ b/montepy/input_parser/input_file.py
@@ -60,7 +60,7 @@ class MCNP_InputFile:
         """
         pass
 
-    def open(self, mode, encoding="ascii", replace=False):
+    def open(self, mode, encoding="ascii", replace=True):
         """
         Opens the underlying file, and returns self.
 
@@ -78,8 +78,10 @@ class MCNP_InputFile:
 
         :param mode: the mode to open the file in
         :type mode: str
-        :param encoding: The encoding scheme to use.
+        :param encoding: The encoding scheme to use. If replace is true, this is ignored, and changed to ASCII
         :type encoding: str
+        :param replace: replace all non-ASCII characters with a space (0x20)
+        :type replace: bool
         :returns: self
         """
         if "r" in mode:

--- a/montepy/input_parser/input_file.py
+++ b/montepy/input_parser/input_file.py
@@ -57,7 +57,7 @@ class MCNP_InputFile:
         """
         pass
 
-    def open(self, mode):
+    def open(self, mode, encoding="ascii"):
         """
         Opens the underlying file, and returns self.
 
@@ -65,8 +65,18 @@ class MCNP_InputFile:
         For this reason, a ``close`` functional is intentionally
         not provided.
 
+
+        .. Note::
+            For different encoding schemes see the available list
+            `here <https://docs.python.org/3.9/library/codecs.html#standard-encodings>`_.
+
+            CP1252 is commonly referred to as "extended-ASCII".
+            You may have success with this encoding for working with special characters.
+
         :param mode: the mode to open the file in
         :type mode: str
+        :param encoding: The encoding scheme to use.
+        :type encoding: str
         :returns: self
         """
         self._fh = open(self.path, mode, encoding="ascii")

--- a/montepy/input_parser/input_reader.py
+++ b/montepy/input_parser/input_reader.py
@@ -32,5 +32,5 @@ def read_input(input_file, mcnp_version=DEFAULT_VERSION, encoding="ascii"):
     """
     problem = mcnp_problem.MCNP_Problem(input_file)
     problem.mcnp_version = mcnp_version
-    problem.parse_input()
+    problem.parse_input(encoding=encoding)
     return problem

--- a/montepy/input_parser/input_reader.py
+++ b/montepy/input_parser/input_reader.py
@@ -3,17 +3,26 @@ from montepy import mcnp_problem
 from montepy.constants import DEFAULT_VERSION
 
 
-def read_input(input_file, mcnp_version=DEFAULT_VERSION):
+def read_input(input_file, mcnp_version=DEFAULT_VERSION, encoding="ascii"):
     """
     Reads the specified MCNP Input file.
 
     The MCNP version must be a three component tuple e.g., (6, 2, 0) and (5, 1, 60).
+
+    .. Note::
+        For different encoding schemes see the available list
+        `here <https://docs.python.org/3.9/library/codecs.html#standard-encodings>`_.
+
+        CP1252 is commonly referred to as "extended-ASCII".
+        You may have success with this encoding for working with special characters.
 
     :param input_file: the path to the input file to read.
     :type input_file: str
     :param mcnp_version: The version of MCNP that the input is intended for.
     :type mcnp_version: tuple
     :returns: The MCNP_Problem instance representing this file.
+    :param encoding: The encoding scheme to use.
+    :type encoding: str
     :rtype: MCNP_Problem
     :raises UnsupportedFeature: If an input format is used that MontePy does not support.
     :raises MalformedInputError: If an input has a broken syntax.

--- a/montepy/input_parser/input_reader.py
+++ b/montepy/input_parser/input_reader.py
@@ -3,26 +3,20 @@ from montepy import mcnp_problem
 from montepy.constants import DEFAULT_VERSION
 
 
-def read_input(input_file, mcnp_version=DEFAULT_VERSION, encoding="ascii"):
+def read_input(input_file, mcnp_version=DEFAULT_VERSION, replace=True):
     """
     Reads the specified MCNP Input file.
 
     The MCNP version must be a three component tuple e.g., (6, 2, 0) and (5, 1, 60).
 
-    .. Note::
-        For different encoding schemes see the available list
-        `here <https://docs.python.org/3.9/library/codecs.html#standard-encodings>`_.
-
-        CP1252 is commonly referred to as "extended-ASCII".
-        You may have success with this encoding for working with special characters.
 
     :param input_file: the path to the input file to read.
     :type input_file: str
     :param mcnp_version: The version of MCNP that the input is intended for.
     :type mcnp_version: tuple
     :returns: The MCNP_Problem instance representing this file.
-    :param encoding: The encoding scheme to use.
-    :type encoding: str
+    :param replace: replace all non-ASCII characters with a space (0x20)
+    :type replace: bool
     :rtype: MCNP_Problem
     :raises UnsupportedFeature: If an input format is used that MontePy does not support.
     :raises MalformedInputError: If an input has a broken syntax.
@@ -32,5 +26,5 @@ def read_input(input_file, mcnp_version=DEFAULT_VERSION, encoding="ascii"):
     """
     problem = mcnp_problem.MCNP_Problem(input_file)
     problem.mcnp_version = mcnp_version
-    problem.parse_input(encoding=encoding)
+    problem.parse_input(replace=replace)
     return problem

--- a/montepy/input_parser/input_syntax_reader.py
+++ b/montepy/input_parser/input_syntax_reader.py
@@ -44,7 +44,7 @@ def read_input_syntax(input_file, mcnp_version=DEFAULT_VERSION, encoding="ascii"
     """
     global reading_queue
     reading_queue = deque()
-    with input_file.open("r") as fh:
+    with input_file.open("r", encoding=encoding) as fh:
         yield from read_front_matters(fh, mcnp_version)
         yield from read_data(fh, mcnp_version)
 

--- a/montepy/input_parser/input_syntax_reader.py
+++ b/montepy/input_parser/input_syntax_reader.py
@@ -15,7 +15,7 @@ import warnings
 reading_queue = []
 
 
-def read_input_syntax(input_file, mcnp_version=DEFAULT_VERSION, encoding="ascii"):
+def read_input_syntax(input_file, mcnp_version=DEFAULT_VERSION, replace=True):
     """
     Creates a generator function to return a new MCNP input for
     every new one that is encountered.
@@ -25,26 +25,19 @@ def read_input_syntax(input_file, mcnp_version=DEFAULT_VERSION, encoding="ascii"
 
     The version must be a three component tuple e.g., (6, 2, 0) and (5, 1, 60).
 
-    .. Note::
-        For different encoding schemes see the available list
-        `here <https://docs.python.org/3.9/library/codecs.html#standard-encodings>`_.
-
-        CP1252 is commonly referred to as "extended-ASCII".
-        You may have success with this encoding for working with special characters.
-
 
     :param input_file: the path to the input file to be read
     :type input_file: MCNP_InputFile
     :param mcnp_version: The version of MCNP that the input is intended for.
     :type mcnp_version: tuple
-    :param encoding: The encoding scheme to use.
-    :type encoding: str
+    :param replace: replace all non-ASCII characters with a space (0x20)
+    :type replace: bool
     :returns: a generator of MCNP_Object objects
     :rtype: generator
     """
     global reading_queue
     reading_queue = deque()
-    with input_file.open("r", encoding=encoding) as fh:
+    with input_file.open("r", replace=replace) as fh:
         yield from read_front_matters(fh, mcnp_version)
         yield from read_data(fh, mcnp_version)
 

--- a/montepy/input_parser/input_syntax_reader.py
+++ b/montepy/input_parser/input_syntax_reader.py
@@ -15,7 +15,7 @@ import warnings
 reading_queue = []
 
 
-def read_input_syntax(input_file, mcnp_version=DEFAULT_VERSION):
+def read_input_syntax(input_file, mcnp_version=DEFAULT_VERSION, encoding="ascii"):
     """
     Creates a generator function to return a new MCNP input for
     every new one that is encountered.
@@ -25,11 +25,20 @@ def read_input_syntax(input_file, mcnp_version=DEFAULT_VERSION):
 
     The version must be a three component tuple e.g., (6, 2, 0) and (5, 1, 60).
 
+    .. Note::
+        For different encoding schemes see the available list
+        `here <https://docs.python.org/3.9/library/codecs.html#standard-encodings>`_.
+
+        CP1252 is commonly referred to as "extended-ASCII".
+        You may have success with this encoding for working with special characters.
+
 
     :param input_file: the path to the input file to be read
     :type input_file: MCNP_InputFile
     :param mcnp_version: The version of MCNP that the input is intended for.
     :type mcnp_version: tuple
+    :param encoding: The encoding scheme to use.
+    :type encoding: str
     :returns: a generator of MCNP_Object objects
     :rtype: generator
     """

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -232,10 +232,19 @@ class MCNP_Problem:
         """
         return self._transforms
 
-    def parse_input(self, check_input=False):
+    def parse_input(self, check_input=False, encoding="ascii"):
         """
         Semantically parses the MCNP file provided to the constructor.
 
+        .. Note::
+            For different encoding schemes see the available list
+            `here <https://docs.python.org/3.9/library/codecs.html#standard-encodings>`_.
+
+            CP1252 is commonly referred to as "extended-ASCII".
+            You may have success with this encoding for working with special characters.
+
+        :param encoding: The encoding scheme to use.
+        :type encoding: str
         :param check_input: If true, will try to find all errors with input and collect them as warnings to log.
         :type check_input: bool
         """

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -261,7 +261,7 @@ class MCNP_Problem:
         try:
             for i, input in enumerate(
                 input_syntax_reader.read_input_syntax(
-                    self._input_file, self.mcnp_version
+                    self._input_file, self.mcnp_version, encoding=encoding
                 )
             ):
                 self._original_inputs.append(input)

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -232,21 +232,14 @@ class MCNP_Problem:
         """
         return self._transforms
 
-    def parse_input(self, check_input=False, encoding="ascii"):
+    def parse_input(self, check_input=False, replace=True):
         """
         Semantically parses the MCNP file provided to the constructor.
 
-        .. Note::
-            For different encoding schemes see the available list
-            `here <https://docs.python.org/3.9/library/codecs.html#standard-encodings>`_.
-
-            CP1252 is commonly referred to as "extended-ASCII".
-            You may have success with this encoding for working with special characters.
-
-        :param encoding: The encoding scheme to use.
-        :type encoding: str
         :param check_input: If true, will try to find all errors with input and collect them as warnings to log.
         :type check_input: bool
+        :param replace: replace all non-ASCII characters with a space (0x20)
+        :type replace: bool
         """
         trailing_comment = None
         last_obj = None
@@ -261,7 +254,7 @@ class MCNP_Problem:
         try:
             for i, input in enumerate(
                 input_syntax_reader.read_input_syntax(
-                    self._input_file, self.mcnp_version, encoding=encoding
+                    self._input_file, self.mcnp_version, replace=replace
                 )
             ):
                 self._original_inputs.append(input)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Documentation = "https://idaholab.github.io/MontePy/index.html"
 "Bug Tracker" = "https://github.com/idaholab/MontePy/issues"
 
 [project.scripts]
-"change_to_ascii" = "scripts.change_to_ascii:main"
+"change_to_ascii" = "montepy._scripts.change_to_ascii:main"
 
 [build-system]
 requires = ["setuptools  >= 61.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ Repository = "https://github.com/idaholab/montepy.git"
 Documentation = "https://idaholab.github.io/MontePy/index.html"
 "Bug Tracker" = "https://github.com/idaholab/MontePy/issues"
 
+[project.scripts]
+"change_to_ascii" = "scripts.change_to_ascii:main"
+
 [build-system]
 requires = ["setuptools  >= 61.0.0"]
 build-backend = "setuptools.build_meta"

--- a/scripts/change_to_ascii.py
+++ b/scripts/change_to_ascii.py
@@ -29,9 +29,9 @@ def define_args(args):
 
 
 def strip_characters(args):
-    if "whitespace" in args:
+    if args.whitespace:
         replacer = " "
-    elif "delete" in args:
+    elif args.delete:
         replacer = ""
     # default to delete
     else:

--- a/scripts/change_to_ascii.py
+++ b/scripts/change_to_ascii.py
@@ -7,15 +7,15 @@ def define_args(args):
         prog="Change_to_ascii",
         description="Change the encoding of a file to strict ASCII. Everything not compliant will be removed.",
     )
-    parser.add_argument(
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
         "-d",
         "--delete",
         dest="delete",
         action="store_true",
-        help="Delete any non-ascii characters",
-        default=True,
+        help="Delete any non-ascii characters. This is the default.",
     )
-    parser.add_argument(
+    group.add_argument(
         "-w",
         "--whitespace",
         dest="whitespace",
@@ -33,14 +33,16 @@ def strip_characters(args):
         replacer = " "
     elif "delete" in args:
         replacer = ""
-    with open(args.in_file[0], "rb") as in_fh, open(args.out_file[0], "w") as out_fh:
+    # default to delete
+    else:
+        replacer = ""
+    with open(args.in_file[0], "rb") as in_fh, open(args.out_file[0], "wb") as out_fh:
         for line in in_fh:
             utf8_line = line.decode(encoding="utf8", errors="replace")
             utf8_line = utf8_line.replace("�", replacer)
+
             try:
-                out_fh.write(
-                    utf8_line.encode(encoding="ascii", errors="strict").decode()
-                )
+                out_fh.write(utf8_line.encode(encoding="ascii", errors="strict"))
             except UnicodeError as e:
                 new_line = []
                 # find the bad characters character by character
@@ -50,7 +52,7 @@ def strip_characters(args):
                     else:
                         new_line.append(char)
                 out_fh.write(
-                    "".join(new_line).encode(encoding="ascii", errors="strict").decode()
+                    "".join(new_line).encode(encoding="ascii", errors="strict")
                 )
 
 

--- a/scripts/change_to_ascii.py
+++ b/scripts/change_to_ascii.py
@@ -1,0 +1,63 @@
+import argparse
+import sys
+
+
+def define_args(args):
+    parser = argparse.ArgumentParser(
+        prog="Change_to_ascii",
+        description="Change the encoding of a file to strict ASCII. Everything not compliant will be removed.",
+    )
+    parser.add_argument(
+        "-d",
+        "--delete",
+        dest="delete",
+        action="store_true",
+        help="Delete any non-ascii characters",
+        default=True,
+    )
+    parser.add_argument(
+        "-w",
+        "--whitespace",
+        dest="whitespace",
+        action="store_true",
+        help="Replace non-ascii characters with a space.",
+    )
+    parser.add_argument("in_file", nargs=1, help="The input file to convert")
+    parser.add_argument("out_file", nargs=1, help="The input file to convert")
+    args = parser.parse_args(args)
+    return args
+
+
+def strip_characters(args):
+    if "whitespace" in args:
+        replacer = " "
+    elif "delete" in args:
+        replacer = ""
+    with open(args.in_file[0], "rb") as in_fh, open(args.out_file[0], "w") as out_fh:
+        for line in in_fh:
+            utf8_line = line.decode(encoding="utf8", errors="replace")
+            utf8_line = utf8_line.replace("�", replacer)
+            try:
+                out_fh.write(
+                    utf8_line.encode(encoding="ascii", errors="strict").decode()
+                )
+            except UnicodeError as e:
+                new_line = []
+                # find the bad characters character by character
+                for char in utf8_line:
+                    if ord(char) > 128:
+                        new_line.append(replacer)
+                    else:
+                        new_line.append(char)
+                out_fh.write(
+                    "".join(new_line).encode(encoding="ascii", errors="strict").decode()
+                )
+
+
+def main(args):
+    args = define_args(args)
+    strip_characters(args)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -24,3 +24,8 @@ IGNORE_FILES = {
     "bad_encoding.imcnp",
     "unicode.imcnp",
 }
+
+BAD_ENCODING_FILES = {
+    "bad_encoding.imcnp",
+    "unicode.imcnp",
+}

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -22,4 +22,5 @@ IGNORE_FILES = {
     "testReadRec3.imcnp",
     "testReadTarget.imcnp",
     "bad_encoding.imcnp",
+    "unicode.imcnp",
 }

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -21,4 +21,5 @@ IGNORE_FILES = {
     "testReadRec2.imcnp",
     "testReadRec3.imcnp",
     "testReadTarget.imcnp",
+    "bad_encoding.imcnp"
 }

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -21,5 +21,5 @@ IGNORE_FILES = {
     "testReadRec2.imcnp",
     "testReadRec3.imcnp",
     "testReadTarget.imcnp",
-    "bad_encoding.imcnp"
+    "bad_encoding.imcnp",
 }

--- a/tests/inputs/bad_encoding.imcnp
+++ b/tests/inputs/bad_encoding.imcnp
@@ -1,0 +1,52 @@
+MESSAGE: this is a message
+it should show up at the beginning
+foo
+Note: this file in encoded in "extended ascii": "CP-1252"
+
+MCNP Test Model for MOAA
+C cells  ÿ
+c
+1 1 20
+         -1000  $ dollar comment
+	imp:n,p=1 U=350 trcl=5
+2 2 8
+      -1005
+     imp:n=1
+     imp:p=0.5
+3 3 -1
+      1000 1005 -1010
+     imp:n,p=1
+99 0
+      1010
+     imp:n,p=0
+5 0 
+      #99
+      imp:n,p=3 fill=350 (1 0 0 )
+c foo end comment
+
+C surfaces
+1000 SO 1
+1005 RCC 0 1.5 -0.5 0 0 1 0.25
+1010 SO 3
+
+C data
+C materials
+C UO2 5 atpt enriched
+m1        92235.80c           5 &
+92238.80c          95
+C Iron
+m2        26054.80c        5.85
+          26056.80c       91.75
+          26057.80c        2.12
+          26058.80c        0.28
+C water
+C foo
+m3        1001.80c           2
+           8016.80c           1
+MT3 lwtr.23t h-zr.20t h/zr.28t
+C execution
+ksrc 0 0 0
+kcode 100000 1.000 50 1050
+phys:p j 1 2j 1
+mode n p
+vol NO 2J 1 1.5 J

--- a/tests/inputs/unicode.imcnp
+++ b/tests/inputs/unicode.imcnp
@@ -1,0 +1,52 @@
+MESSAGE: this is a message
+it should show up at the beginning
+foo
+
+MCNP Test Model for MOAA
+C cells 🔴⚪🐍 MontePy is great
+c
+1 1 20
+         -1000  $ dollar comment
+	imp:n,p=1 U=350 trcl=5
+2 2 8
+      -1005
+     imp:n=1
+     imp:p=0.5
+3 3 -1
+      1000 1005 -1010
+     imp:n,p=1
+99 0
+      1010
+     imp:n,p=0
+5 0 
+      #99
+      imp:n,p=3 fill=350 (1 0 0 )
+c foo end comment
+
+C surfaces
+1000 SO 1
+1005 RCC 0 1.5 -0.5 0 0 1 0.25
+1010 SO 3
+
+C data
+C materials
+C UO2 5 atpt enriched
+m1        92235.80c           5 &
+92238.80c          95
+C Iron
+m2        26054.80c        5.85
+          26056.80c       91.75
+          26057.80c        2.12
+          26058.80c        0.28
+C water
+C foo
+m3        1001.80c           2
+           8016.80c           1
+MT3 lwtr.23t h-zr.20t h/zr.28t
+C execution
+ksrc 0 0 0
+kcode 100000 1.000 50 1050
+phys:p j 1 2j 1
+mode n p
+vol NO 2J 1 1.5 J
+

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1031,3 +1031,8 @@ class testFullFileIntegration(TestCase):
                 os.remove(out)
             except FileNotFoundError:
                 pass
+
+    def test_alternate_encoding(self):
+        with self.assertRaises(UnicodeDecodeError):
+            problem = montepy.read_input(os.path.join("tests", "inputs", "bad_encoding.imcnp"))
+        problem = montepy.read_input(os.path.join("tests", "inputs", "bad_encoding.imcnp"), encoding="cp1252")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1034,5 +1034,9 @@ class testFullFileIntegration(TestCase):
 
     def test_alternate_encoding(self):
         with self.assertRaises(UnicodeDecodeError):
-            problem = montepy.read_input(os.path.join("tests", "inputs", "bad_encoding.imcnp"))
-        problem = montepy.read_input(os.path.join("tests", "inputs", "bad_encoding.imcnp"), encoding="cp1252")
+            problem = montepy.read_input(
+                os.path.join("tests", "inputs", "bad_encoding.imcnp")
+            )
+        problem = montepy.read_input(
+            os.path.join("tests", "inputs", "bad_encoding.imcnp"), encoding="cp1252"
+        )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1035,8 +1035,8 @@ class testFullFileIntegration(TestCase):
     def test_alternate_encoding(self):
         with self.assertRaises(UnicodeDecodeError):
             problem = montepy.read_input(
-                os.path.join("tests", "inputs", "bad_encoding.imcnp")
+                os.path.join("tests", "inputs", "bad_encoding.imcnp"), replace=False
             )
         problem = montepy.read_input(
-            os.path.join("tests", "inputs", "bad_encoding.imcnp"), encoding="cp1252"
+            os.path.join("tests", "inputs", "bad_encoding.imcnp"), replace=True
         )

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,83 @@
+import itertools
+from unittest import TestCase
+from tests import constants
+import os
+import subprocess
+
+
+class TestChangeAsciiScript(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        new_files = {}
+        for input_file in constants.BAD_ENCODING_FILES:
+            new_files[input_file] = {}
+            for flag in {"-w", "-d"}:
+                new_file = f"{input_file}{flag}.imcnp"
+                cls.run_script(
+                    [flag, os.path.join("tests", "inputs", input_file), new_file]
+                )
+                new_files[input_file][flag] = new_file
+        cls.files = new_files
+
+    @classmethod
+    def tearDownClass(cls):
+        for group in cls.files.values():
+            for file_name in group.values():
+                try:
+                    os.remove(file_name)
+                except FileNotFoundError:
+                    pass
+
+    @staticmethod
+    def run_script(args):
+        return subprocess.run(
+            ["python", os.path.join("scripts", "change_to_ascii.py")] + args
+        )
+
+    def test_delete_bad(self):
+        for in_file in self.files:
+            with open(os.path.join("tests", "inputs", in_file), "rb") as in_fh, open(
+                self.files[in_file]["-d"], "rb"
+            ) as out_fh:
+                for in_line, out_line in zip(in_fh, out_fh):
+                    try:
+                        in_line.decode("ascii")
+                        self.assertEqual(in_line, out_line)
+                    except UnicodeError:
+                        new_line = []
+                        for char in in_line:
+                            if char <= 128:
+                                new_line.append(chr(char))
+                        self.assertEqual("".join(new_line), out_line.decode("ascii"))
+
+    def test_whitespace_bad(self):
+        for in_file in self.files:
+            with open(os.path.join("tests", "inputs", in_file), "rb") as in_fh, open(
+                self.files[in_file]["-w"], "rb"
+            ) as out_fh:
+                for in_line, out_line in zip(in_fh, out_fh):
+                    try:
+                        in_line.decode("ascii")
+                        self.assertEqual(in_line, out_line)
+                    except UnicodeError:
+                        try:
+                            print(in_line.decode())
+                        except UnicodeError:
+                            pass
+                        new_line = []
+                        for char in in_line:
+                            if char <= 128:
+                                new_line.append(chr(char))
+                            else:
+                                new_line.append(" ")
+                        self.assertEqual("".join(new_line), out_line.decode("ascii"))
+
+    def test_bad_arguments(self):
+        ret_code = self.run_script(
+            [
+                "-w",
+                "-d",
+                os.path.join("tests", "inputs", "bad_encode.imcnp", "foo.imcnp"),
+            ]
+        )
+        self.assertNotEqual(ret_code.returncode, 0)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -60,16 +60,21 @@ class TestChangeAsciiScript(TestCase):
                         in_line.decode("ascii")
                         self.assertEqual(in_line, out_line)
                     except UnicodeError:
-                        try:
-                            print(in_line.decode())
-                        except UnicodeError:
-                            pass
                         new_line = []
-                        for char in in_line:
-                            if char <= 128:
-                                new_line.append(chr(char))
-                            else:
-                                new_line.append(" ")
+                        try:
+                            # try to change to utf-8
+                            for char in in_line.decode():
+                                if ord(char) <= 128:
+                                    new_line.append(char)
+                                else:
+                                    new_line.append(" ")
+                        except UnicodeError:
+                            # try to go bit by bit
+                            for char in in_line:
+                                if char <= 128:
+                                    new_line.append(chr(char))
+                                else:
+                                    new_line.append(" ")
                         self.assertEqual("".join(new_line), out_line.decode("ascii"))
 
     def test_bad_arguments(self):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -31,7 +31,7 @@ class TestChangeAsciiScript(TestCase):
     @staticmethod
     def run_script(args):
         return subprocess.run(
-            ["python", os.path.join("scripts", "change_to_ascii.py")] + args
+            ["python", os.path.join("montepy", "_scripts", "change_to_ascii.py")] + args
         )
 
     def test_delete_bad(self):


### PR DESCRIPTION
Adds:
- `MCNP_InputFile` to documentation site.
- Added encoding options when opening a file, and to `input_reader`
- Added script utility to strip out all non-ascii characters.
    this works by:
    - reading into UTF-8 with replace.
    - Replaced replaced characters with nothing or `' '`
    - Covert back to ascii. Anything about 128 also gets converted. 
 - Added utilities section to guide
 - Added FAQ that shows a typical stack trace

Needs still:

- [x] test for changes
- [x] graceful error handling for bad encoding
- [x] Document how to use this in user docs.
- [x] Add FAQ: what are encoding errors
- [x] Add doc strings

Closes #186, #334.