### PR TITLE
Remove '"""' from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,4 +44,3 @@ Ensure that:
 - [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
 - [ ] The PR covers all relevant aspects according to the development guidelines.
 - [ ] 100% coverage of the patch is achieved, or justification for a variance is given.
-"""

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 Please provide a summary of the change, referencing the issue it fixes, if applicable. Include relevant context and motivation.
 
-**Fixes # (issue number)**
+Fixes # (issue number)
 
 ---
 


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

Remove trailing `"""` from _pull_request_template.md_.

**Fixes #621**

---

### General Checklist

- [x] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The PR covers all relevant aspects according to the development guidelines.



<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--625.org.readthedocs.build/en/625/

<!-- readthedocs-preview montepy end -->