### PR TITLE
Optimize Material Update Pointers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,6 +160,7 @@ jobs:
       - run: python benchmark/benchmark_big_model.py  
         name: Benchmark against big model
 
+        
   changelog-test:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'

--- a/benchmark/benchmark_big_model.py
+++ b/benchmark/benchmark_big_model.py
@@ -3,7 +3,7 @@ import montepy
 import time
 import tracemalloc
 
-FAIL_THRESHOLD = 500
+FAIL_THRESHOLD = 30
 
 tracemalloc.start()
 start = time.time()

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,6 +1,13 @@
 MontePy Changelog
 =================
 
+#Next Version#
+--------------
+
+**Performance Improvement**
+
+* Fixed method of linking ``Material`` to ``ThermalScattering`` objects, avoiding a very expensive O(N:sup:`2`) (:issue:`510`).
+
 0.4.0
 --------------
 

--- a/montepy/data_inputs/data_input.py
+++ b/montepy/data_inputs/data_input.py
@@ -179,6 +179,8 @@ class DataInputAbstract(MCNP_Object):
 
         :param data_inputs: a list of the data inputs in the problem
         :type data_inputs: list
+        :returns: True iff this input should be removed from ``problem.data_inputs``
+        :rtype: bool, None
         """
         pass
 

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -177,18 +177,7 @@ class Material(data_input.DataInputAbstract, Numbered_MCNP_Object):
         :param data_inputs: a list of the data inputs in the problem
         :type data_inputs: list
         """
-        for input in list(data_inputs):
-            if isinstance(input, thermal_scattering.ThermalScatteringLaw):
-                if input.old_number == self.number:
-                    if not self._thermal_scattering:
-                        self._thermal_scattering = input
-                        input._parent_material = self
-                        data_inputs.remove(input)
-                    else:
-                        raise MalformedInputError(
-                            self,
-                            f"Multiple MT inputs were specified for this material: {self.number}.",
-                        )
+        pass
 
     @staticmethod
     def _class_prefix():

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -332,9 +332,11 @@ class MCNP_Problem:
                 ParticleTypeNotInCell,
             ) as e:
                 handle_error(e)
-        for input in self._data_inputs:
+        to_delete = []
+        for data_index, data_input in enumerate(self._data_inputs):
             try:
-                input.update_pointers(self._data_inputs)
+                if data_input.update_pointers(self._data_inputs):
+                    to_delete.append(data_index)
             except (
                 BrokenObjectLinkError,
                 MalformedInputError,
@@ -343,6 +345,8 @@ class MCNP_Problem:
             ) as e:
                 handle_error(e)
                 continue
