### PR TITLE
Command to automatically link to MCNP manual

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -35,6 +35,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.extlinks",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -49,6 +49,14 @@ exclude_patterns = []
 
 wheel = f"montepy-{release}-py3-none-any.whl"
 
+# -- External link configuration ---------------------------------------------
+UM63 = "https://mcnp.lanl.gov/pdf_files/TechReport_2022_LANL_LA-UR-22-30006" \
+       "Rev.1_KuleszaAdamsEtAl.pdf"
+extlinks = {
+    # MCNP 6.3 User's Manual
+    "manual63" : (UM63 + "#subsection.%s", "%s"),
+}
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/doc/source/starting.rst
+++ b/doc/source/starting.rst
@@ -143,7 +143,7 @@ So what does MontePy keep, and what does it forget?
 
 Information Kept
 ^^^^^^^^^^^^^^^^
-#. The optional message block at the beginning of the problem (it's a niche feature checkout section 2.4 of the user manual)
+#. The optional message block at the beginning of the problem (it's a niche feature; check out section :manual63:`4.4.1` of the user manual)
 #. The problem title
 #. ``C`` style comments (e.g., ``C this is a banana``)
 #. (Almost) all MCNP inputs (cards). Only the read input is discarded.


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

Add a `:manual63:` command to link to relevant sections of the MCNP6.3 user's manual. Apply it in "Getting Started".

Note that LANL used a nice, predictable subsection naming convention for MCNP6.3, and did not for MCNP6.2.

Motivation: prerequisite to address #413.

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
   - Should I add a note to the developer's guide? If not, then not applicable.
