### PR TITLE
Pin black version '25 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@ Fixes # (issue number)
 
 - [ ] I have performed a self-review of my own code.
 - [ ] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).
+- [ ] I have formatted my code with `black` version 25.
 - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
 
 ---

--- a/montepy/__init__.py
+++ b/montepy/__init__.py
@@ -1,5 +1,5 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
-""" MontePy is a library for reading, editing, and writing MCNP input files.
+"""MontePy is a library for reading, editing, and writing MCNP input files.
 
 This creates a semantic understanding of the MCNP input file.
 start by running montepy.read_input().

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ doc = [
 	"sphinx_autodoc_typehints",
 	"autodocsumm"
 ]
-format = ["black>=23.3.0"]
+format = ["black~=25.1"]
 build = [
 	"build",
 	"setuptools>=64.0.0",


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

Pin black 25.1 and update the PR template accordingly.

I just cherry-picked commits from the alpha test dev branch



<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--660.org.readthedocs.build/en/660/

<!-- readthedocs-preview montepy end -->