### PR TITLE
Adding more input context to all error messages. 

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,13 @@ MontePy Changelog
 0.5 releases
 ============
 
+#Next Version#
+--------------
+
+**Error Handling**
+
+* Added the input file, line number, and the input text to almost all errors raised by ``MCNP_Object`` (:pull:`581`).
+
 0.5.1
 --------------
 

--- a/montepy/errors.py
+++ b/montepy/errors.py
@@ -189,3 +189,28 @@ class LineExpansionWarning(Warning):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
+
+
+def add_line_number_to_exception(error, broken_robot):
+    """ """
+    try:
+        input_obj = broken_robot._input
+        assert input_obj is not None
+    except (AttributeError, AssertionError) as e:
+        lineno = "unknown"
+        file = "unknown"
+        lines = []
+    else:
+        lineno = input_obj.line_number
+        file = str(input_obj.input_file)
+        lines = input_obj.input_lines
+    args = e.args
+    if len(args) > 0:
+        message = args[0]
+    else:
+        message = ""
+    message = f"{message}\nError came from line: {lineno} of {file}.\n"
+    f"{'\n'.join(lines)}"
+    args = (message,) + args[1:]
+    e.args = args
+    raise e

--- a/montepy/errors.py
+++ b/montepy/errors.py
@@ -193,6 +193,7 @@ class LineExpansionWarning(Warning):
 
 def add_line_number_to_exception(error, broken_robot):
     """ """
+    raise error
     try:
         input_obj = broken_robot._input
         assert input_obj is not None

--- a/montepy/errors.py
+++ b/montepy/errors.py
@@ -209,16 +209,19 @@ def add_line_number_to_exception(error, broken_robot):
     # avoid calling this n times recursively
     if hasattr(error, "montepy_handled"):
         raise error
+    error.montepy_handled = True
     try:
         input_obj = broken_robot._input
         assert input_obj is not None
-    except (AttributeError, AssertionError) as e:
-        extra_message = f"Error came from {broken_robot} from an unknown file."
-    else:
         lineno = input_obj.line_number
         file = str(input_obj.input_file)
         lines = input_obj.input_lines
         extra_message = f"Error came from line: {lineno} of {file}.\n"
+    except Exception as e:
+        try:
+            extra_message = f"Error came from {broken_robot} from an unknown file."
+        except Exception as e2:
+            extra_message = f"Error came from an object of type {type(broken_robot)} from an unknown file."
     args = error.args
     if len(args) > 0:
         message = args[0]

--- a/montepy/errors.py
+++ b/montepy/errors.py
@@ -204,7 +204,7 @@ def add_line_number_to_exception(error, broken_robot):
         lineno = input_obj.line_number
         file = str(input_obj.input_file)
         lines = input_obj.input_lines
-    args = e.args
+    args = error.args
     if len(args) > 0:
         message = args[0]
     else:
@@ -212,5 +212,5 @@ def add_line_number_to_exception(error, broken_robot):
     message = f"{message}\nError came from line: {lineno} of {file}.\n"
     f"{'\n'.join(lines)}"
     args = (message,) + args[1:]
-    e.args = args
-    raise e
+    error.args = args
+    raise error

--- a/montepy/errors.py
+++ b/montepy/errors.py
@@ -192,8 +192,17 @@ class LineExpansionWarning(Warning):
 
 
 def add_line_number_to_exception(error, broken_robot):
-    """ """
-    raise error
+    """
+    Adds additional context to an Exception raised by an :class:`~montepy.mcnp_object.MCNP_Object`.
+
+    This will add the line, file name, and the input lines to the error.
+
+    :param error: The error that was raised.
+    :type error: Exception
+    :param broken_robot: The parent object that had the error raised.
+    :type broken_robot: MCNP_Object
+    :raises Exception: ... that's the whole point.
+    """
     # avoid calling this n times recursively
     if hasattr(error, "montepy_handled"):
         raise error

