### PR TITLE
Add pyproject link to changelog 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ develop = [
 
 
 [project.urls]
-Homepage = "https://www.montepy.org/"
+Homepage = "https://idaholab.github.io/MontePy/index.html"
 Repository = "https://github.com/idaholab/MontePy.git"
 Documentation = "https://www.montepy.org/"
 "Bug Tracker" = "https://github.com/idaholab/MontePy/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,8 @@ develop = [
 
 [project.urls]
 Homepage = "https://www.montepy.org/"
-Repository = "https://github.com/idaholab/montepy.git"
-Documentation = "https://idaholab.github.io/MontePy/index.html"
+Repository = "https://github.com/idaholab/MontePy.git"
+Documentation = "https://www.montepy.org/"
 "Bug Tracker" = "https://github.com/idaholab/MontePy/issues"
 Changelog = "https://www.montepy.org/changelog.html"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ Homepage = "https://www.montepy.org/"
 Repository = "https://github.com/idaholab/montepy.git"
 Documentation = "https://idaholab.github.io/MontePy/index.html"
 "Bug Tracker" = "https://github.com/idaholab/MontePy/issues"
+Changelog = "https://www.montepy.org/changelog.html"
 
 [project.scripts]
 "change_to_ascii" = "montepy._scripts.change_to_ascii:main"


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

Recently I noticed that some of our links on PyPi are verified, and some are not. This lead to this rabbit hole: https://docs.pypi.org/project_metadata/#verified-details.

Changes:

1. Added a changelog link because that's supported.
2. Corrected capitalization for repo. This was likely blocking the verification.
3. Updated docs page to montepy.org. Note: this will lead to it not being verified.  So not sure if this one should stick. 

# Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
