### PR TITLE
Added hierarchy to MontePy changelog.

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,5 +1,9 @@
+*****************
 MontePy Changelog
-=================
+*****************
+
+0.5 releases
+============
 
 #Next Version#
 --------------
@@ -18,6 +22,9 @@ MontePy Changelog
 * Fixed a bug raised in an edge case when editing cell geometry, by making the error clearer (:issue:`558`).
 * Fixed bug with having a shortcut in a cell fill (:issue:`552`).
 * Fixed bug where file streams couldn't actually be read (:pull:`553`).
+
+0.4 releases
+============
 
 0.4.1
 --------------
@@ -56,6 +63,9 @@ MontePy Changelog
 * Fixed bug where cell modifiers could be made irrelevant by being added after a comment (:issue:`483`).
 * Fixed bug where parentheses in cell geometry are not properly exported (:pull:`491`).
 
+
+0.3 releases
+=============
 
 0.3.3
 --------------
@@ -99,6 +109,9 @@ MontePy Changelog
 
 * Fixed bug with ``SDEF`` input, and made parser more robust (:issue:`396`).
 
+
+0.2 releases
+============
 
 0.2.10
 ----------------------
@@ -213,6 +226,9 @@ MontePy Changelog
 * Much of the internal functions with how objects are written to file were changed and/or deprecated.
 * `montepy.data_cards.data_card.DataCard.class_prefix` was moved to `_class_prefix` as the user usually shouldn't see this. Same goes for `has_classifier` and `has_number`.
 * Most of the data types inside `montepy.input_parser.mcnp_input` were deprecated or changed
+
+0.1 releases
+============
 
 0.1.7
 -----------------


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

Quick change to how the changelog is organized to avoid having dozens of top level entries. Added organization at the minor release level. This looks like:

![image](https://github.com/user-attachments/assets/09b27803-2dc7-458e-a60b-3bcca329a0b8)

This will be helpful one day if we need to split the changelog into multiple files. 
# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
