### PR TITLE
Updated dependency to sphinx 7.4.0, and enabled linkcheck testing.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           ref: main
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
       - run: pip install --user . montepy[doc]
       - run: cd doc && make html
       - uses: actions/configure-pages@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Test for broken hyperlinks
         run: |
              cd doc
-             make linkcheck || true
+             make linkcheck
 
   format-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,7 @@ jobs:
       - run: pip install --user . montepy[format]
       - run: pip install --user . montepy[build]
       - run: pip install --user . montepy[develop]
+        if: ${{ matrix.python-version != '3.8'}}
       - run: pip freeze
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4.3.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
       - run: pip install --user dist/*.tar.gz
       - run: pip install --user . montepy[test]
       - run: pip install --user . montepy[doc]
+        if: ${{ matrix.python-version != '3.8'}}
       - run: pip install --user . montepy[format]
       - run: pip install --user . montepy[build]
       - run: pip install --user . montepy[develop]
@@ -95,10 +96,10 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-      - name: set up python 3.8
+      - name: set up python 3.12
         uses: actions/setup-python@v5
         with: 
-          python-version: 3.8
+          python-version: 3.12
       - run: pip install . montepy[doc,build]
       - uses: mathieudutour/github-tag-action@v6.2
         name: Get next version number

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["coverage[toml]>=6.3.2", "pytest"]
-doc = ["sphinx", "sphinxcontrib-apidoc", "sphinx_rtd_theme"]
+# This is needed for a sphinx bug. See #414.
+doc = ["sphinx>=7.4.0", "sphinxcontrib-apidoc", "sphinx_rtd_theme"]
 format = ["black>=23.3.0"]
 build = [
 	"build",


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

An upstream bug with Sphinx and linkcheck failing for PDFs with anchors has been resolved. This just requires a version of Sphinx with this fix, and requires linkcheck to pass. 

Fixes #414

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] ~I have added tests that prove my fix is effective or that my feature works (if applicable)~
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
