### PR TITLE
Bug fix for parentheses getting dropped from cell definitions. 

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -12,7 +12,7 @@ MontePy Changelog
 
 * Fixed bug that didn't show metastable states for pretty printing and isotope. Also handled the case that Am-241 metstable states break convention (:issue:`486`).
 * Fixed bug where cell modifiers could be made irrelevant by being added after a comment (:issue:`483`).
-* Fixed bug where parentheses in cell geometry is not properly exported (:pull:`491`).
+* Fixed bug where parentheses in cell geometry are not properly exported (:pull:`491`).
 
 
 0.3.3

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -12,6 +12,7 @@ MontePy Changelog
 
 * Fixed bug that didn't show metastable states for pretty printing and isotope. Also handled the case that Am-241 metstable states break convention (:issue:`486`).
 * Fixed bug where cell modifiers could be made irrelevant by being added after a comment (:issue:`483`).
+* Fixed bug where parentheses in cell geometry is not properly exported (:pull:`491`).
 
 
 0.3.3

--- a/montepy/geometry_operators.py
+++ b/montepy/geometry_operators.py
@@ -25,3 +25,4 @@ class Operator(Enum):
 
     This is used to properly handle parentheses while parsing.
     """
+    # TODO decide on group

--- a/montepy/geometry_operators.py
+++ b/montepy/geometry_operators.py
@@ -23,6 +23,9 @@ class Operator(Enum):
     """
     Internal operator essentially equivalent to No-op.
 
-    This is used to properly handle parentheses while parsing.
+    This is used to properly handle some leaf nodes.
     """
-    # TODO decide on group
+    GROUP = "()"
+    """
+    Grouping operator that represents parentheses.
+    """

--- a/montepy/input_parser/cell_parser.py
+++ b/montepy/input_parser/cell_parser.py
@@ -138,7 +138,10 @@ class CellParser(MCNP_Parser):
             else:
                 ret.padding = p.padding
         else:
-            ret.nodes["end_pad"] = p.padding
+            if "end_pad" in ret.nodes:
+                ret.nodes["end_pad"] += p.padding
+            else:
+                ret.nodes["end_pad"] = p.padding
         return ret
 
     @_("geometry_factor")

--- a/montepy/input_parser/cell_parser.py
+++ b/montepy/input_parser/cell_parser.py
@@ -176,7 +176,7 @@ class CellParser(MCNP_Parser):
         if hasattr(p, "padding"):
             for node in p.padding.nodes:
                 nodes["start_pad"].append(node)
-        return syntax_node.GeometryTree("geom parens", nodes, ">", p.geometry_expr)
+        return syntax_node.GeometryTree("geom parens", nodes, "()", p.geometry_expr)
 
     # support for fill card weirdness
     @_(

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -440,7 +440,6 @@ class NumberedDataObjectCollection(NumberedObjectCollection):
         :raises NumberConflictError: if this object has a number that is already in use.
         """
         if self._problem:
-            print(self._last_index, len(self))
             if self._last_index:
                 index = self._last_index
             elif len(self) > 0:

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -144,6 +144,7 @@ class HalfSpace:
             else:
                 sides.append(HalfSpace.parse_input_node(side))
         # ignore shifts, and simplify the tree
+        # TODO how to handle
         if node.operator == Operator._SHIFT:
             return sides[0]
         if len(sides) == 1:
@@ -605,6 +606,7 @@ class UnitHalfSpace(HalfSpace):
             self._node = node
 
     def _update_node(self):
+        # TODO how to detect need for parentheses
         if isinstance(self.divider, int):
             self._node.value = self.divider
         else:

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -70,7 +70,7 @@ class HalfSpace:
             raise TypeError(f"operator must be of type Operator. {operator} given.")
         if not isinstance(node, (GeometryTree, type(None))):
             raise TypeError(f"node must be a GeometryTree or None. {node} given.")
-        if right is None and operator != Operator.COMPLEMENT:
+        if right is None and operator not in {Operator.COMPLEMENT, Operator._SHIFT}:
             raise ValueError(f"Both sides required for: {operator}")
         self._left = left
         self._operator = operator
@@ -143,10 +143,8 @@ class HalfSpace:
                 sides.append(UnitHalfSpace.parse_input_node(side, is_cell))
             else:
                 sides.append(HalfSpace.parse_input_node(side))
-        # ignore shifts, and simplify the tree
-        # TODO how to handle
         if node.operator == Operator._SHIFT:
-            return sides[0]
+            return HalfSpace(sides[0], node.operator, None, node)
         if len(sides) == 1:
             sides.append(None)
         return HalfSpace(sides[0], node.operator, sides[1], node)

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -286,13 +286,13 @@ class HalfSpace:
         # detect need for parens and make child handle it with shift
         if self.operator == Operator.INTERSECTION:
             if type(self) == type(self.left) and self.left.operator == Operator.UNION:
-                self.left = HalfSpace(self.left, operator.GROUP)
+                self.left = HalfSpace(self.left, Operator.GROUP)
             if (
                 self.right is not None
                 and type(self) == type(self.right)
                 and self.right.operator == Operator.UNION
             ):
-                self.right = HalfSpace(self.right, operator.GROUP)
+                self.right = HalfSpace(self.right, Operator.GROUP)
 
     def _update_node(self):
         """

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -242,7 +242,6 @@ class HalfSpace:
         if self.right is not None:
             self.right._ensure_has_nodes()
         if self.node is None:
-            # TODO check on __str__
             if self.operator == Operator.INTERSECTION:
                 operator = " "
             elif self.operator == Operator.UNION:
@@ -298,7 +297,6 @@ class HalfSpace:
         """
         Ensures that the syntax node properly reflects the current HalfSpace structure
         """
-        # TODO update
         try:
             operator_node = self.node.nodes["operator"]
             output = operator_node.format()
@@ -648,7 +646,6 @@ class UnitHalfSpace(HalfSpace):
             self._node = node
 
     def _update_node(self):
-        # TODO how to detect need for parentheses
         if isinstance(self.divider, int):
             self._node.value = self.divider
         else:

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -349,9 +349,11 @@ class HalfSpace:
         """
         operator_node = self.node.nodes["operator"]
         operator_node._nodes = [
-            n.replace("#", " ").replace(":", " ")
-            if not isinstance(n, CommentNode)
-            else n
+            (
+                n.replace("#", " ").replace(":", " ")
+                if not isinstance(n, CommentNode)
+                else n
+            )
             for n in operator_node.nodes
         ]
         if new_symbol == "#":

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -440,6 +440,8 @@ class HalfSpace:
     def __str__(self):
         if self.operator == Operator.COMPLEMENT:
             return f"{self.operator.value}{self.left}"
+        if self.operator == Operator.GROUP:
+            return str(self.left)
         return f"({self.left}{self.operator.value}{self.right})"
 
     def __repr__(self):

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -51,6 +51,12 @@ class HalfSpace:
 
         half_space = ~ other_half_space
 
+    Parantheses are allowed, and handled properly
+
+    .. code-block:: python
+
+        half_space = +bottom & (-left | +right)
+
     :param left: The left side of the binary tree.
     :type left: HalfSpace
     :param operator: the operator to apply between the two branches.
