### PR TITLE
Implemented overwrite guardrails thanks to @tjlaboss.

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,11 +1,15 @@
 MontePy Changelog
 =================
 
-0.2.10
-----------------------
-**Miscellanious Changes**
+#Next Version#
+---------------------
+
+**Features Added**
 
 * ``overwrite`` argument added to `MCNP_Problem.write_to_file` to ensure files are only overwritten if the user really wants to do so (:pull:`443`).
+
+0.2.10
+----------------------
 
 **Bug fixes**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -3,6 +3,9 @@ MontePy Changelog
 
 0.2.10
 ----------------------
+**Miscellanious Changes**
+
+* ``overwrite`` argument added to `MCNP_Problem.write_to_file` to ensure files are only overwritten if the user really wants to do so (:pull:`443`).
 
 **Bug fixes**
 

--- a/doc/source/starting.rst
+++ b/doc/source/starting.rst
@@ -79,8 +79,12 @@ state as a valid MCNP input file.
 
 >>> problem.write_to_file("bar.imcnp")
 
+The :func:`~montepy.mcnp_problem.MCNP_Problem.write_to_file` method does take an optional argument: ``overwrite``. 
+By default if the file exists, it will not be overwritten and an error will be raised.
+This can be changed by ``overwrite=True``.
+
 .. warning::
-   Be careful with overwriting the original file when writing a modified file out.
+   Be careful with overwriting the original file (and ``overwrite=True`` in general) when writing a modified file out.
    This will wipe out the original version, and if you have no version control,
    may lead to losing information.
 

--- a/montepy/input_parser/input_file.py
+++ b/montepy/input_parser/input_file.py
@@ -2,6 +2,7 @@
 import itertools as it
 from montepy.constants import ASCII_CEILING
 from montepy.utilities import *
+import os
 
 
 class MCNP_InputFile:

--- a/montepy/input_parser/input_file.py
+++ b/montepy/input_parser/input_file.py
@@ -15,13 +15,16 @@ class MCNP_InputFile:
     :type path: str
     :param parent_file: the parent file for this file if any. This occurs when a "read" input is used.
     :type parent_file: str
+    :param overwrite: Whether to overwrite the file 'path' if it exists
+    :type overwrite: bool
     """
 
-    def __init__(self, path, parent_file=None):
+    def __init__(self, path, parent_file=None, overwrite=False):
         self._path = path
         self._parent_file = parent_file
         self._lineno = 1
         self._replace_with_space = False
+        self._overwrite = overwrite
         self._mode = None
         self._fh = None
 
@@ -90,6 +93,15 @@ class MCNP_InputFile:
                 mode = "rb"
                 encoding = None
         self._mode = mode
+        if "w" in mode:
+            if os.path.isfile(self.path) and self._overwrite is not True:
+                raise FileExistsError(
+                    f"{self.path} already exists, and overwrite is not set."
+                )
+            if os.path.isdir(self.path):
+                raise IsADirectoryError(
+                    f"{self.path} is a directory, and cannot be overwritten."
+                )
         self._fh = open(self.path, mode, encoding=encoding)
         return self
 

--- a/montepy/input_parser/input_file.py
+++ b/montepy/input_parser/input_file.py
@@ -12,7 +12,7 @@ class MCNP_InputFile:
     .. Note::
         this is a bare bones implementation to be fleshed out in the future.
 
-    .. versionchanged:: 0.2.11
+    .. versionchanged:: 0.3.0
         Added the overwrite attribute.
 
     :param path: the path to the input file

--- a/montepy/input_parser/input_file.py
+++ b/montepy/input_parser/input_file.py
@@ -12,6 +12,9 @@ class MCNP_InputFile:
     .. Note::
         this is a bare bones implementation to be fleshed out in the future.
 
+    .. versionchanged:: 0.2.11
+        Added the overwrite attribute.
+
     :param path: the path to the input file
     :type path: str
     :param parent_file: the parent file for this file if any. This occurs when a "read" input is used.
@@ -80,6 +83,9 @@ class MCNP_InputFile:
             CP1252 is commonly referred to as "extended-ASCII".
             You may have success with this encoding for working with special characters.
 
+        .. versionchanged:: 0.2.11
+            Added guardrails to raise FileExistsError and IsADirectoryError.
+
         :param mode: the mode to open the file in
         :type mode: str
         :param encoding: The encoding scheme to use. If replace is true, this is ignored, and changed to ASCII
@@ -87,6 +93,8 @@ class MCNP_InputFile:
         :param replace: replace all non-ASCII characters with a space (0x20)
         :type replace: bool
         :returns: self
+        :raises FileExistsError: if a file already exists with the same path while writing.
+        :raises IsADirectoryError: if the path given is actually a directory while writing.
         """
         if "r" in mode:
             if replace:

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -394,7 +394,7 @@ class MCNP_Problem:
         """
         Writes the problem to a file.
 
-        .. versionchanged:: 0.2.11
+        .. versionchanged:: 0.3.0
             The overwrite parameter was added.
 
         :param new_problem: the file name to write this problem to

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -390,15 +390,17 @@ class MCNP_Problem:
         self._transforms = Transforms(transforms)
         self._data_inputs = sorted(set(self._data_inputs + materials + transforms))
 
-    def write_to_file(self, new_problem):
+    def write_to_file(self, new_problem, overwrite=False):
         """
         Writes the problem to a file.
 
         :param new_problem: the file name to write this problem to
         :type new_problem: str
         :raises IllegalState: if an object in the problem has not been fully initialized.
