### PR TITLE
Rtd action update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,19 +155,6 @@ jobs:
           cd demo
           for file in *.ipynb; do papermill $file foo.ipynb; done
         name: Test all demo notebooks 
-  
-  RTD-links:
-    on:
-      pull_request_target:
-        types:
-          -opened
-    permissions:
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: readthedocs/actions/preview@v1
-        with:
-          project-slug: "montepy"
 
   format-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: CI testing
 
 on: 
   pull_request:
+    branches: [develop, alpha-test-dev]
   push: 
      branches: [develop, main, alpha-test]
 
@@ -156,6 +157,10 @@ jobs:
         name: Test all demo notebooks 
   
   RTD-links:
+    on:
+      pull_request_target:
+        types:
+          -opened
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest

--- a/.github/workflows/rtd_link.yml
+++ b/.github/workflows/rtd_link.yml
@@ -1,7 +1,7 @@
 name: add RTD links
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, edited]
 jobs:
   add_rtd_link:
     permissions:

--- a/.github/workflows/rtd_link.yml
+++ b/.github/workflows/rtd_link.yml
@@ -1,17 +1,13 @@
 name: add RTD links
 on:
   pull_request_target:
-    types:
-      - opened
-    # Execute this action only on PRs that touch
-    # documentation files.
-    # paths:
-    #   - "docs/**"
-
-  permissions:
-    pull-requests: write
-  runs-on: ubuntu-latest
-  steps:
-    - uses: readthedocs/actions/preview@v1
-      with:
-        project-slug: "montepy"
+    types: [opened]
+jobs:
+  add_rtd_link:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "montepy"

--- a/.github/workflows/rtd_link.yml
+++ b/.github/workflows/rtd_link.yml
@@ -1,8 +1,7 @@
 name: add RTD links
 on:
   pull_request:
- # pull_request_target:
- #   types: [opened, edited]
+    types: [opened, reopened, edited]
 jobs:
   add_rtd_link:
     permissions:

--- a/.github/workflows/rtd_link.yml
+++ b/.github/workflows/rtd_link.yml
@@ -1,7 +1,8 @@
 name: add RTD links
 on:
-  pull_request_target:
-    types: [opened, edited]
+  pull_request:
+ # pull_request_target:
+ #   types: [opened, edited]
 jobs:
   add_rtd_link:
     permissions:

--- a/.github/workflows/rtd_link.yml
+++ b/.github/workflows/rtd_link.yml
@@ -1,0 +1,17 @@
+name: add RTD links
+on:
+  pull_request_target:
+    types:
+      - opened
+    # Execute this action only on PRs that touch
+    # documentation files.
+    # paths:
+    #   - "docs/**"
+
+  permissions:
+    pull-requests: write
+  runs-on: ubuntu-latest
+  steps:
+    - uses: readthedocs/actions/preview@v1
+      with:
+        project-slug: "montepy"


### PR DESCRIPTION
# Pull Request Checklist for MontePy

This restricts the RTD action to only there is a potential need for a link to be added to a PR description. This also limits the test workflow to dev PRs. This avoids double runs of the workflow on deploy PRs. 

Follow on to #624 


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--627.org.readthedocs.build/en/627/

<!-- readthedocs-preview montepy end -->