@@ -344,8 +350,9 @@ class HalfSpace:
         operator_node = self.node.nodes["operator"]
         operator_node._nodes = [
             n.replace("#", " ").replace(":", " ")
-            for n in operator_node.nodes
             if not isinstance(n, CommentNode)
+            else n
+            for n in operator_node.nodes
         ]
         if new_symbol == "#":
             operator_node._nodes[-1] = operator_node.nodes[-1][:-1] + "#"

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -70,7 +70,7 @@ class HalfSpace:
             raise TypeError(f"operator must be of type Operator. {operator} given.")
         if not isinstance(node, (GeometryTree, type(None))):
             raise TypeError(f"node must be a GeometryTree or None. {node} given.")
-        if right is None and operator not in {Operator.COMPLEMENT, Operator._SHIFT}:
+        if right is None and operator not in {Operator.COMPLEMENT, Operator.GROUP}:
             raise ValueError(f"Both sides required for: {operator}")
         self._left = left
         self._operator = operator
@@ -249,7 +249,7 @@ class HalfSpace:
                 operator = " : "
             elif self.operator == Operator.COMPLEMENT:
                 operator = " #"
-            elif self.operator == Operator._SHIFT:
+            elif self.operator == Operator.GROUP:
                 operator = None
             operator = PaddingNode(operator)
             # Update trees
@@ -286,13 +286,13 @@ class HalfSpace:
         # detect need for parens and make child handle it with shift
         if self.operator == Operator.INTERSECTION:
             if type(self) == type(self.left) and self.left.operator == Operator.UNION:
-                self.left = HalfSpace(self.left, operator._SHIFT)
+                self.left = HalfSpace(self.left, operator.GROUP)
             if (
                 self.right is not None
                 and type(self) == type(self.right)
                 and self.right.operator == Operator.UNION
             ):
-                self.right = HalfSpace(self.right, operator._SHIFT)
+                self.right = HalfSpace(self.right, operator.GROUP)
 
     def _update_node(self):
         """
@@ -324,7 +324,7 @@ class HalfSpace:
                     self.left.node,
                     None,
                 )
-        elif self.operator == Operator._SHIFT:
+        elif self.operator == Operator.GROUP:
             if "start_pad" not in self.node.nodes:
                 self._node = GeometryTree(
                     "default Geometry",

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -277,12 +277,13 @@ class HalfSpace:
 
     def _ensure_has_parens(self):
         """
+        Ensures that when a parentheses is needed it is added.
 
-        ignoring parens needed for complements.
+        This detects unions below an intersection. It then "adds" a parentheses
+        by adding a GROUP to the tree.
 
