### PR TITLE
Added RTD action.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,6 +154,15 @@ jobs:
           cd demo
           for file in *.ipynb; do papermill $file foo.ipynb; done
         name: Test all demo notebooks 
+  
+  RTD-links:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "montepy"
 
   format-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

Yet another follow on to #600. It sounds like we may not get permission for RTD to add a status check to actions for a PR build due to Oauth apps for orgs being all or nothing permissions. This will edit the PR description and link the test build.

FYI: `d` is the hotkey doc diffs which will show what changed from stable for a PR. 



<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--624.org.readthedocs.build/en/624/

<!-- readthedocs-preview montepy end -->