### PR TITLE
make version info more reliable for git archive

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,7 @@ jobs:
         id: get_new_version
         run: echo "new_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
       - name: Check match
-        if (steps.get_version.output.old_version != steps.get_new_version.output.new_version)
+        if: (steps.get_version.output.old_version != steps.get_new_version.output.new_version)
         run: | 
           echo "Versions didn't match"
           exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
           file: coverage.xml
           github-token: ${{ secrets.github_token }}
   
-  test-archive:
+  archive-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -121,9 +121,7 @@ jobs:
       - name: open tar ball
         run: tar xzf montepy.tar.gz
       - run: |
-          ls
-          ls * 
-          tree
+          ls -la
       - name: Get version from archive 
         id: get_new_version
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           fetch-tags: true
       - name: set up python 
         uses: actions/setup-python@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,14 +100,26 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-tags: true
+      - name: set up python 
+        uses: actions/setup-python@v5
+        with: 
+          python-version: 3.12
+      - name: Get Base Version
+        id: get_version
+        run: echo "old_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
       - name: Git-archive-all
         uses: qmonnet/git-archive-all-action@v1
         with:
           output-files: montepy.tar.gz
       - name: delete git tree
-        run: rm -rf .git
+        run: rm -rf .git montepy
       - name: open tar ball
         run: tar xzf montepy.tar.gz
+      - name: Get version from archive 
+        id: get_new_version
+        run: echo "old_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
+      - name: Check match
+        run: echo foo 
 
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
           python -m setuptools_scm
           echo "old_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
       - name: Git archive
-        run: git archive ${GITHUB_HEAD_REF} -o montepy.tar.gz
+        run: git archive ${GITHUB_SHA} -o montepy.tar.gz
       - name: delete git tree
         run: rm -rf .git montepy
       - name: open tar ball

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,8 @@ jobs:
         uses: actions/setup-python@v5
         with: 
           python-version: 3.12
+      - name: install depencies
+        run: pip install setuptools-scm
       - name: Get Base Version
         id: get_version
         run: echo "old_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
           python -m setuptools_scm
           echo "old_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
       - name: Git archive
-        run: git archive ${{ GITHUB_HEAD_REF }} -o montepy.tar.gz
+        run: git archive ${GITHUB_HEAD_REF} -o montepy.tar.gz
       - name: delete git tree
         run: rm -rf .git montepy
       - name: open tar ball

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,10 @@ jobs:
         run: rm -rf .git montepy
       - name: open tar ball
         run: tar xzf montepy.tar.gz
+      - run: |
+          ls
+          ls * 
+          tree
       - name: Get version from archive 
         id: get_new_version
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,6 +93,22 @@ jobs:
         with:
           file: coverage.xml
           github-token: ${{ secrets.github_token }}
+  
+  test-archive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+      - name: Git-archive-all
+        uses: qmonnet/git-archive-all-action@v1
+        with:
+          output-files: montepy.tar.gz
+      - name: delete git tree
+        run: rm -rf .git
+      - name: open tar ball
+        run: tar xzf montepy.tar.gz
+
 
 
   doc-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,10 +112,8 @@ jobs:
         run: |
           python -m setuptools_scm
           echo "old_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
-      - name: Git-archive-all
-        uses: qmonnet/git-archive-all-action@v1
-        with:
-          output-files: montepy.tar.gz
+      - name: Git archive
+        run: git archive ${{ GITHUB_HEAD_REF }} -o montepy.tar.gz
       - name: delete git tree
         run: rm -rf .git montepy
       - name: open tar ball

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,9 +117,12 @@ jobs:
         run: tar xzf montepy.tar.gz
       - name: Get version from archive 
         id: get_new_version
-        run: echo "old_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
+        run: echo "new_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
       - name: Check match
-        run: echo foo 
+        if (steps.get_version.output.old_version != steps.get_new_version.output.new_version)
+        run: | 
+          echo "Versions didn't match"
+          exit 1
 
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,42 +94,6 @@ jobs:
           file: coverage.xml
           github-token: ${{ secrets.github_token }}
   
-  archive-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-      - name: set up python 
-        uses: actions/setup-python@v5
-        with: 
-          python-version: 3.12
-      - name: install depencies
-        run: pip install setuptools-scm
-      - name: Get Base Version
-        id: get_version
-        run: |
-          python -m setuptools_scm
-          echo "old_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
-      - name: Git archive
-        run: git archive ${GITHUB_SHA} -o montepy.tar.gz
-      - name: delete git tree
-        run: rm -rf .git montepy
-      - name: open tar ball
-        run: tar xzf montepy.tar.gz
-      - run: |
-          cat .git_archival.txt
-      - name: Get version from archive 
-        id: get_new_version
-        run: |
-          python -m setuptools_scm
-          echo "new_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
-      - name: Check match
-        if: (steps.get_version.output.old_version != steps.get_new_version.output.new_version)
-        run: | 
-          echo "Versions didn't match"
-          exit 1
 
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,9 @@ jobs:
         run: pip install setuptools-scm
       - name: Get Base Version
         id: get_version
-        run: echo "old_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
+        run: |
+          python -m setuptools_scm
+          echo "old_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
       - name: Git-archive-all
         uses: qmonnet/git-archive-all-action@v1
         with:
@@ -120,7 +122,9 @@ jobs:
         run: tar xzf montepy.tar.gz
       - name: Get version from archive 
         id: get_new_version
-        run: echo "new_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
+        run:|
+          python -m setuptools_scm
+        echo "new_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
       - name: Check match
         if: (steps.get_version.output.old_version != steps.get_new_version.output.new_version)
         run: | 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
       - name: open tar ball
         run: tar xzf montepy.tar.gz
       - run: |
-          ls -la
+          cat .git_archival.txt
       - name: Get version from archive 
         id: get_new_version
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,9 +122,9 @@ jobs:
         run: tar xzf montepy.tar.gz
       - name: Get version from archive 
         id: get_new_version
-        run:|
+        run: |
           python -m setuptools_scm
-        echo "new_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
+          echo "new_version=`python -m setuptools_scm`" >> $GITHUB_OUTPUT
       - name: Check match
         if: (steps.get_version.output.old_version != steps.get_new_version.output.new_version)
         run: | 


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

Make it so that `git archive` includes the information necessary for `setuptools_scm` to get a version number. This is based on [this guide](https://setuptools-scm.readthedocs.io/en/stable/usage/#git-archives). Also added a test to make sure this works. 
Fixes #576

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