+        for delete_index in to_delete[::-1]:
+            del self._data_inputs[delete_index]
 
     def remove_duplicate_surfaces(self, tolerance):
         """Finds duplicate surfaces in the problem, and remove them.

--- a/prof/dump_results.py
+++ b/prof/dump_results.py
@@ -2,5 +2,5 @@ import pstats
 from pstats import SortKey
 
 stats = pstats.Stats("prof/combined.prof")
-stats.sort_stats(SortKey.CUMULATIVE, SortKey.TIME).print_stats(300, "montepy")
-stats.sort_stats(SortKey.CUMULATIVE, SortKey.TIME).print_stats(100, "sly")
+stats.sort_stats(SortKey.CUMULATIVE, SortKey.TIME).print_stats("montepy", 50)
+stats.sort_stats(SortKey.CUMULATIVE, SortKey.TIME).print_stats("sly", 20)

--- a/prof/profile_big_model.py
+++ b/prof/profile_big_model.py
@@ -10,6 +10,6 @@ stats = cProfile.run(
 
 stats = pstats.Stats("prof/big.prof")
 stats.sort_stats(pstats.SortKey.CUMULATIVE, pstats.SortKey.TIME).print_stats(
-    100, "montepy"
+    "montepy", 70
 )
-stats.sort_stats(pstats.SortKey.CUMULATIVE, pstats.SortKey.TIME).print_stats(100, "sly")
+stats.sort_stats(pstats.SortKey.CUMULATIVE, pstats.SortKey.TIME).print_stats("sly", 20)

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -340,7 +340,8 @@ class TestThermalScattering(TestCase):
         in_str = "M20 1001.80c 0.5 8016.80c 0.5"
         input_card = Input([in_str], BlockType.DATA)
         material = Material(input_card)
-        material.update_pointers([card])
+        material.thermal_scattering = card
+        card._parent_material = material
         material.thermal_scattering.thermal_scattering_laws = ["grph.20t"]
         self.assertEqual(card.format_for_mcnp_input((6, 2, 0)), ["Mt20 grph.20t "])
 


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

This is a fix of a really inefficient implementation of how `Material` and `ThermalScattering` are linked together during problem setup. The issue is that in `MCNP_Problem`:

``` python
for data_input in self.data_inputs:
    data_input.update_pointers(self.data_inputs)
```

This in itself isn't an issue; this is just an O(N) operator, and it's necessary.

But inside of both `Material` and `ThermalScattering` there was:

``` python
def update_pointers(self, data_innputs):
    for data_input in data_inputs:
        ...
```
So this effectively became:

``` python
for data_input_1 in data_inputs:
    for data_input_2 in data_inputs:
        ...
```

This is an O(N<sup>2</sup>) operation. Yikes!

To fix this, I changed:

1. Removed all code from `Material.update_values`
2. Move all linking to `ThermalScattering.update_value`
3. Use `problem.materials` hashing as much as possible to perform the linking operation. 

This changes the benchmark run time from 424 seconds to 26 second, a speed up of 398 seconds, or 93%.  

The old profiling of the benchmark test:

```

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000  272.390  272.390 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/input_parser/input_reader.py:6(read_input)
        1    0.026    0.026  272.390  272.390 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/mcnp_problem.py:236(parse_input)
        1    0.002    0.002  253.773  253.773 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/mcnp_problem.py:304(__update_internal_pointers)
     1001    0.363    0.000  252.721    0.252 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/data_inputs/material.py:173(update_pointers)
   501501    0.203    0.000  250.632    0.000 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/data_inputs/material.py:259(__eq__)
   501501   51.196    0.000  250.090    0.000 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/data_inputs/material.py:243(__hash__)
 46138092   61.034    0.000   87.767    0.000 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/data_inputs/isotope.py:213(__str__)
 50688652   25.463    0.000   47.373    0.000 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/utilities.py:76(getter)
 45636591   28.897    0.000   35.159    0.000 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/data_inputs/isotope.py:221(__lt__)
 46138092   11.372    0.000   15.170    0.000 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/data_inputs/element.py:19(symbol)
 46230184    8.718    0.000   13.946    0.000 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/data_inputs/isotope.py:218(__hash__)
     2004    0.013    0.000   13.050    0.007 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/data_inputs/data_parser.py:29(parse_data)
     1001    0.194    0.000   12.057    0.012 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/data_inputs/material.py:33(__init__)
    22041    0.047    0.000   11.893    0.001 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/mcnp_object.py:37(__init__)
     7015    0.017    0.000   11.790    0.002 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/input_parser/parser_base.py:133(parse)
```

With the vast majority of the costliest operations all being in `montepy.data_inputs.Material`, with `update_pointers` taking > 250 seconds. 

After this change the new profiling is:

``` 
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   21.367   21.367 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/input_parser/input_reader.py:6(read_input)
        1    0.026    0.026   21.366   21.366 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/mcnp_problem.py:236(parse_input)
     2004    0.012    0.000   13.293    0.007 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/data_inputs/data_parser.py:29(parse_data)
    22041    0.047    0.000   12.626    0.001 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/mcnp_object.py:37(__init__)
     7015    0.017    0.000   12.523    0.002 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/input_parser/parser_base.py:133(parse)
     1001    0.197    0.000   12.062    0.012 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/data_inputs/material.py:33(__init__)
    19033    0.021    0.000   11.837    0.001 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/data_inputs/data_input.py:55(__init__)
   408452    0.151    0.000    3.058    0.000 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/input_parser/mcnp_input.py:200(tokenize)
  4051061    1.811    0.000    3.025    0.000 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/utilities.py:76(getter)
     6009    0.176    0.000    2.980    0.000 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/numbered_object_collection.py:192(append)
  1514516    0.555    0.000    2.770    0.000 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/numbered_object_collection.py:75(numbers)
        1    0.002    0.002    2.539    2.539 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/mcnp_problem.py:304(__update_internal_pointers)
   194205    0.257    0.000    1.876    0.000 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/input_parser/parser_base.py:304(padding)
     1001    0.305    0.000    1.442    0.001 /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/montepy/data_inputs/thermal_scattering.py:119(update_pointers)
```

Now this operation takes 1.5 seconds. 


Fixes #510 

# Checklist

- [x] I have performed a self-review of my own code
