### PR TITLE
Fixed edge case of bad typing in parser

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,7 +6,8 @@ MontePy Changelog
 
 **Bug fixes**
 
-* Fixed bug with appending and renumbeing numbered objects from other MCNP problems (:issue:`466`).
+* Fixed bug with appending and renumbering numbered objects from other MCNP problems (:issue:`466`).
+* Fixed bug with dynamic typing and the parsers that only appear in edge cases (:issue:`461`).
 
 
 0.3.2

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -393,7 +393,7 @@ class PaddingNode(SyntaxNodeBase):
         :param is_comment: whether or not the node is a comment.
         :type is_comment: bool
         """
-        if is_comment:
+        if is_comment or isinstance(val, CommentNode):
             if not isinstance(val, CommentNode):
                 val = CommentNode(val)
             self.nodes.append(val)

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -393,9 +393,9 @@ class PaddingNode(SyntaxNodeBase):
         :param is_comment: whether or not the node is a comment.
         :type is_comment: bool
         """
-        if is_comment or isinstance(val, CommentNode):
-            if not isinstance(val, CommentNode):
-                val = CommentNode(val)
+        if is_comment and not isinstance(val, CommentNode):
+            val = CommentNode(val)
+        if isinstance(val, CommentNode):
             self.nodes.append(val)
             return
         parts = val.split("\n")

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -163,6 +163,14 @@ class EdgeCaseTests(TestCase):
             "                            3201  15i   3217",
             "                            u=20",
         ],
+        # issue #461
+        [
+            "43    0",
+            "      (                 $ a dollar comment here",
+            "        -1 2",
+            "      )",
+            "      IMP:N=1.000000 IMP:P=1.000000",
+        ],
     ],
 )
 def test_complex_cell_parsing(lines):


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

This bug was caused by bad type enforcement in `PaddingNode` when it could be passed a `CommentNode` or `str`. Handled this checking for `CommentNode` while appending.

Fixes #461 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