-        :rtype: BrokenObjectLinkError
+        This ignores parentheses needed for complements as its handled in _update_node.
         """
-        # detect need for parens and make child handle it with shift
         if self.operator == Operator.INTERSECTION:
             if type(self) == type(self.left) and self.left.operator == Operator.UNION:
                 self.left = HalfSpace(self.left, Operator.GROUP)

--- a/montepy/utilities.py
+++ b/montepy/utilities.py
@@ -129,7 +129,7 @@ def make_prop_pointer(
 
     :param hidden_param: The string representing the parameter name of the internally stored ValueNode.
     :type hidden_param: str
-    :param types: the acceptable types for the settable, which is passed to isinstance.
+    :param types: the acceptable types for the settable, which is passed to isinstance, if an empty tuple is provided the type will be self.
     :type types: Class, tuple
     :param validator: A validator function to run on values before setting. Must accept func(self, value).
     :type validator: function

--- a/tests/inputs/test_paren_groups.imcnp
+++ b/tests/inputs/test_paren_groups.imcnp
@@ -1,0 +1,44 @@
+MCNP Test Model
+C Cells with parentheses
+1 3   1  (-1001 +11 +13):(-1001 -11 -13)   imp:n=2
+2 2   1 ((-1001 +11 -13):(-1001 -11 +13))  imp:n=2
+3 1 -10 (   -1010                                   $ inside big sphere
+            +1001                                   $ outside origin sphere
+            +13                                     $ above Z-axis
+           (-1002:-1003:-1004:-1005)    )           $ inside the 4 spheres
+           imp:n=4
+4 1 -10 -1010 +1001 -13 (-1002:-1003:-1004:-1005)   $ like 3 but below the z-plane
+           imp:n=1
+5     0 -1010 1001 1002 1003 1004 1005     imp:n=2  $ outside the spheres
+C Graveyard
+99    0 +1010     imp:n=0
+
+C Surfaces
+C
+C Planes
+11  PX  0
+12  PY  0
+13  PZ  0
+C
+C Spheres
+1001 SO      0.6
+1002 SX -1.1 0.1
+1003 SX +1.1 0.1
+1004 SY -1.1 0.1
+1005 SY +1.1 0.1
+1010 SO 3
+
+C data
+C materials
+C UO2 5 atpt enriched
+m1        92235.80c           5
+          92238.80c          95
+C Helium
+m2         2004.80c           1
+C Helium-3
+m3         2003.80c           1
+C execution
+ksrc -1.1 0 0.01
+kcode 100000 1.000 50 1050
+mode n
+vol NO 2J 1 1.5 J

--- a/tests/inputs/test_paren_groups.imcnp
+++ b/tests/inputs/test_paren_groups.imcnp
@@ -41,4 +41,4 @@ C execution
 ksrc -1.1 0 0.01
 kcode 100000 1.000 50 1050
 mode n
-vol NO 2J 1 1.5 J
+vol NO 2J 1 1.5 2J

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -195,7 +195,7 @@ def test_the_dissapearing_parens():
                 if char in {"(", ")"}:
                     parens_count += 1
     fh = io.StringIO()
-    problem.write_to_file(fh)
+    problem.write_problem(fh)
     new_parens_count = 0
     fh.seek(0)
     for line in fh:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -196,9 +196,11 @@ def test_the_dissapearing_parens():
     problem.write_problem(fh)
     new_parens_count = 0
     fh.seek(0)
-    for line in fh:
-        print(line.rstrip())
-        new_parens_count += line.count("(") + line.count(")")
+    with open(in_file, "r") as gold_fh:
+        for line, gold_line in zip(fh, gold_fh):
+            print(line.rstrip())
+            new_parens_count += line.count("(") + line.count(")")
+            assert line.rstrip() == gold_line.rstrip()
     assert new_parens_count == parens_count
 
 
@@ -213,7 +215,6 @@ def test_universe_after_comment():
     try:
         out_file = "universe_after_comment"
         problem.write_to_file(out_file)
-        # TODO check that the Universe does show up
         found = False
         with open(out_file, "r") as fh:
             for line in fh:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -187,3 +187,29 @@ def test_complex_cell_parsing(lines):
         montepy.input_parser.block_type.BlockType.CELL,
     )
     montepy.Cell(input)
+
+def test_the_dissapearing_parens():
+    in_file = os.path.join("tests", "inputs", "test_paren_groups.imcnp")
+    problem = montepy.read_input(in_file)
+    parens_count = 0
+    with open(in_file, "r") as fh:
+        for line in fh:
+            for char in line:
+                if char in {"(", ")"}:
+                    parens_count += 1
+    try:
+        out_file = "test_parens"
+        problem.write_to_file(out_file)
+        new_parens_count = 0
+        with open(out_file, "r") as fh:
+            for line in fh:
+                print(line.rstrip())
+                for char in line:
+                    if char in {"(", ")"}:
+                        new_parens_count += 1
+        assert new_parens_count == parens_count
+    finally:
+        try:
+            os.remove(out_file)
+        except FileNotFoundError:
+            pass

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -184,6 +184,7 @@ def test_complex_cell_parsing(lines):
     )
     montepy.Cell(input)
 
+
 def test_the_dissapearing_parens():
     in_file = os.path.join("tests", "inputs", "test_paren_groups.imcnp")
     problem = montepy.read_input(in_file)
@@ -193,19 +194,13 @@ def test_the_dissapearing_parens():
             for char in line:
                 if char in {"(", ")"}:
                     parens_count += 1
-    try:
-        out_file = "test_parens"
-        problem.write_to_file(out_file)
-        new_parens_count = 0
-        with open(out_file, "r") as fh:
-            for line in fh:
-                print(line.rstrip())
-                for char in line:
-                    if char in {"(", ")"}:
-                        new_parens_count += 1
-        assert new_parens_count == parens_count
-    finally:
-        try:
-            os.remove(out_file)
-        except FileNotFoundError:
-            pass
+    fh = io.StringIO()
+    problem.write_to_file(fh)
+    new_parens_count = 0
+    fh.seek(0)
+    for line in fh:
+        print(line.rstrip())
+        for char in line:
+            if char in {"(", ")"}:
+                new_parens_count += 1
+    assert new_parens_count == parens_count

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -198,7 +198,7 @@ def test_the_dissapearing_parens():
     fh.seek(0)
     for line in fh:
         print(line.rstrip())
-        parens_count += line.count("(") + line.count(")")
+        new_parens_count += line.count("(") + line.count(")")
     assert new_parens_count == parens_count
 
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -191,16 +191,12 @@ def test_the_dissapearing_parens():
     parens_count = 0
     with open(in_file, "r") as fh:
         for line in fh:
-            for char in line:
-                if char in {"(", ")"}:
-                    parens_count += 1
+            parens_count += line.count("(") + line.count(")")
     fh = io.StringIO()
     problem.write_problem(fh)
     new_parens_count = 0
     fh.seek(0)
     for line in fh:
         print(line.rstrip())
-        for char in line:
-            if char in {"(", ")"}:
-                new_parens_count += 1
+        parens_count += line.count("(") + line.count(")")
     assert new_parens_count == parens_count

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -318,7 +318,11 @@ def test_parse_input_tree():
     half_space = HalfSpace.parse_input_node(geometry)
     assert half_space.operator == Operator.COMPLEMENT
     assert half_space.right is None
-    assert half_space.left.operator == Operator.INTERSECTION
+    assert half_space.left.operator == Operator.GROUP
+    nested = half_space.left.left
+    assert nested.operator == Operator.INTERSECTION
+    assert nested.right is not None
+    assert nested.left.operator == Operator.INTERSECTION
 
 
 def test_update_tree_with_comment():

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -8,7 +8,7 @@ from montepy.input_parser import syntax_node
 from montepy.surfaces.half_space import HalfSpace, UnitHalfSpace
 
 
-def test_init():
+def test_halfspace_init():
     surface = montepy.surfaces.CylinderOnAxis()
     node = montepy.input_parser.syntax_node.GeometryTree("hi", {}, "*", " ", " ")
     half_space = HalfSpace(+surface, Operator.UNION, -surface, node)
@@ -39,14 +39,14 @@ def test_get_leaves():
     assert surfaces == {surface}
 
 
-def test_len():
+def test_half_len():
     surface = montepy.surfaces.CylinderOnAxis()
     cell = montepy.Cell()
     half_space = -surface & ~cell
     assert len(half_space) == 2
 
 
-def test_eq():
+def test_half_eq():
     cell1 = montepy.Cell()
     cell2 = montepy.Cell()
     half1 = ~cell1 & ~cell2
@@ -64,7 +64,7 @@ def test_eq():
         half1 == "hi"
 
 
-def test_str():
+def test_half_str():
     cell1 = montepy.Cell()
     cell1.number = 1
     cell2 = montepy.Cell()
@@ -79,7 +79,7 @@ def test_str():
     repr(half_space)
 
 
-def test_init():
+def test_unit_half_init():
     node = montepy.input_parser.syntax_node.ValueNode("123", float)
     half_space = UnitHalfSpace(123, True, False, node)
     assert half_space.divider == 123
@@ -96,7 +96,7 @@ def test_init():
         half_space = UnitHalfSpace(123, True, False, "hi")
 
 
-def test_eq():
+def test_unit_eq():
     half1 = UnitHalfSpace(1, True, False)
     assert half1 == half1
     half2 = UnitHalfSpace(2, True, False)
@@ -109,7 +109,7 @@ def test_eq():
         half1 == "hi"
 
 
-def test_str():
+def test_unit_str():
     half_space = UnitHalfSpace(1, True, False)
     assert str(half_space) == "+1"
     half_space.side = False

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,5 +1,6 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
 from unittest import TestCase
+import pytest
 
 import montepy
 from montepy.geometry_operators import Operator
@@ -7,437 +8,454 @@ from montepy.input_parser import syntax_node
 from montepy.surfaces.half_space import HalfSpace, UnitHalfSpace
 
 
-class TestHalfSpaceUnit(TestCase):
-    def test_init(self):
-        surface = montepy.surfaces.CylinderOnAxis()
-        node = montepy.input_parser.syntax_node.GeometryTree("hi", {}, "*", " ", " ")
-        half_space = HalfSpace(+surface, Operator.UNION, -surface, node)
-        self.assertIs(half_space.operator, Operator.UNION)
-        self.assertEqual(half_space.left, +surface)
-        self.assertEqual(half_space.right, -surface)
-        self.assertIs(half_space.node, node)
-        with self.assertRaises(TypeError):
-            HalfSpace(surface, Operator.UNION)
-        with self.assertRaises(TypeError):
-            HalfSpace(+surface, "hi")
-        with self.assertRaises(TypeError):
-            HalfSpace(+surface, Operator.UNION, surface)
-        with self.assertRaises(TypeError):
-            HalfSpace(+surface, Operator.UNION, -surface, "hi")
-        with self.assertRaises(ValueError):
-            HalfSpace(+surface, Operator.UNION)
-        with self.assertRaises(ValueError):
-            HalfSpace(+surface, Operator.INTERSECTION)
-
-    def test_get_leaves(self):
-        surface = montepy.surfaces.CylinderOnAxis()
-        cell = montepy.Cell()
-        half_space = -surface & ~cell
-        cells, surfaces = half_space._get_leaf_objects()
-        self.assertEqual(cells, {cell})
-        self.assertEqual(surfaces, {surface})
-
-    def test_len(self):
-        surface = montepy.surfaces.CylinderOnAxis()
-        cell = montepy.Cell()
-        half_space = -surface & ~cell
-        self.assertEqual(len(half_space), 2)
-
-    def test_eq(self):
-        cell1 = montepy.Cell()
-        cell2 = montepy.Cell()
-        half1 = ~cell1 & ~cell2
-        self.assertTrue(half1 == half1)
-        half2 = ~cell1 | ~cell2
-        self.assertTrue(half1 != half2)
-        half2 = ~cell1 & ~cell1
-        self.assertTrue(half1 != half2)
-        half2 = ~cell2 & ~cell2
-        self.assertTrue(half1 != half2)
-        half2 = ~half1
-        half2._operator = Operator.INTERSECTION
-        self.assertTrue(half1 != half2)
-        with self.assertRaises(TypeError):
-            half1 == "hi"
-
-    def test_str(self):
-        cell1 = montepy.Cell()
-        cell1.number = 1
-        cell2 = montepy.Cell()
-        cell2.number = 2
-        half_space = ~cell1 | ~cell2
-        self.assertEqual(str(half_space), "(#1:#2)")
-        half_space = ~cell1 & ~cell2
-        self.assertEqual(str(half_space), "(#1*#2)")
-        half_space = ~(~cell1 & ~cell2)
-        self.assertEqual(str(half_space), "#(#1*#2)")
-        # test that no errors occur
-        repr(half_space)
+def test_init():
+    surface = montepy.surfaces.CylinderOnAxis()
+    node = montepy.input_parser.syntax_node.GeometryTree("hi", {}, "*", " ", " ")
+    half_space = HalfSpace(+surface, Operator.UNION, -surface, node)
+    assert half_space.operator is Operator.UNION
+    assert half_space.left == +surface
+    assert half_space.right == -surface
+    assert half_space.node is node
+    with pytest.raises(TypeError):
+        HalfSpace(surface, Operator.UNION)
+    with pytest.raises(TypeError):
+        HalfSpace(+surface, "hi")
+    with pytest.raises(TypeError):
+        HalfSpace(+surface, Operator.UNION, surface)
+    with pytest.raises(TypeError):
+        HalfSpace(+surface, Operator.UNION, -surface, "hi")
+    with pytest.raises(ValueError):
+        HalfSpace(+surface, Operator.UNION)
+    with pytest.raises(ValueError):
+        HalfSpace(+surface, Operator.INTERSECTION)
 
 
-class TestUnitHalfSpaceUnit(TestCase):
-    def test_init(self):
-        node = montepy.input_parser.syntax_node.ValueNode("123", float)
-        half_space = UnitHalfSpace(123, True, False, node)
-        self.assertEqual(half_space.divider, 123)
-        self.assertTrue(half_space.side)
-        self.assertTrue(not half_space.is_cell)
-        self.assertIs(half_space.node, node)
-        with self.assertRaises(TypeError):
-            UnitHalfSpace("hi", True, False)
-        with self.assertRaises(TypeError):
-            half_space = UnitHalfSpace(123, "hi", False)
-        with self.assertRaises(TypeError):
-            half_space = UnitHalfSpace(123, True, "hi")
-        with self.assertRaises(TypeError):
-            half_space = UnitHalfSpace(123, True, False, "hi")
-
-    def test_eq(self):
-        half1 = UnitHalfSpace(1, True, False)
-        self.assertTrue(half1 == half1)
-        half2 = UnitHalfSpace(2, True, False)
-        self.assertTrue(half1 != half2)
-        half2 = UnitHalfSpace(1, False, False)
-        self.assertTrue(half1 != half2)
-        half2 = UnitHalfSpace(1, True, True)
-        self.assertTrue(half1 != half2)
-        with self.assertRaises(TypeError):
-            half1 == "hi"
-
-    def test_str(self):
-        half_space = UnitHalfSpace(1, True, False)
-        self.assertEqual(str(half_space), "+1")
-        half_space.side = False
-        self.assertEqual(str(half_space), "-1")
-        half_space.is_cell = True
-        self.assertEqual(str(half_space), "1")
-        cell = montepy.Cell()
-        cell.number = 1
-        half_space.divider = cell
-        self.assertEqual(str(half_space), "1")
+def test_get_leaves():
+    surface = montepy.surfaces.CylinderOnAxis()
+    cell = montepy.Cell()
+    half_space = -surface & ~cell
+    cells, surfaces = half_space._get_leaf_objects()
+    assert cells == {cell}
+    assert surfaces == {surface}
 
 
-class TestGeometryIntegration(TestCase):
-    def test_surface_half_space(self):
-        surface = montepy.surfaces.cylinder_on_axis.CylinderOnAxis()
-        half_space = +surface
-        self.assertIsInstance(half_space, HalfSpace)
-        self.assertIsInstance(half_space, UnitHalfSpace)
-        self.assertIs(half_space.divider, surface)
-        self.assertTrue(half_space.side)
-        half_space = -surface
-        self.assertIsInstance(half_space, HalfSpace)
-        self.assertIsInstance(half_space, UnitHalfSpace)
-        self.assertIs(half_space.divider, surface)
-        self.assertTrue(not half_space.side)
-        with self.assertRaises(TypeError):
-            half_space = surface & surface
-        with self.assertRaises(TypeError):
-            half_space = surface | surface
-        with self.assertRaises(TypeError):
-            half_space = ~surface
+def test_len():
+    surface = montepy.surfaces.CylinderOnAxis()
+    cell = montepy.Cell()
+    half_space = -surface & ~cell
+    assert len(half_space) == 2
 
-    def test_cell_half_space(self):
-        cell = montepy.Cell()
-        half_space = ~cell
-        self.assertIsInstance(half_space, HalfSpace)
-        self.assertIs(half_space.left.divider, cell)
-        self.assertTrue(half_space.left.side)
-        with self.assertRaises(TypeError):
-            half_space = cell & cell
-        with self.assertRaises(TypeError):
-            half_space = cell | cell
-        with self.assertRaises(TypeError):
-            half_space = +cell
-        with self.assertRaises(TypeError):
-            half_space = -cell
 
-    def test_intersect_half_space(self):
-        cell1 = ~montepy.Cell()
-        cell2 = ~montepy.Cell()
-        half_space = cell1 & cell2
-        self.assertIsInstance(half_space, HalfSpace)
-        self.assertIs(half_space.operator, Operator.INTERSECTION)
-        self.assertIs(half_space.left, cell1)
-        self.assertIs(half_space.right, cell2)
-        with self.assertRaises(TypeError):
-            cell1 & "hi"
-        with self.assertRaises(TypeError):
-            "hi" & cell1
-        with self.assertRaises(TypeError):
-            cell2 + cell1
-        with self.assertRaises(TypeError):
-            cell2 - cell1
+def test_eq():
+    cell1 = montepy.Cell()
+    cell2 = montepy.Cell()
+    half1 = ~cell1 & ~cell2
+    assert half1 == half1
+    half2 = ~cell1 | ~cell2
+    assert half1 != half2
+    half2 = ~cell1 & ~cell1
+    assert half1 != half2
+    half2 = ~cell2 & ~cell2
+    assert half1 != half2
+    half2 = ~half1
+    half2._operator = Operator.INTERSECTION
+    assert half1 != half2
+    with pytest.raises(TypeError):
+        half1 == "hi"
 
-    def test_union_half_space(self):
-        cell1 = ~montepy.Cell()
-        cell2 = ~montepy.Cell()
-        half_space = cell1 | cell2
-        self.assertIsInstance(half_space, HalfSpace)
-        self.assertIs(half_space.operator, Operator.UNION)
-        self.assertIs(half_space.left, cell1)
-        self.assertIs(half_space.right, cell2)
-        with self.assertRaises(TypeError):
-            cell1 | "hi"
-        with self.assertRaises(TypeError):
-            "hi" | cell1
 
-    def test_invert_half_space(self):
-        cell1 = ~montepy.Cell()
-        cell2 = ~montepy.Cell()
-        half_space1 = cell1 | cell2
-        half_space = ~half_space1
-        self.assertIsInstance(half_space, HalfSpace)
-        self.assertIs(half_space.operator, Operator.COMPLEMENT)
-        self.assertIs(half_space.left, half_space1)
-        self.assertIsNone(half_space.right)
+def test_str():
+    cell1 = montepy.Cell()
+    cell1.number = 1
+    cell2 = montepy.Cell()
+    cell2.number = 2
+    half_space = ~cell1 | ~cell2
+    assert str(half_space) == "(#1:#2)"
+    half_space = ~cell1 & ~cell2
+    assert str(half_space) == "(#1*#2)"
+    half_space = ~(~cell1 & ~cell2)
+    assert str(half_space) == "#(#1*#2)"
+    # test that no errors occur
+    repr(half_space)
 
-    def test_iand_recursion(self):
-        cell1 = montepy.Cell()
-        cell2 = montepy.Cell()
-        cell3 = montepy.Cell()
-        half_space = ~cell1 & ~cell2
-        cell1.number = 1
-        cell2.number = 2
-        cell3.number = 3
-        cell3.geometry = half_space
+
+def test_init():
+    node = montepy.input_parser.syntax_node.ValueNode("123", float)
+    half_space = UnitHalfSpace(123, True, False, node)
+    assert half_space.divider == 123
+    assert half_space.side
+    assert not half_space._is_cell
+    assert half_space.node is node
+    with pytest.raises(TypeError):
+        UnitHalfSpace("hi", True, False)
+    with pytest.raises(TypeError):
+        half_space = UnitHalfSpace(123, "hi", False)
+    with pytest.raises(TypeError):
+        half_space = UnitHalfSpace(123, True, "hi")
+    with pytest.raises(TypeError):
+        half_space = UnitHalfSpace(123, True, False, "hi")
+
+
+def test_eq():
+    half1 = UnitHalfSpace(1, True, False)
+    assert half1 == half1
+    half2 = UnitHalfSpace(2, True, False)
+    assert half1 != half2
+    half2 = UnitHalfSpace(1, False, False)
+    assert half1 != half2
+    half2 = UnitHalfSpace(1, True, True)
+    assert half1 != half2
+    with pytest.raises(TypeError):
+        half1 == "hi"
+
+
+def test_str():
+    half_space = UnitHalfSpace(1, True, False)
+    assert str(half_space) == "+1"
+    half_space.side = False
+    assert str(half_space) == "-1"
+    half_space.is_cell = True
+    assert str(half_space), "1"
+    cell = montepy.Cell()
+    cell.number = 1
+    half_space.divider = cell
+    assert str(half_space) == "1"
+
+
+# test geometry integration
+def test_surface_half_space():
+    surface = montepy.surfaces.cylinder_on_axis.CylinderOnAxis()
+    half_space = +surface
+    assert isinstance(half_space, HalfSpace)
+    assert isinstance(half_space, UnitHalfSpace)
+    assert half_space.divider is surface
+    assert half_space.side
+    half_space = -surface
+    assert isinstance(half_space, HalfSpace)
+    assert isinstance(half_space, UnitHalfSpace)
+    assert half_space.divider is surface
+    assert not half_space.side
+    with pytest.raises(TypeError):
+        half_space = surface & surface
+    with pytest.raises(TypeError):
+        half_space = surface | surface
+    with pytest.raises(TypeError):
+        half_space = ~surface
+
+
+def test_cell_half_space():
+    cell = montepy.Cell()
+    half_space = ~cell
+    assert isinstance(half_space, HalfSpace)
+    assert half_space.left.divider is cell
+    assert half_space.left.side
+    with pytest.raises(TypeError):
+        half_space = cell & cell
+    with pytest.raises(TypeError):
+        half_space = cell | cell
+    with pytest.raises(TypeError):
+        half_space = +cell
+    with pytest.raises(TypeError):
+        half_space = -cell
+
+
+def test_intersect_half_space():
+    cell1 = ~montepy.Cell()
+    cell2 = ~montepy.Cell()
+    half_space = cell1 & cell2
+    assert isinstance(half_space, HalfSpace)
+    assert half_space.operator is Operator.INTERSECTION
+    assert half_space.left is cell1
+    assert half_space.right is cell2
+    with pytest.raises(TypeError):
+        cell1 & "hi"
+    with pytest.raises(TypeError):
+        "hi" & cell1
+    with pytest.raises(TypeError):
+        cell2 + cell1
+    with pytest.raises(TypeError):
+        cell2 - cell1
+
+
+def test_union_half_space():
+    cell1 = ~montepy.Cell()
+    cell2 = ~montepy.Cell()
+    half_space = cell1 | cell2
+    assert isinstance(half_space, HalfSpace)
+    assert half_space.operator is Operator.UNION
+    assert half_space.left is cell1
+    assert half_space.right is cell2
+    with pytest.raises(TypeError):
+        cell1 | "hi"
+    with pytest.raises(TypeError):
+        "hi" | cell1
+
+
+def test_invert_half_space():
+    cell1 = ~montepy.Cell()
+    cell2 = ~montepy.Cell()
+    half_space1 = cell1 | cell2
+    half_space = ~half_space1
+    assert isinstance(half_space, HalfSpace)
+    assert half_space.operator is Operator.COMPLEMENT
+    assert half_space.left is half_space1
+    assert half_space.right is None
+
+
+def test_iand_recursion():
+    cell1 = montepy.Cell()
+    cell2 = montepy.Cell()
+    cell3 = montepy.Cell()
+    half_space = ~cell1 & ~cell2
+    cell1.number = 1
+    cell2.number = 2
+    cell3.number = 3
+    cell3.geometry = half_space
+    half_space &= ~cell1
+    assert half_space.left == ~cell1
+    assert not isinstance(half_space.right, UnitHalfSpace)
+    assert half_space.right.left == ~cell2
+    assert half_space.right.right == ~cell1
+    assert half_space.operator == Operator.INTERSECTION
+    assert len(half_space) == 3
+    for i in range(1, 100):
         half_space &= ~cell1
-        self.assertEqual(half_space.left, ~cell1)
-        self.assertNotIsInstance(half_space.right, UnitHalfSpace)
-        self.assertEqual(half_space.right.left, ~cell2)
-        self.assertEqual(half_space.right.right, ~cell1)
-        self.assertEqual(half_space.operator, Operator.INTERSECTION)
-        self.assertEqual(len(half_space), 3)
-        for i in range(1, 100):
-            half_space &= ~cell1
-            self.assertEqual(len(half_space), i + 3)
-        with self.assertRaises(TypeError):
-            half_space &= "hi"
-        # test with unit halfspaces
-        surf = montepy.surfaces.CylinderParAxis()
-        # test going from leaf to tree
-        half_space = -surf
-        half_space &= +surf
-        self.assertEqual(len(half_space), 2)
-        # test with actual tree
-        half_space = -surf | +surf
-        half_space &= +surf
-        self.assertEqual(len(half_space), 3)
+        assert len(half_space) == i + 3
+    with pytest.raises(TypeError):
+        half_space &= "hi"
+    # test with unit halfspaces
+    surf = montepy.surfaces.CylinderParAxis()
+    # test going from leaf to tree
+    half_space = -surf
+    half_space &= +surf
+    assert len(half_space) == 2
+    # test with actual tree
+    half_space = -surf | +surf
+    half_space &= +surf
+    assert len(half_space) == 3
 
-    def test_ior_recursion(self):
-        cell1 = ~montepy.Cell()
-        cell2 = ~montepy.Cell()
-        half_space = cell1 | cell2
+
+def test_ior_recursion():
+    cell1 = ~montepy.Cell()
+    cell2 = ~montepy.Cell()
+    half_space = cell1 | cell2
+    half_space |= cell1
+    assert half_space.left is cell1
+    assert not isinstance(half_space.right, UnitHalfSpace)
+    assert half_space.right.left == cell2
+    assert half_space.right.right == cell1
+    assert half_space.operator == Operator.UNION
+    assert len(half_space) == 3
+    for i in range(1, 100):
         half_space |= cell1
-        self.assertIs(half_space.left, cell1)
-        self.assertNotIsInstance(half_space.right, UnitHalfSpace)
-        self.assertEqual(half_space.right.left, cell2)
-        self.assertEqual(half_space.right.right, cell1)
-        self.assertEqual(half_space.operator, Operator.UNION)
-        self.assertEqual(len(half_space), 3)
-        for i in range(1, 100):
-            half_space |= cell1
-            self.assertEqual(len(half_space), i + 3)
-        with self.assertRaises(TypeError):
-            half_space |= "hi"
-        # test with unit halfspaces
-        surf = montepy.surfaces.CylinderParAxis()
-        half_space = -surf
-        half_space |= +surf
-        self.assertEqual(len(half_space), 2)
-        half_space = -surf | +surf
-        half_space |= +surf
-        self.assertEqual(len(half_space), 3)
+        assert len(half_space), i + 3
+    with pytest.raises(TypeError):
+        half_space |= "hi"
+    # test with unit halfspaces
+    surf = montepy.surfaces.CylinderParAxis()
+    half_space = -surf
+    half_space |= +surf
+    assert len(half_space) == 2
+    half_space = -surf | +surf
+    half_space |= +surf
+    assert len(half_space) == 3
 
-    def test_parse_input_tree(self):
-        # simplest intersection
-        input = montepy.input_parser.mcnp_input.Input(
-            ["1 0 1 -2"], montepy.input_parser.block_type.BlockType.CELL
-        )
-        parser = montepy.input_parser.cell_parser.CellParser()
-        tree = parser.parse(input.tokenize())
-        geometry = tree["geometry"]
-        half_space = HalfSpace.parse_input_node(geometry)
-        self.assertEqual(half_space.operator, Operator.INTERSECTION)
-        self.assertEqual(half_space.left.divider, 1)
-        self.assertTrue(half_space.left.side)
-        self.assertTrue(not half_space.left.is_cell)
-        self.assertEqual(half_space.right.divider, 2)
-        self.assertTrue(not half_space.right.side)
-        self.assertTrue(not half_space.right.is_cell)
-        # Test type checking
-        with self.assertRaises(TypeError):
-            HalfSpace.parse_input_node("hi")
-        # test assymetric
-        input = montepy.input_parser.mcnp_input.Input(
-            ["1 0 #2"], montepy.input_parser.block_type.BlockType.CELL
-        )
-        parser = montepy.input_parser.cell_parser.CellParser()
-        tree = parser.parse(input.tokenize())
-        geometry = tree["geometry"]
-        half_space = HalfSpace.parse_input_node(geometry)
-        self.assertEqual(half_space.operator, Operator.COMPLEMENT)
-        self.assertEqual(half_space.left.divider, 2)
-        self.assertTrue(half_space.left.side)
-        self.assertTrue(half_space.left.is_cell)
-        self.assertIsNone(half_space.right)
-        # Test nested trees
-        input = montepy.input_parser.mcnp_input.Input(
-            ["1 0 1 -2 : 3"], montepy.input_parser.block_type.BlockType.CELL
-        )
-        parser = montepy.input_parser.cell_parser.CellParser()
-        tree = parser.parse(input.tokenize())
-        geometry = tree["geometry"]
-        half_space = HalfSpace.parse_input_node(geometry)
-        self.assertEqual(half_space.operator, Operator.UNION)
-        self.assertNotIsInstance(half_space.left, UnitHalfSpace)
-        self.assertIsInstance(half_space.right, UnitHalfSpace)
-        self.assertEqual(half_space.left.operator, Operator.INTERSECTION)
-        self.assertEqual(half_space.right.divider, 3)
-        self.assertEqual(half_space.left.left.divider, 1)
-        self.assertEqual(half_space.left.right.divider, 2)
-        # test shift
-        input = montepy.input_parser.mcnp_input.Input(
-            ["1 0 #(1 2 3)"], montepy.input_parser.block_type.BlockType.CELL
-        )
-        parser = montepy.input_parser.cell_parser.CellParser()
-        tree = parser.parse(input.tokenize())
-        geometry = tree["geometry"]
-        half_space = HalfSpace.parse_input_node(geometry)
-        self.assertEqual(half_space.operator, Operator.COMPLEMENT)
-        self.assertIsNone(half_space.right)
-        self.assertEqual(half_space.left.operator, Operator.INTERSECTION)
 
-    def test_update_tree_with_comment(self):
-        input = montepy.input_parser.mcnp_input.Input(
-            ["1 0 -1 $hi there", "      2"],
-            montepy.input_parser.block_type.BlockType.CELL,
-        )
-        cell = montepy.Cell(input)
-        geometry = cell.geometry
-        geometry._update_values()
+def test_parse_input_tree():
+    # simplest intersection
+    input = montepy.input_parser.mcnp_input.Input(
+        ["1 0 1 -2"], montepy.input_parser.block_type.BlockType.CELL
+    )
+    parser = montepy.input_parser.cell_parser.CellParser()
+    tree = parser.parse(input.tokenize())
+    geometry = tree["geometry"]
+    half_space = HalfSpace.parse_input_node(geometry)
+    assert half_space.operator == Operator.INTERSECTION
+    assert half_space.left.divider == 1
+    assert half_space.left.side
+    assert not half_space.left.is_cell
+    assert half_space.right.divider == 2
+    assert not half_space.right.side
+    assert not half_space.right.is_cell
+    # Test type checking
+    with pytest.raises(TypeError):
+        HalfSpace.parse_input_node("hi")
+    # test assymetric
+    input = montepy.input_parser.mcnp_input.Input(
+        ["1 0 #2"], montepy.input_parser.block_type.BlockType.CELL
+    )
+    parser = montepy.input_parser.cell_parser.CellParser()
+    tree = parser.parse(input.tokenize())
+    geometry = tree["geometry"]
+    half_space = HalfSpace.parse_input_node(geometry)
+    assert half_space.operator == Operator.COMPLEMENT
+    assert half_space.left.divider == 2
+    assert half_space.left.side
+    assert half_space.left.is_cell
+    assert half_space.right is None
+    # Test nested trees
+    input = montepy.input_parser.mcnp_input.Input(
+        ["1 0 1 -2 : 3"], montepy.input_parser.block_type.BlockType.CELL
+    )
+    parser = montepy.input_parser.cell_parser.CellParser()
+    tree = parser.parse(input.tokenize())
+    geometry = tree["geometry"]
+    half_space = HalfSpace.parse_input_node(geometry)
+    assert half_space.operator == Operator.UNION
+    assert not isinstance(half_space.left, UnitHalfSpace)
+    assert isinstance(half_space.right, UnitHalfSpace)
+    assert half_space.left.operator == Operator.INTERSECTION
+    assert half_space.right.divider == 3
+    assert half_space.left.left.divider == 1
+    assert half_space.left.right.divider == 2
+    # test shift
+    input = montepy.input_parser.mcnp_input.Input(
+        ["1 0 #(1 2 3)"], montepy.input_parser.block_type.BlockType.CELL
+    )
+    parser = montepy.input_parser.cell_parser.CellParser()
+    tree = parser.parse(input.tokenize())
+    geometry = tree["geometry"]
+    half_space = HalfSpace.parse_input_node(geometry)
+    assert half_space.operator == Operator.COMPLEMENT
+    assert half_space.right is None
+    assert half_space.left.operator == Operator.INTERSECTION
 
-    def test_parse_input_value_node(self):
-        node = montepy.input_parser.syntax_node.ValueNode("-1", float)
-        half_space = UnitHalfSpace.parse_input_node(node)
-        self.assertTrue(not half_space.is_cell)
-        self.assertTrue(not half_space.side)
-        self.assertEqual(half_space.divider, 1)
-        half_space = UnitHalfSpace.parse_input_node(node, True)
-        self.assertTrue(half_space.is_cell)
-        self.assertTrue(half_space.side)
-        self.assertEqual(half_space.divider, 1)
-        node = montepy.input_parser.syntax_node.ValueNode("+1", float)
-        half_space = UnitHalfSpace.parse_input_node(node, False)
-        self.assertTrue(not half_space.is_cell)
-        self.assertTrue(half_space.side)
-        self.assertEqual(half_space.divider, 1)
-        with self.assertRaises(TypeError):
-            UnitHalfSpace.parse_input_node("hi", False)
-        with self.assertRaises(TypeError):
-            UnitHalfSpace.parse_input_node(node, "hi")
 
-    def test_unit_divider_setter(self):
-        cell = montepy.Cell()
-        cell.number = 1
-        parent = montepy.Cell()
-        parent.number = 2
-        node = montepy.input_parser.syntax_node.ValueNode("1", float)
-        half_space = UnitHalfSpace.parse_input_node(node, True)
-        cells = montepy.cells.Cells()
-        cells.append(cell)
-        half_space.update_pointers(cells, [], parent)
-        self.assertIs(half_space.divider, cell)
-        cell2 = montepy.Cell()
-        # #madLads
-        cell2.number = 4
-        half_space.divider = cell2
-        self.assertIs(half_space.divider, cell2)
-        self.assertIn(cell2, parent.complements)
-        # test with surface
-        surf = montepy.surfaces.CylinderParAxis()
-        surf.number = 5
-        with self.assertRaises(TypeError):
-            half_space.divider = surf
-        half_space.is_cell = False
+def test_update_tree_with_comment():
+    input = montepy.input_parser.mcnp_input.Input(
+        ["1 0 -1 $hi there", "      2"],
+        montepy.input_parser.block_type.BlockType.CELL,
+    )
+    cell = montepy.Cell(input)
+    geometry = cell.geometry
+    geometry._update_values()
+
+
+def test_parse_input_value_node():
+    node = montepy.input_parser.syntax_node.ValueNode("-1", float)
+    half_space = UnitHalfSpace.parse_input_node(node)
+    assert not half_space.is_cell
+    assert not half_space.side
+    assert half_space.divider == 1
+    half_space = UnitHalfSpace.parse_input_node(node, True)
+    assert half_space.is_cell
+    assert half_space.side
+    assert half_space.divider == 1
+    node = montepy.input_parser.syntax_node.ValueNode("+1", float)
+    half_space = UnitHalfSpace.parse_input_node(node, False)
+    assert not half_space.is_cell
+    assert half_space.side
+    assert half_space.divider == 1
+    with pytest.raises(TypeError):
+        UnitHalfSpace.parse_input_node("hi", False)
+    with pytest.raises(TypeError):
+        UnitHalfSpace.parse_input_node(node, "hi")
+
+
+def test_unit_divider_setter():
+    cell = montepy.Cell()
+    cell.number = 1
+    parent = montepy.Cell()
+    parent.number = 2
+    node = montepy.input_parser.syntax_node.ValueNode("1", float)
+    half_space = UnitHalfSpace.parse_input_node(node, True)
+    cells = montepy.cells.Cells()
+    cells.append(cell)
+    half_space.update_pointers(cells, [], parent)
+    assert half_space.divider is cell
+    cell2 = montepy.Cell()
+    # #madLads
+    cell2.number = 4
+    half_space.divider = cell2
+    assert half_space.divider is cell2
+    assert cell2 in parent.complements
+    # test with surface
+    surf = montepy.surfaces.CylinderParAxis()
+    surf.number = 5
+    with pytest.raises(TypeError):
         half_space.divider = surf
-        self.assertIs(half_space.divider, surf)
-        self.assertIn(surf, parent.surfaces)
-        with self.assertRaises(TypeError):
-            half_space.divider = "hi"
+    half_space.is_cell = False
+    half_space.divider = surf
+    assert half_space.divider is surf
+    assert surf in parent.surfaces
+    with pytest.raises(TypeError):
+        half_space.divider = "hi"
 
-    def test_unit_create_default_node(self):
-        surf = montepy.surfaces.CylinderParAxis()
-        surf.number = 1
-        half_space = UnitHalfSpace(surf, True, False)
-        half_space._ensure_has_nodes()
-        node = half_space.node
-        self.assertIsInstance(node, syntax_node.ValueNode)
-        self.assertEqual(node.value, 1)
-        self.assertEqual(node.format(), "1")
-        # test with negative side
-        half_space = UnitHalfSpace(surf, False, False)
-        half_space._ensure_has_nodes()
-        node = half_space.node
-        self.assertEqual(node.format(), "-1")
-        # test with int and not an object
-        half_space = UnitHalfSpace(1, True, False)
-        half_space._ensure_has_nodes()
-        node = half_space.node
-        self.assertIsInstance(node, syntax_node.ValueNode)
-        self.assertEqual(node.value, 1)
 
-    def test_tree_create_default_node(self):
-        surf = montepy.surfaces.CylinderParAxis()
-        surf.number = 1
-        half_space = -surf | +surf
-        half_space._ensure_has_nodes()
-        node = half_space.node
-        self.assertIsInstance(node, syntax_node.GeometryTree)
-        self.assertEqual(node.operator, Operator.UNION)
-        self.assertEqual(node.format(), "-1 : 1")
-        # Test intersection
-        half_space = -surf & +surf
-        half_space._ensure_has_nodes()
-        node = half_space.node
-        self.assertEqual(node.operator, Operator.INTERSECTION)
-        # Test complement
-        half_space = ~(-surf | +surf)
-        half_space._ensure_has_nodes()
-        node = half_space.node
-        self.assertEqual(node.operator, Operator.COMPLEMENT)
-        self.assertEqual(node.format(), " #(-1 : 1)")
-        # test cell complement
-        cell = montepy.Cell()
-        cell.number = 1
-        half_space = ~cell
-        half_space._ensure_has_nodes()
-        node = half_space.node
-        self.assertEqual(node.operator, Operator.COMPLEMENT)
-        self.assertEqual(node.format(), " #1")
+def test_unit_create_default_node():
+    surf = montepy.surfaces.CylinderParAxis()
+    surf.number = 1
+    half_space = UnitHalfSpace(surf, True, False)
+    half_space._ensure_has_nodes()
+    node = half_space.node
+    assert isinstance(node, syntax_node.ValueNode)
+    assert node.value == 1
+    assert node.format() == "1"
+    # test with negative side
+    half_space = UnitHalfSpace(surf, False, False)
+    half_space._ensure_has_nodes()
+    node = half_space.node
+    assert node.format() == "-1"
+    # test with int and not an object
+    half_space = UnitHalfSpace(1, True, False)
+    half_space._ensure_has_nodes()
+    node = half_space.node
+    assert isinstance(node, syntax_node.ValueNode)
+    assert node.value == 1
 
-    def test_update_operators_in_node(self):
-        surf = montepy.surfaces.CylinderParAxis()
-        surf.number = 1
-        half_space = -surf | +surf
-        half_space._ensure_has_nodes()
-        half_space.operator = Operator.INTERSECTION
-        half_space._update_values()
-        self.assertEqual(half_space.node.format(), "-1   1")
-        del half_space.right
-        half_space.operator = Operator.COMPLEMENT
-        cell = montepy.Cell()
-        cell.number = 1
-        half_space.left = UnitHalfSpace(cell, True, True)
-        half_space._update_values()
-        self.assertEqual(half_space.node.format(), "  #1")
-        # test with blank tree
-        half_space = -surf & +surf
-        half_space._update_values()
-        self.assertEqual(half_space.node.format(), "-1 1")
-        # test move to union
-        # test centering
-        half_space.node.nodes["operator"].append("  ")
-        half_space.operator = Operator.UNION
-        half_space._update_values()
-        self.assertEqual(half_space.node.format(), "-1 : 1")
+
+def test_tree_create_default_node():
+    surf = montepy.surfaces.CylinderParAxis()
+    surf.number = 1
+    half_space = -surf | +surf
+    half_space._ensure_has_nodes()
+    node = half_space.node
+    assert isinstance(node, syntax_node.GeometryTree)
+    assert node.operator == Operator.UNION
+    assert node.format() == "-1 : 1"
+    # Test intersection
+    half_space = -surf & +surf
+    half_space._ensure_has_nodes()
+    node = half_space.node
+    assert node.operator == Operator.INTERSECTION
+    # Test complement
+    half_space = ~(-surf | +surf)
+    half_space._ensure_has_nodes()
+    node = half_space.node
+    assert node.operator == Operator.COMPLEMENT
+    assert node.format() == " #(-1 : 1)"
+    # test cell complement
+    cell = montepy.Cell()
+    cell.number = 1
+    half_space = ~cell
+    half_space._ensure_has_nodes()
+    node = half_space.node
+    assert node.operator == Operator.COMPLEMENT
+    assert node.format() == " #1"
+
+
+def test_update_operators_in_node():
+    surf = montepy.surfaces.CylinderParAxis()
+    surf.number = 1
+    half_space = -surf | +surf
+    half_space._ensure_has_nodes()
+    half_space.operator = Operator.INTERSECTION
+    half_space._update_values()
+    assert half_space.node.format() == "-1   1"
+    del half_space.right
+    half_space.operator = Operator.COMPLEMENT
+    cell = montepy.Cell()
+    cell.number = 1
+    half_space.left = UnitHalfSpace(cell, True, True)
+    half_space._update_values()
+    assert half_space.node.format() == "  #1"
+    # test with blank tree
+    half_space = -surf & +surf
+    half_space._update_values()
+    assert half_space.node.format() == "-1 1"
+    # test move to union
+    # test centering
+    half_space.node.nodes["operator"].append("  ")
+    half_space.operator = Operator.UNION
+    half_space._update_values()
+    assert half_space.node.format() == "-1 : 1"

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -159,6 +159,22 @@ def test_cell_half_space():
         half_space = -cell
 
 
+def test_parens_node_export():
+    surf1 = montepy.surfaces.cylinder_on_axis.CylinderOnAxis()
+    surf2 = montepy.surfaces.cylinder_on_axis.CylinderOnAxis()
+    surf3 = montepy.surfaces.cylinder_on_axis.CylinderOnAxis()
+    surf1.number = 1
+    surf2.number = 2
+    surf3.number = 3
+    for half_space, form_answer, str_answer in [
+        (-surf1 & (+surf2 | -surf3), "-1 (2 : -3)", "(-1*(+2:-3))"),
+        ((-surf1 | +surf2) & -surf3, "(-1 : 2) -3", "((-1:+2)*-3)"),
+    ]:
+        half_space._update_values()
+        assert half_space.node.format() == form_answer
+        assert str(half_space) == str_answer
+
+
 def test_intersect_half_space():
     cell1 = ~montepy.Cell()
     cell2 = ~montepy.Cell()


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

This fixes a bug where parentheses disappear from the geometry definition of a cell. This was because `surfaces.HalfSpace` essentially had no way to store that information, and when it was time to export the geometry would override the old parentheses. 

This was solved in a few ways.

1. Introduce `Operation.GROUP` to replace `Operation._SHIFT` in this context. This was because this will be more visible to users and `GROUP` is clearer. Also `_SHIFT` is used for certain leaf nodes in complex geometry, and lead to confusion.
2. Adding an unbalanced tree level to `HalfSpace` to represent `GROUP`
3. Updating `HalfSapce` to ensure that `GROUP` is properly handled on export.
4. Made a method to detect when a group needs to be added for scratch geometries. This is done whenever a union node is below an intersection node. This is the proper order of operations (see #490). 

To sanity check this logic:

```
    *
   / \
  +   3
 /\
1  2
```
Should be `(1 : 2) 3` not `1 : 2 3`

Fixes #490

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Implement unit testing. 
- [x] Clear out all `TODO`
- [x] Look into disappearing comments with @tjlaboss 
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
