### PR TITLE
Fixed test_version to ensure it always has _version.py

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,9 +1,16 @@
 import importlib
 import os
+import subprocess
 import sys
+from pathlib import Path
 
 
 def test_version():
+    version_file = Path("montepy") / "_version.py"
+    if not version_file.exists():
+        subprocess.run(
+            ["python", "-m", "setuptools_scm", "--force-write-version-files"]
+        )
     assert os.path.exists(os.path.join("montepy", "_version.py"))
     # Test without version.py
     try:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,38 +1,36 @@
 import importlib
 import os
 import sys
-from unittest import TestCase
 
 
-class TestVersion(TestCase):
-    def test_version(self):
-        self.assertTrue(os.path.exists(os.path.join("montepy", "_version.py")))
-        # Test without version.py
-        try:
-            # try without setuptools_scm
-            old_file = os.path.join("montepy", "_version.py")
-            new_file = os.path.join("montepy", "_version.bak")
-            os.rename(old_file, new_file)
-            # clear out previous imports
-            to_delete = set()
-            for mod in sys.modules:
-                for bad_mod in ["setuptools_scm", "montepy"]:
-                    if bad_mod in mod:
-                        to_delete.add(mod)
-            for mod in to_delete:
-                del sys.modules[mod]
-            sys.modules["setuptools_scm"] = None
-            import montepy
+def test_version():
+    assert os.path.exists(os.path.join("montepy", "_version.py"))
+    # Test without version.py
+    try:
+        # try without setuptools_scm
+        old_file = os.path.join("montepy", "_version.py")
+        new_file = os.path.join("montepy", "_version.bak")
+        os.rename(old_file, new_file)
+        # clear out previous imports
+        to_delete = set()
+        for mod in sys.modules:
+            for bad_mod in ["setuptools_scm", "montepy"]:
+                if bad_mod in mod:
+                    to_delete.add(mod)
+        for mod in to_delete:
+            del sys.modules[mod]
+        sys.modules["setuptools_scm"] = None
+        import montepy
 
-            self.assertEqual(montepy.__version__, "Undefined")
-            # try with setuptools_scm
-            del sys.modules["setuptools_scm"]
-            importlib.reload(montepy)
-            print(f"From setuptools_scm: {montepy.__version__}")
-            self.assertTrue(len(montepy.__version__.split(".")) >= 3)
-        finally:
-            os.rename(new_file, old_file)
-        # do base with _version
+        assert montepy.__version__ == "Undefined"
+        # try with setuptools_scm
+        del sys.modules["setuptools_scm"]
         importlib.reload(montepy)
-        print(f"From _version.py: {montepy.__version__}")
-        self.assertTrue(len(montepy.__version__.split(".")) >= 3)
+        print(f"From setuptools_scm: {montepy.__version__}")
+        assert len(montepy.__version__.split(".")) >= 3
+    finally:
+        os.rename(new_file, old_file)
+    # do base with _version
+    importlib.reload(montepy)
+    print(f"From _version.py: {montepy.__version__}")
+    assert len(montepy.__version__.split(".")) >= 3


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

This fixes test_version to make no assumptions about the users setup. It does this by running `setuptools_scm` first if the `_version.py` file is not present.

Fixes #572

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
