### PR TITLE
Fixed Project metadata to have authorship be clearer on PyPI

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,6 +6,8 @@ MontePy Changelog
 
 **Bug fixes**
 
+**CI/CD**
+* Fixed project metadata for author to show up correctly on PyPI (#408)
 
 0.2.7
 -----------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
 authors = [
 	{name = "Micah Gale", email = "micah.gale@inl.gov"},
 	{name = "Travis Labossiere-Hickman", email = "Travis.LabossiereHickman@inl.gov"},
-	{name = "Brenna Carbno"}
+	{name = "Brenna Carbno", email="brenna.carbno@inl.gov"}
 ]
 keywords = ["MCNP", "neutronics", "imcnp", "input file", "monte carlo", "radiation transport"]
 license = {file="LICENSE"}


### PR DESCRIPTION
# Description

It was noticed that on PyPI Brenna was showing up as the author: https://pypi.org/project/montepy/0.2.7/. While her contributions are important, having her as the point of contact for a project that she is not responsible for is a bit of a big ask. 

After further investigation this comes down to how the data are packaged in the wheel as that's what PyPI reads.

The problematic wheel (0.2.7) has the `METADATA` file that looks like:

``` 
Metadata-Version: 2.1
Name: montepy
Version: 0.2.7
Summary: A library for reading, editing, and writing MCNP input files
Author: Brenna Carbno
Author-email: Micah Gale <micah.gale@inl.gov>, Travis Labossiere-Hickman <Travis.LabossiereHickman@inl.gov>
Maintainer-email: Micah Gale <micah.gale@inl.gov>
License: MIT License
```

It appears that `author` takes precedence over `author-email`.

After this fix the file reads:

```
Metadata-Version: 2.1
Name: montepy
Version: 0.2.8.dev2+gd62620d.d20240612
Summary: A library for reading, editing, and writing MCNP input files
Author-email: Micah Gale <micah.gale@inl.gov>, Travis Labossiere-Hickman <Travis.LabossiereHickman@inl.gov>, Brenna Carbno <brenna.carbno@inl.gov>
Maintainer-email: Micah Gale <micah.gale@inl.gov>
License: MIT License
```


# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
