### PR TITLE
Add robits

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![JOSS article status](https://joss.theoj.org/papers/e5b5dc8cea19605a1507dd4d420d5199/status.svg)](https://joss.theoj.org/papers/e5b5dc8cea19605a1507dd4d420d5199)
 [![Coverage Status](https://coveralls.io/repos/github/idaholab/MontePy/badge.svg?branch=develop)](https://coveralls.io/github/idaholab/MontePy?branch=develop)
 [![PyPI version](https://badge.fury.io/py/montepy.svg)](https://badge.fury.io/py/montepy)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 
 MontePy is a python library to read, edit, and write MCNP input files. 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,12 +36,15 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
     "sphinx.ext.extlinks",
+    "sphinx_sitemap",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 html_favicon = "monty.svg"
 html_logo = "monty.svg"
+
+html_baseurl = "https://www.montepy.org/"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -45,6 +45,7 @@ html_favicon = "monty.svg"
 html_logo = "monty.svg"
 
 html_baseurl = "https://www.montepy.org/"
+html_extra_path = ["robots.txt"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.

--- a/doc/source/robots.txt
+++ b/doc/source/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.montepy.org/sitemap.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,12 @@ dependencies = [
 [project.optional-dependencies]
 test = ["coverage[toml]>=6.3.2", "pytest"]
 # This is needed for a sphinx bug. See #414.
-doc = ["sphinx>=7.4.0", "sphinxcontrib-apidoc", "sphinx_rtd_theme"]
+doc = [
+	"sphinx>=7.4.0", 
+	"sphinxcontrib-apidoc", 
+	"sphinx_rtd_theme",
+	"sphinx-sitemap"
+]
 format = ["black>=23.3.0"]
 build = [
 	"build",


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

This adds support for robits to our documentation website via `robots.txt` and by creating a `sitemap.xml`, because

![why not](https://memes.ucoz.com/_nw/24/73222789.jpg)

Fixes #478.

# Checklist

- [x] I have performed a self-review of my own code
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
