### PR TITLE
Quick doc updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Battelle Energy Alliance, LLC
+Copyright (c) 2024 - 2025 Battelle Energy Alliance, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3,7 +3,7 @@ Github URL:  https://github.com/idaholab/MontePy
 Licensed under MIT
 
 
-© 2024 Battelle Energy Alliance, LLC
+© 2024 - 2025 Battelle Energy Alliance, LLC
 ALL RIGHTS RESERVED
 
 Prepared by Battelle Energy Alliance, LLC

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -37,7 +37,7 @@ MontePy Changelog
 **Performance Improvement**
 
 * Fixed cyclic memory reference that lead to memory leak in ``copy.deepcopy`` (:issue:`514`).
-* Fixed O(N<sup>2</sup>) operation in how append works for object collections like Cells (:issue:`556`).
+* Fixed O(N\ :sup:`2`) operation in how append works for object collections like Cells (:issue:`556`).
 
 **Bug Fixes**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ Homepage = "https://www.montepy.org/"
 Repository = "https://github.com/idaholab/MontePy.git"
 Documentation = "https://www.montepy.org/"
 "Bug Tracker" = "https://github.com/idaholab/MontePy/issues"
-Changelog = "https://www.montepy.org/changelog.html"
+Changelog = "https://www.montepy.org/en/stable/changelog.html"
 
 [project.scripts]
 "change_to_ascii" = "montepy._scripts.change_to_ascii:main"


### PR DESCRIPTION
Just a few fast fixes. 

* Updates changelog link in meta data
* Fixes superscript in changelog.

Fixes #599

<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--628.org.readthedocs.build/en/628/

<!-- readthedocs-preview montepy end -->