### PR TITLE
Solved error with trailing dollar-sign comments moving on export

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,6 +1,13 @@
 MontePy Changelog
 =================
 
+#Next Version#
+-------------
+
+**Bug fixes**
+
+* Fixed bug with trailing dollar sign comments that moved them to a new line. (:issue:`458`).
+
 0.3.1
 ----------------
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -2,7 +2,7 @@ MontePy Changelog
 =================
 
 #Next Version#
--------------
+--------------
 
 **Bug fixes**
 

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -96,7 +96,7 @@ class SyntaxNodeBase(ABC):
 
     def get_trailing_comment(self):
         """
-        Get the trailing comments if any.
+        Get the trailing ``c`` style  comments if any.
 
         :returns: The trailing comments of this tree.
         :rtype: list
@@ -427,13 +427,13 @@ class PaddingNode(SyntaxNodeBase):
 
     def _get_first_comment(self):
         """
-        Get the first index that is a comment.
+        Get the first index that is a ``c`` style comment.
 
         :returns: the index of the first comment, if there is no comment then None.
         :rtype: int, None
         """
         for i, item in enumerate(self.nodes):
-            if isinstance(item, CommentNode):
+            if isinstance(item, CommentNode) and not item.is_dollar:
                 return i
         return None
 

--- a/tests/inputs/test.imcnp
+++ b/tests/inputs/test.imcnp
@@ -38,7 +38,7 @@ C Iron
 m2        26054.80c        5.85
           26056.80c       91.75
           26057.80c        2.12
-          26058.80c        0.28
+          26058.80c        0.28 $ trailing comment shouldn't move #458.
 C water
 C foo
 m3        1001.80c           2

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -340,7 +340,7 @@ class TestValueNode(TestCase):
         self.assertIsNone(value_node.get_trailing_comment())
         value_node._delete_trailing_comment()
         self.assertIsNone(value_node.get_trailing_comment())
-        padding = syntax_node.PaddingNode("$ hi", True)
+        padding = syntax_node.PaddingNode("c hi", True)
         value_node.padding = padding
         comment = value_node.get_trailing_comment()
         self.assertEqual(len(comment), 1)
@@ -431,7 +431,7 @@ class TestSyntaxNode(TestCase):
         test = copy.deepcopy(self.test_node)
         test["bar2"].nodes["foo"] = syntax_node.ValueNode("1.23", float)
         self.assertIsNone(test.get_trailing_comment())
-        test["bar2"]["foo"].padding = syntax_node.PaddingNode("$ hi", True)
+        test["bar2"]["foo"].padding = syntax_node.PaddingNode("c hi", True)
         self.assertEqual(len(test.get_trailing_comment()), 1)
         test._delete_trailing_comment()
         self.assertIsNone(test.get_trailing_comment())
@@ -691,7 +691,7 @@ class TestListNode(TestCase):
         list_node1 = syntax_node.ListNode("list")
         for i in range(20):
             list_node1.append(syntax_node.ValueNode("1.0", float))
-        padding = syntax_node.PaddingNode("$ hi", True)
+        padding = syntax_node.PaddingNode("c hi", True)
         list_node1[-1].padding = padding
         comments = list(list_node1.get_trailing_comment())
         self.assertEqual(len(comments), 1)
@@ -1481,7 +1481,9 @@ class TestParametersNode(TestCase):
         padding = syntax_node.PaddingNode("$ hi", True)
         param["vol"]["data"][0].padding = padding
         comment = param.get_trailing_comment()
-        self.assertEqual(len(comment), 1)
+        self.assertIsNone(comment)
+        padding.append(syntax_node.CommentNode("c hi"), True)
+        comment = param.get_trailing_comment()
         self.assertEqual(comment[0].contents, "hi")
         param._delete_trailing_comment()
         self.assertIsNone(param.get_trailing_comment())


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

This is a bug fix for the #458. Basically a trailing dollar sign comment would be moved around and on export be put on its own line.

This is because of the way trailing comments are handled. They are moved from the end of the last input to the beginning of the next input as they usually describe the next one. This was being done indiscriminately. This fix only starts moving everything after the first `c` style trailing comment.

This way dollar sign comments stay where they are. 

Fixes #458

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
