### PR TITLE
Updated index to use OSTI/DOI for MCNP 6.3

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -10,6 +10,7 @@ MontePy Changelog
 
 * Added link to the PyPI project on the Sphinx site (:issue:`410`)
 * Added link shortcuts for MCNP manual, and github issues and pull requests (:pull:`417`).
+* Updated MCNP 6.3 manual link to point to OSTI/DOI (:issue:`424`).
 
 **CI/CD**
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -33,8 +33,8 @@ See Also
 
 * `MontePy github Repository <https://github.com/idaholab/montepy>`_
 * `MontePy PyPI Project <https://pypi.org/project/montepy/>`_
+* `MCNP 6.3 User Manual <https://www.osti.gov/biblio/1889957>`_ DOI: `10.2172/1889957 <https://doi.org/10.2172/1889957>`_
 * `MCNP 6.2 User Manual <https://mcnp.lanl.gov/pdf_files/TechReport_2017_LANL_LA-UR-17-29981_WernerArmstrongEtAl.pdf>`_
-* `MCNP 6.3 User Manual <https://mcnp.lanl.gov/pdf_files/TechReport_2022_LANL_LA-UR-22-30006Rev.1_KuleszaAdamsEtAl.pdf>`_
 
 Indices and tables
 ==================


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

This does:

* Point to OSTI on the index for the MCNP 6.3 manual.
* DOI is included as a separate link as this links directly to the pdf. 
* Moved MCNP 6.3 up to make it reverse chronological order. 

Fixes #424

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