--- a/montepy/errors.py
+++ b/montepy/errors.py
@@ -65,7 +65,7 @@ class ParsingError(MalformedInputError):
                     _print_input(
                         path,
                         start_line,
-                        error,
+                        error["message"],
                         line_no,
                         input,
                         token,
@@ -83,7 +83,7 @@ class ParsingError(MalformedInputError):
 def _print_input(
     path,
     start_line,
-    error,
+    error_msg,
     line_no=0,
     input=None,
     token=None,
@@ -105,7 +105,7 @@ def _print_input(
                 buffer.append(f"     {start_line + i:5g}| {line}")
         if base_message:
             buffer.append(base_message)
-        buffer.append(error.args[0])
+        buffer.append(error_msg)
     return "\n".join(buffer)
 
 
@@ -243,7 +243,7 @@ def add_line_number_to_exception(error, broken_robot):
         lineno = input_obj.line_number
         file = str(input_obj.input_file)
         lines = input_obj.input_lines
-        message = _print_input(file, lineno, error, input=input_obj)
+        message = _print_input(file, lineno, message, input=input_obj)
     except Exception as e:
         try:
             message = (

--- a/montepy/errors.py
+++ b/montepy/errors.py
@@ -223,17 +223,12 @@ def add_line_number_to_exception(error, broken_robot):
         except Exception as e2:
             extra_message = f"Error came from an object of type {type(broken_robot)} from an unknown file."
     args = error.args
+    trace = error.__traceback__
     if len(args) > 0:
         message = args[0]
     else:
         message = ""
     message = f"{message}\n{extra_message}"
-    tb = error.__traceback__
-    trace = tb
-    for _ in range(2):
-        trace = trace.tb_next
-
     args = (message,) + args[1:]
     error.args = args
-    error.montepy_handled = True
     raise error.with_traceback(trace)

--- a/montepy/errors.py
+++ b/montepy/errors.py
@@ -1,4 +1,7 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+
+import traceback
+
 class LineOverRunWarning(UserWarning):
     """
     Raised when non-comment inputs exceed the allowed line length in an input.
@@ -215,15 +218,19 @@ def add_line_number_to_exception(error, broken_robot):
         lineno = input_obj.line_number
         file = str(input_obj.input_file)
         lines = input_obj.input_lines
-        #extra_message = f"Error came from line: {lineno} of {file}.\n"
-        extra_message = ""
+        extra_message = f"Error came from line: {lineno} of {file}.\n"
     args = error.args
     if len(args) > 0:
         message = args[0]
     else:
         message = ""
     message = f"{message}\n{extra_message}"
+    tb = error.__traceback__
+    trace = tb
+    for _ in range(2):
+        trace = trace.tb_next
+
     args = (message,) + args[1:]
     error.args = args
     error.montepy_handled = True
-    raise error
+    raise error.with_traceback(trace)

--- a/montepy/errors.py
+++ b/montepy/errors.py
@@ -194,24 +194,27 @@ class LineExpansionWarning(Warning):
 def add_line_number_to_exception(error, broken_robot):
     """ """
     raise error
+    # avoid calling this n times recursively
+    if hasattr(error, "montepy_handled"):
+        raise error
     try:
         input_obj = broken_robot._input
         assert input_obj is not None
     except (AttributeError, AssertionError) as e:
-        lineno = "unknown"
-        file = "unknown"
-        lines = []
+        extra_message = f"Error came from {broken_robot} from an unknown file."
     else:
         lineno = input_obj.line_number
         file = str(input_obj.input_file)
         lines = input_obj.input_lines
+        #extra_message = f"Error came from line: {lineno} of {file}.\n"
+        extra_message = ""
     args = error.args
     if len(args) > 0:
         message = args[0]
     else:
         message = ""
-    message = f"{message}\nError came from line: {lineno} of {file}.\n"
-    f"{'\n'.join(lines)}"
+    message = f"{message}\n{extra_message}"
     args = (message,) + args[1:]
     error.args = args
+    error.montepy_handled = True
     raise error

--- a/montepy/input_parser/input_file.py
+++ b/montepy/input_parser/input_file.py
@@ -180,4 +180,4 @@ class MCNP_InputFile:
             return self._fh.write(to_write)
 
     def __str__(self):
-        return self.name
+        return str(self.name)

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -1,6 +1,7 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
 from abc import ABC, ABCMeta, abstractmethod
 import copy
+import functools
 import itertools as it
 from montepy.errors import *
 from montepy.constants import (
@@ -23,21 +24,32 @@ import weakref
 
 
 class _ExceptionContextAdder(ABCMeta):
+    """
+
+    """
 
     @staticmethod
     def _wrap_attr_call(func):
-        print(func)
+        """
 
-        def wrapped(self, *args, **kwargs):
+        """
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
             try:
-                print(args, kwargs)
-                func(self, *args, **kwargs)
+                return func(*args, **kwargs)
             except Exception as e:
-                add_line_number_to_exception(e, self)
+                if len(args) > 0 and isinstance(args[0], MCNP_Object):
+                    self = args[0]
+                    add_line_number_to_exception(e, self)
+                else:
+                    raise e
 
         return wrapped
 
     def __new__(meta, classname, bases, attributes):
+        """
+
+        """
         new_attrs = {}
         for key, value in attributes.items():
             if callable(value):

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -52,6 +52,8 @@ class _ExceptionContextAdder(ABCMeta):
         """
         new_attrs = {}
         for key, value in attributes.items():
+            if key.startswith("_"):
+                new_attrs[key] = value
             if callable(value):
                 new_attrs[key] = _ExceptionContextAdder._wrap_attr_call(value)
             elif isinstance(value, property):

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -25,13 +25,14 @@ import weakref
 
 class _ExceptionContextAdder(ABCMeta):
     """
+    A metaclass for wrapping all class properties and methods in :func:`~montepy.errors.add_line_number_to_exception`.
 
     """
 
     @staticmethod
     def _wrap_attr_call(func):
         """
-
+        Wraps the function, and returns the modified function.
         """
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
@@ -52,6 +53,8 @@ class _ExceptionContextAdder(ABCMeta):
 
     def __new__(meta, classname, bases, attributes):
         """
+        This will replace all properties and callable attributes with 
+        wrapped versions.
 
         """
         new_attrs = {}

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -34,6 +34,7 @@ class _ExceptionContextAdder(ABCMeta):
         """
         Wraps the function, and returns the modified function.
         """
+
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
             try:
@@ -53,7 +54,7 @@ class _ExceptionContextAdder(ABCMeta):
 
     def __new__(meta, classname, bases, attributes):
         """
-        This will replace all properties and callable attributes with 
+        This will replace all properties and callable attributes with
         wrapped versions.
 
         """

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -44,6 +44,10 @@ class _ExceptionContextAdder(ABCMeta):
                 else:
                     raise e
 
+        if isinstance(func, staticmethod):
+            return staticmethod(wrapped)
+        if isinstance(func, classmethod):
+            return classmethod(wrapped)
         return wrapped
 
     def __new__(meta, classname, bases, attributes):

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -394,7 +394,7 @@ class MCNP_Problem:
                             else:
                                 message = ""
                             message = f"{message}\nError came from line: {obj._input.line_number} of {obj._input.input_file}.\n"
-                            f"{'\n'.join(obj._input.input_lines)}"
+                            message += '\n'.join(obj._input.input_lines)
                             args = (message,) + args[1:]
                             raise type(e)(*args) from e
                         last_obj._delete_trailing_comment()

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -385,7 +385,14 @@ class MCNP_Problem:
                         if isinstance(obj, transform.Transform):
                             self._transforms.append(obj, False)
                     if trailing_comment is not None and last_obj is not None:
-                        obj._grab_beginning_comment(trailing_comment)
+                        try:
+                            obj._grab_beginning_comment(trailing_comment)
+                        except Exception as e:
+                            message = e.message
+                            message = f"Error came from line: {obj._input.lineno} of {obj._input.input_file}.\n"
+                            f"{'\n'.join(obj._input.lines)}\n{message}"
+                            e.mesage = message
+                            raise e from e
                         last_obj._delete_trailing_comment()
                     trailing_comment = obj.trailing_comment
                     last_obj = obj

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -396,7 +396,8 @@ class MCNP_Problem:
                             message = f"{message}\nError came from line: {obj._input.line_number} of {obj._input.input_file}.\n"
                             message += '\n'.join(obj._input.input_lines)
                             args = (message,) + args[1:]
-                            raise type(e)(*args) from e
+                            e.args = args
+                            raise e
                         last_obj._delete_trailing_comment()
                     trailing_comment = obj.trailing_comment
                     last_obj = obj

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -388,11 +388,15 @@ class MCNP_Problem:
                         try:
                             obj._grab_beginning_comment(trailing_comment)
                         except Exception as e:
-                            message = e.message
-                            message = f"Error came from line: {obj._input.lineno} of {obj._input.input_file}.\n"
-                            f"{'\n'.join(obj._input.lines)}\n{message}"
-                            e.mesage = message
-                            raise e from e
+                            args = e.args
+                            if len(args) > 0:
+                                message = args[0]
+                            else:
+                                message = ""
+                            message = f"{message}\nError came from line: {obj._input.line_number} of {obj._input.input_file}.\n"
+                            f"{'\n'.join(obj._input.input_lines)}"
+                            args = (message,) + args[1:]
+                            raise type(e)(*args) from e
                         last_obj._delete_trailing_comment()
                     trailing_comment = obj.trailing_comment
                     last_obj = obj

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -394,7 +394,7 @@ class MCNP_Problem:
                             else:
                                 message = ""
                             message = f"{message}\nError came from line: {obj._input.line_number} of {obj._input.input_file}.\n"
-                            message += '\n'.join(obj._input.input_lines)
+                            message += "\n".join(obj._input.input_lines)
                             args = (message,) + args[1:]
                             e.args = args
                             raise e

--- a/montepy/universe.py
+++ b/montepy/universe.py
@@ -17,11 +17,12 @@ class Universe(Numbered_MCNP_Object):
     """
 
     def __init__(self, number):
+        self._number = self._generate_default_node(int, -1)
         if not isinstance(number, int):
             raise TypeError("number must be int")
         if number < 0:
             raise ValueError(f"Universe number must be ≥ 0. {number} given.")
-        self._number = montepy.input_parser.syntax_node.ValueNode(number, int)
+        self._number = self._generate_default_node(int, number)
 
         class Parser:
             def parse(self, token_gen, input):


### PR DESCRIPTION
<!--
If you are a first-time contributor to MontePy,
refer the developing guidelines at:
https://idaholab.github.io/MontePy/developing.html
-->

# Description

This wraps almost errors from `MCNP_Object` with information of where in a file this error came from. This works by:

1. Creating `montepy.errors.add_line_number_to_exception`. This takes an error and a `MCNP_Object` instance. If possible it takes the `_input` information and appends that information to the error message (see below). 
2. Create a `metaclass` (`_ExceptionContextAdder`) for `MCNP_Object` this modifies all attributes. If it's `_private` or `__dunder__` it does nothing. Otherwise for `callable` and `property` it gets wrapped using `_wrap_attr_call`. This just wraps the function call in a `try except`
3. Modularized the pretty-printing function from `ParsingError` for use here to print the input, see below. 

Here is an example stack trace. 


``` python
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
File ~/dev/montepy/montepy/cell.py:528, in Cell.update_pointers(self, cells, materials, surfaces)
    527 try:
--> 528     self._material = materials[self.old_mat_number]
    529 except KeyError:

File ~/dev/montepy/montepy/numbered_object_collection.py:458, in NumberedObjectCollection.__getitem__(self, i)
    457 if ret is None:
--> 458     raise KeyError(f"Object with number {i} not found in {type(self)}")
    459 return ret

KeyError: "Object with number 1 not found in <class 'montepy.materials.Materials'>"

During handling of the above exception, another exception occurred:

BrokenObjectLinkError                     Traceback (most recent call last)
Cell In[2], line 1
----> 1 problem = montepy.read_input("tests/inputs/test.imcnp")

File ~/dev/montepy/montepy/input_parser/input_reader.py:31, in read_input(destination, mcnp_version, replace)
     29 problem = mcnp_problem.MCNP_Problem(destination)
     30 problem.mcnp_version = mcnp_version
---> 31 problem.parse_input(replace=replace)
     32 return problem

File ~/dev/montepy/montepy/mcnp_problem.py:397, in MCNP_Problem.parse_input(self, check_input, replace)
    395     else:
    396         raise e
--> 397 self.__update_internal_pointers(check_input)

File ~/dev/montepy/montepy/mcnp_problem.py:413, in MCNP_Problem.__update_internal_pointers(self, check_input)
    410         raise e
    412 self.__load_data_inputs_to_object(self._data_inputs)
--> 413 self._cells.update_pointers(
    414     self.cells,
    415     self.materials,
    416     self.surfaces,
    417     self._data_inputs,
    418     self,
    419     check_input,
    420 )
    421 for surface in self._surfaces:
    422     try:

File ~/dev/montepy/montepy/cells.py:172, in Cells.update_pointers(self, cells, materials, surfaces, data_inputs, problem, check_input)
    165         cell.update_pointers(cells, materials, surfaces)
    166     except (
    167         BrokenObjectLinkError,
    168         MalformedInputError,
    169         ParticleTypeNotInProblem,
    170         ParticleTypeNotInCell,
    171     ) as e:
--> 172         handle_error(e)
    173         continue
    174 self.__setup_blank_cell_modifiers(problem, check_input)

File ~/dev/montepy/montepy/cells.py:130, in Cells.update_pointers.<locals>.handle_error(e)
    128     warnings.warn(f"{type(e).__name__}: {e.message}", stacklevel=3)
    129 else:
--> 130     raise e

File ~/dev/montepy/montepy/cells.py:165, in Cells.update_pointers(self, cells, materials, surfaces, data_inputs, problem, check_input)
    163 for cell in self:
    164     try:
--> 165         cell.update_pointers(cells, materials, surfaces)
    166     except (
    167         BrokenObjectLinkError,
    168         MalformedInputError,
    169         ParticleTypeNotInProblem,
    170         ParticleTypeNotInCell,
    171     ) as e:
    172         handle_error(e)

File ~/dev/montepy/montepy/mcnp_object.py:45, in _ExceptionContextAdder._wrap_attr_call.<locals>.wrapped(*args, **kwargs)
     43 if len(args) > 0 and isinstance(args[0], MCNP_Object):
     44     self = args[0]
---> 45     add_line_number_to_exception(e, self)
     46 else:
     47     raise e

File ~/dev/montepy/montepy/errors.py:254, in add_line_number_to_exception(error, broken_robot)
    252 args = (message,) + args[1:]
    253 error.args = args
--> 254 raise error.with_traceback(trace)

File ~/dev/montepy/montepy/mcnp_object.py:41, in _ExceptionContextAdder._wrap_attr_call.<locals>.wrapped(*args, **kwargs)
     38 @functools.wraps(func)
     39 def wrapped(*args, **kwargs):
     40     try:
---> 41         return func(*args, **kwargs)
     42     except Exception as e:
     43         if len(args) > 0 and isinstance(args[0], MCNP_Object):

File ~/dev/montepy/montepy/cell.py:530, in Cell.update_pointers(self, cells, materials, surfaces)
    528         self._material = materials[self.old_mat_number]
    529     except KeyError:
--> 530         raise BrokenObjectLinkError(
    531             "Cell", self.number, "Material", self.old_mat_number
    532         )
    533 else:
    534     self._material = None

BrokenObjectLinkError:     tests/inputs/test.imcnp, line 1

         2| C cells
         3| c # hidden vertical Do not touch
         4| c
         5| 1 1 20
         6|          -1000  $ dollar comment
         7|         imp:n,p,e=1 U=350 trcl=5
Material 1 is missing from the input from the definition of: Cell 1
```

Some thoughts:

1. ~This shows the exception as a re-catch. Does that matter?~  This is due to the catch raise a new exception wrapping. 
2. This shows the wrapping and decorating functions in the stack trace; does that matter?

Fixes #579, fixes #362 

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
<!--
While tests will automatically be checked by CI, it is good practice to
ensure that they pass locally first. 
-->
