### PR TITLE
Added autodocsumm to make TOCs in docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -37,8 +37,10 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.extlinks",
     "sphinx.ext.doctest",
+    "sphinx_autodoc_typehints",
     "sphinx_favicon",
-    "sphinx_copybutton"
+    "sphinx_copybutton",
+    "autodocsumm",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -60,6 +62,13 @@ exclude_patterns = []
 
 # Display the version
 display_version = True
+autosummary_generate = True
+autosummary_imported_member = True
+autodoc_default_options = {
+    "autosummary": True,
+    "show-inheritance": True,
+    "inherited-members": True,
+}
 
 # -- External link configuration ---------------------------------------------
 UM63 = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ doc = [
 	"sphinxcontrib-apidoc", 
 	"pydata_sphinx_theme",
 	"sphinx-favicon",
-	"sphinx-copybutton"
+	"sphinx-copybutton",
+	"autodocsumm"
 ]
 format = ["black>=23.3.0"]
 build = [


### PR DESCRIPTION
This is a quick improvement that makes it so that a class and modules have a TOC at the top the documentation to quickly find methods and attributes. 