### PR TITLE
Fixed how metastable isomers are printed. 

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,6 +1,13 @@
 MontePy Changelog
 =================
 
+#Next Version#
+--------------
+
+**Bug Fixes**
+
+* Fixed bug that didn't show metastable states for pretty printing and isotope. Also handled the case that Am-241 metstable states break convention (:issue:`486`).
+
 0.3.3
 --------------
 

--- a/montepy/data_inputs/isotope.py
+++ b/montepy/data_inputs/isotope.py
@@ -14,6 +14,10 @@ class Isotope:
 
     #                   Cl-52      Br-101     Xe-150      Os-203    Cm-251     Og-296
     _BOUNDING_CURVE = [(17, 52), (35, 101), (54, 150), (76, 203), (96, 251), (118, 296)]
+    _STUPID_MAP = {
+        "95642": {"_is_metastable": False, "_meta_state": None},
+        "95242": {"_is_metastable": True, "_meta_state": 1},
+    }
     """
     Points on bounding curve for determining if "valid" isotope
     """
@@ -38,6 +42,14 @@ class Isotope:
             self._library = ""
         if node is None:
             self._tree = ValueNode(self.mcnp_str(), str, PaddingNode(" "))
+        self._handle_stupid_legacy_stupidity()
+
+    def _handle_stupid_legacy_stupidity(self):
+        # TODO work on this for mat_redesign
+        if self.ZAID in self._STUPID_MAP:
+            stupid_overwrite = self._STUPID_MAP[self.ZAID]
+            for key, value in stupid_overwrite.items():
+                setattr(self, key, value)
 
     def __parse_zaid(self):
         """

--- a/montepy/data_inputs/isotope.py
+++ b/montepy/data_inputs/isotope.py
@@ -183,8 +183,9 @@ class Isotope:
         return f"{self.ZAID}.{self.library}" if self.library else self.ZAID
 
     def nuclide_str(self):
+        meta_suffix = f"m{self.meta_state}" if self.is_metastable else ""
         suffix = f".{self._library}" if self._library else ""
-        return f"{self.element.symbol}-{self.A}{suffix}"
+        return f"{self.element.symbol}-{self.A}{meta_suffix}{suffix}"
 
     def get_base_zaid(self):
         """
@@ -198,8 +199,9 @@ class Isotope:
         return self.Z * 1000 + self.A
 
     def __str__(self):
+        meta_suffix = f"m{self.meta_state}" if self.is_metastable else ""
         suffix = f" ({self._library})" if self._library else ""
-        return f"{self.element.symbol:>2}-{self.A:<3}{suffix}"
+        return f"{self.element.symbol:>2}-{self.A:<3}{meta_suffix:<2}{suffix}"
 
     def __hash__(self):
         return hash(self._ZAID)

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -247,9 +247,9 @@ class TestIsotope(TestCase):
         assert isotope.mcnp_str() == "95642"
         assert repr(isotope) == "Isotope('Am-242')"
         isotope = Isotope("95242")
-        assert isotope.nuclide_str() == "Am-242"
-        assert isotope.mcnp_str() == "95642"
-        assert repr(isotope) == "Isotope('Am-242')"
+        assert isotope.nuclide_str() == "Am-242m1"
+        assert isotope.mcnp_str() == "95242"
+        assert repr(isotope) == "Isotope('Am-242m1')"
 
 
 class TestThermalScattering(TestCase):

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -15,7 +15,6 @@ from montepy.input_parser.mcnp_input import Input
 
 
 class testMaterialClass(TestCase):
-
     def test_material_parameter_parsing(self):
         for line in ["M20 1001.80c 1.0 gas=0", "M20 1001.80c 1.0 gas = 0 nlib = 00c"]:
             input = Input([line], BlockType.CELL)
@@ -153,7 +152,6 @@ def test_material_update_format():
     ],
 )
 def test_material_init(line, mat_number, is_atom, fractions):
-
     input = Input([line], BlockType.DATA)
     material = Material(input)
     assert material.number == mat_number
@@ -238,7 +236,17 @@ class TestIsotope(TestCase):
         assert isotope.nuclide_str() == "Pu-239.80c"
         assert isotope.mcnp_str() == "94239.80c"
         assert repr(isotope) == "Isotope('Pu-239.80c')"
+        isotope = Isotope("92635.80c")
+        assert isotope.nuclide_str() == "U-235m1.80c"
+        assert isotope.mcnp_str() == "92635.80c"
+        assert str(isotope) == " U-235m1 (80c)"
+        assert repr(isotope) == "Isotope('U-235m1.80c')"
+        # stupid legacy stupidity #486
         isotope = Isotope("95642")
+        assert isotope.nuclide_str() == "Am-242"
+        assert isotope.mcnp_str() == "95642"
+        assert repr(isotope) == "Isotope('Am-242')"
+        isotope = Isotope("95242")
         assert isotope.nuclide_str() == "Am-242"
         assert isotope.mcnp_str() == "95642"
         assert repr(isotope) == "Isotope('Am-242')"

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -44,9 +44,9 @@ class testMaterialClass(TestCase):
         material = Material(input_card)
         answers = """\
 MATERIAL: 20 fractions: atom
- H-1   (80c) 0.5
- O-16  (80c) 0.4
-Pu-239 (80c) 0.1
+ H-1     (80c) 0.5
+ O-16    (80c) 0.4
+Pu-239   (80c) 0.1
 """
         output = repr(material)
         print(output)
@@ -231,7 +231,7 @@ class TestIsotope(TestCase):
         assert isotope.mcnp_str() == "1001.80c"
         assert isotope.nuclide_str() == "H-1.80c"
         assert repr(isotope) == "Isotope('H-1.80c')"
-        assert str(isotope) == " H-1   (80c)"
+        assert str(isotope) == " H-1     (80c)"
         isotope = Isotope("94239.80c")
         assert isotope.nuclide_str() == "Pu-239.80c"
         assert isotope.mcnp_str() == "94239.80c"


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

This fixed a bug where the metastable state for isotopes (really isomers, but not going to change the class names) was not printed in the string representations. This fixed it using `mN` notation. For example: `U-235m1`.

This also handles the edge case where the ZAID for Am-242m1 (and also Am-242) is intentionally wrong. 

I hate legacy software. 

Fixes #486

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
