### PR TITLE
Fixed bug double adding materials.

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -4,6 +4,10 @@ MontePy Changelog
 #Next Version#
 --------------
 
+**Bug Fixes**
+
+* Fixed a bug where ``problem.materials.append_renumber`` would double add a material to ``problem.data_inputs`` (:issue:`516`).
+
 **Performance Improvement**
 
 * Fixed method of linking ``Material`` to ``ThermalScattering`` objects, avoiding a very expensive O(N:sup:`2`) (:issue:`510`).

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -439,6 +439,7 @@ class NumberedDataObjectCollection(NumberedObjectCollection):
         :type insert_in_data: bool
         :raises NumberConflictError: if this object has a number that is already in use.
         """
+        super().append(obj)
         if self._problem:
             if self._last_index:
                 index = self._last_index
@@ -452,7 +453,6 @@ class NumberedDataObjectCollection(NumberedObjectCollection):
             if insert_in_data:
                 self._problem.data_inputs.insert(index + 1, obj)
             self._last_index = index + 1
-        super().append(obj)
 
     def __delitem__(self, idx):
         if not isinstance(idx, int):

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -317,11 +317,13 @@ def test_data_append(cp_simple_problem):
     prob.materials.append(new_mat)
     assert new_mat in prob.materials
     assert new_mat in prob.data_inputs
+    assert prob.data_inputs.count(new_mat) == 1
     # trigger getting data_inputs end
     prob.materials.clear()
     prob.materials.append(new_mat)
     assert new_mat in prob.materials
     assert new_mat in prob.data_inputs
+    assert prob.data_inputs.count(new_mat) == 1
     prob.data_inputs.clear()
     prob.materials._last_index = None
     new_mat = copy.deepcopy(next(iter(prob.materials)))
@@ -329,6 +331,7 @@ def test_data_append(cp_simple_problem):
     prob.materials.append(new_mat)
     assert new_mat in prob.materials
     assert new_mat in prob.data_inputs
+    assert prob.data_inputs.count(new_mat) == 1
     # trigger getting index of last material
     prob.materials._last_index = None
     new_mat = copy.deepcopy(next(iter(prob.materials)))

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -339,6 +339,16 @@ def test_data_append(cp_simple_problem):
     prob.materials.append(new_mat)
     assert new_mat in prob.materials
     assert new_mat in prob.data_inputs
+    assert prob.data_inputs.count(new_mat) == 1
+
+
+def test_data_append_renumber(cp_simple_problem):
+    prob = cp_simple_problem
+    new_mat = copy.deepcopy(next(iter(prob.materials)))
+    prob.materials.append_renumber(new_mat)
+    assert new_mat in prob.materials
+    assert new_mat in prob.data_inputs
+    assert prob.data_inputs.count(new_mat) == 1
 
 
 def test_data_remove(cp_simple_problem):


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

This fixes a bug where `append_renumber` can double add a material to `data_inputs`.

`append_renumber` does:

1. tries to append
2. if failure occurs
3. change the number
4. append again.

`NumberedDataObjectCollection` append was doing:

1. `data_inputs.insert`
2. `super().append`

This fail and retry method led to `data_inputs.insert` being called twice. So making sure `super().append` occurs first fixes this. 

Fixes #516

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
