### PR TITLE
Do not warn about comments that go over the line length

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@ Fixes # (issue number)
 
 - [ ] I have performed a self-review of my own code.
 - [ ] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).
+- [ ] I have formatted my code with `black` version 25.
 - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
 
 ---

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -23,6 +23,7 @@ MontePy Changelog
 * Added ability to parse all MCNP objects from a string (:issue:`88`).
 * Added function: :func:`~montepy.mcnp_problem.MCNP_Problem.parse` to parse arbitrary MCNP object (:issue:`88`).
 * An error is now raised when typos in object attributes are used, e.g., ``cell.nubmer`` (:issue:`508`).
+* Warnings are no longer raised for comments that exceed the maximum line lengths (:issue:`188`).
 
 **Bugs Fixed**
 

--- a/montepy/__init__.py
+++ b/montepy/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
-""" MontePy is a library for reading, editing, and writing MCNP input files.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
+"""MontePy is a library for reading, editing, and writing MCNP input files.
 
 This creates a semantic understanding of the MCNP input file.
 start by running montepy.read_input().

--- a/montepy/constants.py
+++ b/montepy/constants.py
@@ -1,4 +1,6 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
+import re
+
 from montepy.errors import UnsupportedFeature
 
 """
@@ -23,6 +25,11 @@ Absolute tolerance passed to math.isclose.
 BLANK_SPACE_CONTINUE = 5
 """
 Number of spaces in a new line before it's considered a continuation.
+"""
+
+COMMENT_FINDER = re.compile(rf"\s{{0,{BLANK_SPACE_CONTINUE - 1}}}c", re.IGNORECASE)
+"""
+A regular expression for finding the start of a ``c`` style comment.
 """
 
 LINE_LENGTH = {

--- a/montepy/input_parser/input_syntax_reader.py
+++ b/montepy/input_parser/input_syntax_reader.py
@@ -6,11 +6,9 @@ import re
 import os
 import warnings
 
-
-from .block_type import BlockType
-from .. import errors
 from montepy.constants import *
 from montepy.errors import *
+from montepy.input_parser.block_type import BlockType
 from montepy.input_parser.input_file import MCNP_InputFile
 from montepy.input_parser.mcnp_input import Input, Message, ReadInput, Title
 from montepy.input_parser.read_parser import ReadParser
@@ -178,7 +176,7 @@ def read_data(fh, mcnp_version, block_type=None, recursion=False):
             yield from flush_input()
         # die if it is a vertical syntax format
         if "#" in line[0:BLANK_SPACE_CONTINUE] and not line_is_comment:
-            raise errors.UnsupportedFeature("Vertical Input format is not allowed")
+            raise UnsupportedFeature("Vertical Input format is not allowed")
         # cut line down to allowed length
         old_line = line
         line = line[:line_length]
@@ -188,7 +186,7 @@ def read_data(fh, mcnp_version, block_type=None, recursion=False):
             ):
                 warnings.warn(
                     f"The line: {old_line} exceeded the allowed line length of: {line_length} for MCNP {mcnp_version}",
-                    errors.LineOverRunWarning,
+                    LineOverRunWarning,
                 )
             # if extra length is a comment keep it long
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ doc = [
     	"sphinx_autodoc_typehints",
 	"autodocsumm",
 ]
-format = ["black>=23.3.0"]
+format = ["black~=25.1"]
 build = [
 	"build",
 	"setuptools>=64.0.0",

--- a/tests/inputs/test.imcnp
+++ b/tests/inputs/test.imcnp
@@ -41,7 +41,7 @@ C Iron
 m2        26054.80c        5.85
 	  plib= 80p
           26056.80c       91.75
-          26057.80c        2.12
+          26057.80c        2.12 $ very very very very very very very very very very very very very very long line that exceeds line limit
           26058.80c        0.28 $ trailing comment shouldn't move #458.
 C water
 C foo

--- a/tests/inputs/test_universe.imcnp
+++ b/tests/inputs/test_universe.imcnp
@@ -24,6 +24,7 @@ c
 c foo end comment
 
 C surfaces
+c this comment is a ver very very very very very very very very very long line in a comment that shouldn't raise a warning but maybe?
 1000 SO 1
 1005 RCC 0 1.5 -0.5 0 0 1 0.25
 1010 SO 3


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This is probably the most requested feature (whether they say so or not). `LineOverrunWarnings` and `LineExpansionWarnings` are no longer created for comments.

This does the following:

1. Filters out comments from raising warnings, and un-truncate them. 
2. If a line is wrapped on export check if it has a comment.
   3. If it's a `c` comment do nothing; do not wrap.
   4. If it has a `$` comment wrap the uncommented part, and then add the comment to the end. 

Fixes #188

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--658.org.readthedocs.build/en/658/

<!-- readthedocs-preview montepy end -->