### PR TITLE
Fix material to update compositions on export

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,6 +6,7 @@ MontePy Changelog
 
 **Bug fixes**
 
+* Fixed bug with material compositions not being updated when written to file (:issue:`470`).
 * Fixed bug with appending and renumbering numbered objects from other MCNP problems (:issue:`466`).
 * Fixed bug with dynamic typing and the parsers that only appear in edge cases (:issue:`461`).
 

--- a/montepy/data_inputs/isotope.py
+++ b/montepy/data_inputs/isotope.py
@@ -1,7 +1,7 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
 from montepy.data_inputs.element import Element
 from montepy.errors import *
-from montepy.input_parser.syntax_node import ValueNode
+from montepy.input_parser.syntax_node import PaddingNode, ValueNode
 
 
 class Isotope:
@@ -36,6 +36,8 @@ class Isotope:
             self._library = parts[1]
         else:
             self._library = ""
+        if node is None:
+            self._tree = ValueNode(self.mcnp_str(), str, PaddingNode(" "))
 
     def __parse_zaid(self):
         """

--- a/montepy/data_inputs/isotope.py
+++ b/montepy/data_inputs/isotope.py
@@ -178,7 +178,7 @@ class Isotope:
         :returns: a string that can be used in MCNP
         :rtype: str
         """
-        return f"{self.ZAID}.{self.library}"
+        return f"{self.ZAID}.{self.library}" if self.library else self.ZAID
 
     def get_base_zaid(self):
         """

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -41,15 +41,7 @@ class Material(data_input.DataInputAbstract, Numbered_MCNP_Object):
             self._number = num
             set_atom_frac = False
             isotope_fractions = self._tree["data"]
-            if isinstance(isotope_fractions, syntax_node.ListNode):
-                # in python 3.12 this can be replaced with itertools.batched
-                def batch_gen():
-                    it = iter(isotope_fractions)
-                    while batch := tuple(itertools.islice(it, 2)):
-                        yield batch
-
-                iterator = batch_gen()
-            elif isinstance(isotope_fractions, syntax_node.IsotopesNode):
+            if isinstance(isotope_fractions, syntax_node.IsotopesNode):
                 iterator = iter(isotope_fractions)
             else:  # pragma: no cover
                 # this is a fall through error, that should never be raised,
@@ -154,6 +146,9 @@ class Material(data_input.DataInputAbstract, Numbered_MCNP_Object):
         if self.thermal_scattering is not None:
             lines += self.thermal_scattering.format_for_mcnp_input(mcnp_version)
         return lines
+
+    def _update_values(self):
+        print(self._tree)
 
     def add_thermal_scattering(self, law):
         """

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -148,7 +148,11 @@ class Material(data_input.DataInputAbstract, Numbered_MCNP_Object):
         return lines
 
     def _update_values(self):
-        print(self._tree)
+        new_list = syntax_node.IsotopesNode("new isotope list")
+        for isotope, component in self.material_components.items():
+            isotope._tree.value = isotope.mcnp_str()
+            new_list.append(("_", isotope._tree, component._tree))
+        self._tree.nodes["data"] = new_list
 
     def add_thermal_scattering(self, law):
         """

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -112,6 +112,9 @@ class Material(data_input.DataInputAbstract, Numbered_MCNP_Object):
         """
         The internal dictionary containing all the components of this material.
 
+        The keys are :class:`~montepy.data_inputs.isotope.Isotope` instances, and the values are
+        :class:`~montepy.data_inputs.material_component.MaterialComponent` instances.
+
         :rtype: dict
         """
         return self._material_components

--- a/montepy/input_parser/material_parser.py
+++ b/montepy/input_parser/material_parser.py
@@ -1,4 +1,6 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+import itertools
+
 from montepy.input_parser.data_parser import DataParser
 from montepy.input_parser import syntax_node
 
@@ -21,11 +23,27 @@ class MaterialParser(DataParser):
 
     @_("isotope_fractions", "number_sequence", "isotope_hybrid_fractions")
     def isotopes(self, p):
+        if hasattr(p, "number_sequence"):
+            return self._convert_to_isotope(p.number_sequence)
         return p[0]
 
     @_("number_sequence isotope_fraction", "isotope_hybrid_fractions isotope_fraction")
     def isotope_hybrid_fractions(self, p):
-        ret = p[0]
-        for node in p.isotope_fraction[1:]:
-            ret.append(node)
+        if hasattr(p, "number_sequence"):
+            ret = self._convert_to_isotope(p.number_sequence)
+        else:
+            ret = p[0]
+        ret.append(p.isotope_fraction)
         return ret
+
+    def _convert_to_isotope(self, old):
+        new_list = syntax_node.IsotopesNode("converted isotopes")
+
+        def batch_gen():
+            it = iter(old)
+            while batch := tuple(itertools.islice(it, 2)):
+                yield batch
+
+        for group in batch_gen():
+            new_list.append(("foo", *group))
+        return new_list

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -176,7 +176,8 @@ def test_material_update_format():
     print(material.format_for_mcnp_input((6, 2, 0)))
     assert "2004" in material.format_for_mcnp_input((6, 2, 0))[0]
     # update
-    isotope = Isotope("8016.80c")
+    isotope = list(material.material_components.keys())[-1]
+    print(material.material_components.keys())
     material.material_components[isotope].fraction = 0.7
     print(material.format_for_mcnp_input((6, 2, 0)))
     assert "0.7" in material.format_for_mcnp_input((6, 2, 0))[0]

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -162,13 +162,31 @@ def test_material_comp_fraction_str():
     repr(comp)
 
 
-def test_material_card_pass_through():
+def test_material_update_format():
     in_str = "M20 1001.80c 0.5 8016.80c 0.5"
     input_card = Input([in_str], BlockType.DATA)
     material = Material(input_card)
     assert material.format_for_mcnp_input((6, 2, 0)) == [in_str]
     material.number = 5
-    assert "8016" not in material.format_for_mcnp_input((6, 2, 0))
+    print(material.format_for_mcnp_input((6, 2, 0)))
+    assert "8016" in material.format_for_mcnp_input((6, 2, 0))[0]
+    # addition
+    isotope = Isotope("2004.80c")
+    material.material_components[isotope] = MaterialComponent(isotope, 0.1)
+    print(material.format_for_mcnp_input((6, 2, 0)))
+    assert "2004" in material.format_for_mcnp_input((6, 2, 0))[0]
+    # update
+    isotope = Isotope("8016.80c")
+    material.material_components[isotope].fraction = 0.7
+    print(material.format_for_mcnp_input((6, 2, 0)))
+    assert "0.7" in material.format_for_mcnp_input((6, 2, 0))[0]
+    material.material_components[isotope] = MaterialComponent(isotope, 0.6)
+    print(material.format_for_mcnp_input((6, 2, 0)))
+    assert "0.6" in material.format_for_mcnp_input((6, 2, 0))[0]
+    # delete
+    del material.material_components[isotope]
+    print(material.format_for_mcnp_input((6, 2, 0)))
+    assert "8016" in material.format_for_mcnp_input((6, 2, 0))[0]
 
 
 class TestIsotope(TestCase):


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

this fixes a bug where material composition data is not updated when written to file. 
This is because the syntax tree was not being properly updated. 

Fixes #470.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
