### PR TITLE
Simplify isotope printing with __repr__

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -8,6 +8,10 @@ MontePy Changelog
 
 * Fixed bug with appending and renumbeing numbered objects from other MCNP problems (:issue:`466`).
 
+**Code Quality**
+
+* Simpler ``Isotope`` representation (:issue:`473`).
+
 
 0.3.2
 --------------

--- a/montepy/data_inputs/isotope.py
+++ b/montepy/data_inputs/isotope.py
@@ -178,7 +178,8 @@ class Isotope:
         :returns: a string that can be used in MCNP
         :rtype: str
         """
-        return f"{self.ZAID}.{self.library}"
+        suffix = f".{self.library}" if self._library else ""
+        return f"{self.ZAID}{suffix}"
 
     def nuclide_str(self):
         suffix = f".{self._library}" if self._library else ""

--- a/montepy/data_inputs/isotope.py
+++ b/montepy/data_inputs/isotope.py
@@ -167,7 +167,7 @@ class Isotope:
         self._library = library
 
     def __repr__(self):
-        return f"{self.__class__.__name__}({repr(self.mcnp_str())})"
+        return f"{self.__class__.__name__}({repr(self.nuclide_str())})"
 
     def mcnp_str(self):
         """
@@ -179,6 +179,9 @@ class Isotope:
         :rtype: str
         """
         return f"{self.ZAID}.{self.library}"
+
+    def nuclide_str(self):
+        return f"{self.element.symbol}-{self.A}.{self._library}"
 
     def get_base_zaid(self):
         """

--- a/montepy/data_inputs/isotope.py
+++ b/montepy/data_inputs/isotope.py
@@ -196,7 +196,8 @@ class Isotope:
         return self.Z * 1000 + self.A
 
     def __str__(self):
-        return f"ZAID={self.ZAID}, Z={self.Z}, A={self.A}, element={self.element}, library={self.library}"
+        suffix = f" ({self._library})" if self._library else ""
+        return f"{self.element.symbol:>2}-{self.A:<3}{suffix}"
 
     def __hash__(self):
         return hash(self._ZAID)

--- a/montepy/data_inputs/isotope.py
+++ b/montepy/data_inputs/isotope.py
@@ -166,8 +166,8 @@ class Isotope:
             raise TypeError("library must be a string")
         self._library = library
 
-    def __str__(self):
-        return f"{self.element.symbol:>2}-{self.A:<3} ({self._library})"
+    def __repr__(self):
+        return f"{self.__class__.__name__}({repr(self.mcnp_str())})"
 
     def mcnp_str(self):
         """
@@ -191,7 +191,7 @@ class Isotope:
         """
         return self.Z * 1000 + self.A
 
-    def __repr__(self):
+    def __str__(self):
         return f"ZAID={self.ZAID}, Z={self.Z}, A={self.A}, element={self.element}, library={self.library}"
 
     def __hash__(self):

--- a/montepy/data_inputs/isotope.py
+++ b/montepy/data_inputs/isotope.py
@@ -181,7 +181,8 @@ class Isotope:
         return f"{self.ZAID}.{self.library}"
 
     def nuclide_str(self):
-        return f"{self.element.symbol}-{self.A}.{self._library}"
+        suffix = f".{self._library}" if self._library else ""
+        return f"{self.element.symbol}-{self.A}{suffix}"
 
     def get_base_zaid(self):
         """

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -100,9 +100,9 @@ class testMaterialClass(TestCase):
         material = Material(input_card)
         answers = """\
 MATERIAL: 20 fractions: atom
