### PR TITLE
Test the addition of a numbered object from another problem

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,6 +1,14 @@
 MontePy Changelog
 =================
 
+#Next Version#
+--------------
+
+**Bug fixes**
+
+* Fixed bug with appending and renumbeing numbered objects from other MCNP problems (:issue:`466`).
+
+
 0.3.2
 --------------
 

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -230,6 +230,8 @@ class NumberedObjectCollection(ABC):
         if not isinstance(step, int):
             raise TypeError("The step number must be an int")
         number = obj.number
+        if self._problem:
+            obj.link_to_problem(self._problem)
         try:
             self.append(obj)
         except NumberConflictError:
@@ -237,8 +239,6 @@ class NumberedObjectCollection(ABC):
             obj.number = number
             self.append(obj)
 
-        if self._problem:
-            obj.link_to_problem(self._problem)
         return number
 
     def request_number(self, start_num=1, step=1):

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -115,6 +115,12 @@ class TestNumberedObjectCollection(unittest.TestCase):
         self.assertEqual(cell.number, 4)
         self.assertEqual(len(cells), size + 2)
 
+    def test_append_renumber_problems(self):
+        prob1 = copy.deepcopy(self.simple_problem)
+        prob2 = copy.deepcopy(self.simple_problem)
+        prob2.materials.remove(prob2.materials[2])
+        prob2.materials.append_renumber(prob1.materials[1])
+
     def test_request_number(self):
         cells = self.simple_problem.cells
         self.assertEqual(cells.request_number(6), 6)

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -123,9 +123,9 @@ class TestNumberedObjectCollection(unittest.TestCase):
         len_mats = len(prob2.materials)
         mat1 = prob1.materials[1]
         new_num = prob2.materials.append_renumber(mat1)
-        self.assertEqual(new_num, 2)
-        self.assertEqual(len(prob2.materials), len_mats + 1)
-        self.assertIs(prob2.materials[2], mat1)
+        assert new_num == 2, "Material not renumbered correctly."
+        assert len(prob2.materials) == len_mats + 1, "Material not appended"
+        assert prob2.materials[2] is mat1, "Material 2 is not the new material"
 
     def test_request_number(self):
         cells = self.simple_problem.cells

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -118,8 +118,14 @@ class TestNumberedObjectCollection(unittest.TestCase):
     def test_append_renumber_problems(self):
         prob1 = copy.deepcopy(self.simple_problem)
         prob2 = copy.deepcopy(self.simple_problem)
+        # Delete Material 2, making its number available.
         prob2.materials.remove(prob2.materials[2])
-        prob2.materials.append_renumber(prob1.materials[1])
+        len_mats = len(prob2.materials)
+        mat1 = prob1.materials[1]
+        new_num = prob2.materials.append_renumber(mat1)
+        self.assertEqual(new_num, 2)
+        self.assertEqual(len(prob2.materials), len_mats + 1)
+        self.assertIs(prob2.materials[2], mat1)
 
     def test_request_number(self):
         cells = self.simple_problem.cells


### PR DESCRIPTION
# Description

Fix bug when with copying numbered objects from one `MCNP_Problem` to another when the new number in the new problem is already in use in the old problem.

Fixes #466

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works 
- [x] I have updated the changelog 
