### PR TITLE
Fix bug with hidden vertical input mode. 

### DIFF
--- a/montepy/input_parser/input_syntax_reader.py
+++ b/montepy/input_parser/input_syntax_reader.py
@@ -186,7 +186,7 @@ def read_data(fh, mcnp_version, block_type=None, recursion=False):
         ):
             yield from flush_input()
         # die if it is a vertical syntax format
-        if "#" in line[0:BLANK_SPACE_CONTINUE]:
+        if "#" in line[0:BLANK_SPACE_CONTINUE] and not line_is_comment:
             raise errors.UnsupportedFeature("Vertical Input format is not allowed")
         # cut line down to allowed length
         old_line = line

--- a/tests/inputs/test.imcnp
+++ b/tests/inputs/test.imcnp
@@ -4,6 +4,7 @@ foo
 
 MCNP Test Model for MOAA
 C cells
+c # hidden vertical Do not touch 
 c
 1 1 20
          -1000  $ dollar comment

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -342,6 +342,7 @@ class testFullFileIntegration(TestCase):
         # test input pass-through
         answer = [
             "C cells",
+            "c # hidden vertical Do not touch",
             "c",
             "1 1 20",
             "         -1000  $ dollar comment",
@@ -354,20 +355,20 @@ class testFullFileIntegration(TestCase):
         cell = new_prob.cells[1]
         output = cell.format_for_mcnp_input((6, 2, 0))
         print(output)
-        self.assertEqual(int(output[3].split("$")[0]), -5)
+        self.assertEqual(int(output[4].split("$")[0]), -5)
         # test mass density printer
         cell.mass_density = 10.0
         with self.assertWarns(LineExpansionWarning):
             output = cell.format_for_mcnp_input((6, 2, 0))
         print(output)
-        self.assertAlmostEqual(float(output[2].split()[2]), -10)
+        self.assertAlmostEqual(float(output[3].split()[2]), -10)
         # ensure that surface number updated
         # Test material number change
         new_prob = copy.deepcopy(problem)
         new_prob.materials[1].number = 5
         cell = new_prob.cells[1]
         output = cell.format_for_mcnp_input((6, 2, 0))
-        self.assertEqual(int(output[2].split()[1]), 5)
+        self.assertEqual(int(output[3].split()[1]), 5)
 
     def test_thermal_scattering_pass_through(self):
         problem = copy.deepcopy(self.simple_problem)


### PR DESCRIPTION
Vertical mode detection accidentally wasn't considering comments. This fixed this logic.

Fixes #370. 