### PR TITLE
Include the latest MontePy release on montepy.org

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,8 +24,9 @@ project = "MontePy"
 copyright = "2021 – 2024, Battelle Energy Alliance LLC."
 author = "Micah D. Gale (@micahgale), Travis J. Labossiere-Hickman (@tjlaboss)"
 
-
-release = importlib.metadata.version("montepy")
+# FIXME: This displays the latest build, not the latest release.
+version = importlib.metadata.version("montepy")
+release = version
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -51,6 +52,9 @@ html_extra_path = ["robots.txt"]
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
+
+# Display the version
+display_version = True
 
 # -- External link configuration ---------------------------------------------
 UM63 = (


### PR DESCRIPTION
# Description

 * Rename "release" -> "version"
 * Display version under the logo on the website

Fixes #544

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)

# Discussion

As of 08ded2fcf4ec77bcb3c3d06bea7c40e1596b0995, this displays the latest build. Is that better / more correct?

If not: how should we make it display the most recent release?