-ZAID=1001, Z=1, A=1, element=hydrogen, library=80c 0.5
-ZAID=8016, Z=8, A=16, element=oxygen, library=80c 0.4
-ZAID=94239, Z=94, A=239, element=plutonium, library=80c 0.1
+ H-1   (80c) 0.5
+ O-16  (80c) 0.4
+Pu-239 (80c) 0.1
 """
         output = repr(material)
         print(output)
@@ -225,11 +225,11 @@ class TestIsotope(TestCase):
     def test_isotope_str(self):
         isotope = Isotope("1001.80c")
         assert isotope.mcnp_str() == "1001.80c"
-        assert repr(isotope) == "Isotope('1001.80c')"
-        assert str(isotope) == "ZAID=1001, Z=1, A=1, element=hydrogen, library=80c"
+        assert repr(isotope) == "Isotope('H-1.80c')"
+        assert str(isotope) == " H-1   (80c)"
         isotope = Isotope("94239.80c")
         assert isotope.mcnp_str() == "94239.80c"
-        assert repr(isotope) == "Isotope('94239.80c')"
+        assert repr(isotope) == "Isotope('Pu-239.80c')"
 
 
 class TestThermalScattering(TestCase):

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -225,11 +225,17 @@ class TestIsotope(TestCase):
     def test_isotope_str(self):
         isotope = Isotope("1001.80c")
         assert isotope.mcnp_str() == "1001.80c"
+        assert isotope.nuclide_str() == "H-1.80c"
         assert repr(isotope) == "Isotope('H-1.80c')"
         assert str(isotope) == " H-1   (80c)"
         isotope = Isotope("94239.80c")
+        assert isotope.nuclide_str() == "Pu-239.80c"
         assert isotope.mcnp_str() == "94239.80c"
         assert repr(isotope) == "Isotope('Pu-239.80c')"
+        isotope = Isotope("95642")
+        assert isotope.nuclide_str() == "Am-242"
+        assert isotope.mcnp_str() == "95642"
+        assert repr(isotope) == "Isotope('Am-242')"
 
 
 class TestThermalScattering(TestCase):

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -98,16 +98,17 @@ class testMaterialClass(TestCase):
         in_str = "M20 1001.80c 0.5 8016.80c 0.4 94239.80c 0.1"
         input_card = Input([in_str], BlockType.DATA)
         material = Material(input_card)
-        answers = """MATERIAL: 20 fractions: atom
- H-1   (80c) 0.5
- O-16  (80c) 0.4
-Pu-239 (80c) 0.1
+        answers = """\
+MATERIAL: 20 fractions: atom
+ZAID=1001, Z=1, A=1, element=hydrogen, library=80c 0.5
+ZAID=8016, Z=8, A=16, element=oxygen, library=80c 0.4
+ZAID=94239, Z=94, A=239, element=plutonium, library=80c 0.1
 """
         output = repr(material)
         print(output)
-        self.assertEqual(output, answers)
+        assert output == answers
         output = str(material)
-        self.assertEqual(output, "MATERIAL: 20, ['hydrogen', 'oxygen', 'plutonium']")
+        assert output == "MATERIAL: 20, ['hydrogen', 'oxygen', 'plutonium']"
 
     def test_material_sort(self):
         in_str = "M20 1001.80c 0.5 8016.80c 0.5"

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -223,14 +223,13 @@ class TestIsotope(TestCase):
 
     def test_isotope_str(self):
         isotope = Isotope("1001.80c")
-        self.assertEqual(isotope.mcnp_str(), "1001.80c")
-        self.assertEqual(str(isotope), " H-1   (80c)")
-        self.assertEqual(
-            repr(isotope), "ZAID=1001, Z=1, A=1, element=hydrogen, library=80c"
-        )
+        assert isotope.mcnp_str() == "1001.80c"
+        assert repr(isotope) == "Isotope('1001.80c')"
+        assert str(isotope) == \
+            "ZAID=1001, Z=1, A=1, element=hydrogen, library=80c"
         isotope = Isotope("94239.80c")
-        self.assertEqual(isotope.mcnp_str(), "94239.80c")
-        self.assertEqual(str(isotope), "Pu-239 (80c)")
+        assert isotope.mcnp_str() == "94239.80c"
+        assert repr(isotope) == "Isotope('94239.80c')"
 
 
 class TestThermalScattering(TestCase):

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -226,8 +226,7 @@ class TestIsotope(TestCase):
         isotope = Isotope("1001.80c")
         assert isotope.mcnp_str() == "1001.80c"
         assert repr(isotope) == "Isotope('1001.80c')"
-        assert str(isotope) == \
-            "ZAID=1001, Z=1, A=1, element=hydrogen, library=80c"
+        assert str(isotope) == "ZAID=1001, Z=1, A=1, element=hydrogen, library=80c"
         isotope = Isotope("94239.80c")
         assert isotope.mcnp_str() == "94239.80c"
         assert repr(isotope) == "Isotope('94239.80c')"


### PR DESCRIPTION
# Description

* New, simpler `Isotope.__repr__`
* Add method `Isotope.nuclide_str()`
* Update _test_material.py_ accordingly

Fixes #473 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have updated the changelog
- [x] I have updated tests that prove my fix is effective or that my feature works 