+        :param overwrite: Whether to overwrite the file at 'new_problem' if it exists
+        :type overwrite: bool
         """
-        new_file = MCNP_InputFile(new_problem)
+        new_file = MCNP_InputFile(new_problem, overwrite=overwrite)
         with new_file.open("w") as fh, warnings.catch_warnings(
             record=True
         ) as warning_catch:

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -394,11 +394,16 @@ class MCNP_Problem:
         """
         Writes the problem to a file.
 
+        .. versionchanged:: 0.2.11
+            The overwrite parameter was added.
+
         :param new_problem: the file name to write this problem to
         :type new_problem: str
-        :raises IllegalState: if an object in the problem has not been fully initialized.
         :param overwrite: Whether to overwrite the file at 'new_problem' if it exists
         :type overwrite: bool
+        :raises IllegalState: if an object in the problem has not been fully initialized.
+        :raises FileExistsError: if a file already exists with the same path.
+        :raises IsADirectoryError: if the path given is actually a directory.
         """
         new_file = MCNP_InputFile(new_problem, overwrite=overwrite)
         with new_file.open("w") as fh, warnings.catch_warnings(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -545,7 +545,7 @@ class testFullFileIntegration(TestCase):
                     pass
 
     def test_importance_write_data(self):
-        out_file = "test_import_data"
+        out_file = "test_import_data_2"
         problem = copy.deepcopy(self.simple_problem)
         problem.print_in_data_block["imp"] = True
         try:
@@ -968,12 +968,13 @@ class testFullFileIntegration(TestCase):
             cell.validate()
 
     def test_importance_rewrite(self):
-        out_file = "test_import_data"
+        out_file = "test_import_data_1"
         problem = copy.deepcopy(self.simple_problem)
         problem.print_in_data_block["imp"] = True
         try:
             problem.write_to_file(out_file)
             problem = montepy.read_input(out_file)
+            os.remove(out_file)
             problem.print_in_data_block["imp"] = False
             problem.write_to_file(out_file)
             found_n = False


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

This introduces a new argument to `MCNP_Problem.write_to_file`, (and `montepy.input_parser.input_file.write_to_file.open`), `overwrite`, which indicates if the existing file should be overwritten. The default behavior is to raise a `FileExistsError` if the file exists, and overwrite is not specified. This error is ignored in `overwrite=True`. No matter what a `IsADirectoryError` is raised if the path is a folder.

Thanks @tjlaboss  for the prototyping.

Fixes #442

# Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
