### PR TITLE
Allow strictly finding material components

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -14,7 +14,7 @@ MontePy Changelog
 * Made it easier to create an Isotope (now Nuclide): ``montepy.Nuclide("H-1.80c")`` (:issue:`505`).
 * When a typo in an object attribute is made an Error is raised rather than silently having no effect (:issue:`508`).
 * Improved material printing to avoid very long lists of components (:issue:`144`).
-* Allow querying for materials by components (:issue:`95`).
+* Allow querying for materials by components (:issue:`95`), either broadly or specifically (:issue:`642`).
 * Added support for getting and setting default libraries, e.g., ``nlib``, from a material (:issue:`369`).
 * Added most objects to the top level so they can be accessed like: ``montepy.Cell``.
 * Made ``Material.is_atom_fraction`` settable (:issue:`511`). 

--- a/doc/source/starting.rst
+++ b/doc/source/starting.rst
@@ -409,14 +409,15 @@ For surfaces this is: :func:`~montepy.surfaces.surface_builder.parse_surface`,
 and for data inputs this is :func:`~montepy.data_inputs.data_parser.parse_data`.
 
 .. doctest::
+
    >>> surf = montepy.parse_surface("1 cz 5.0")
    >>> type(surf)
-   foo
+   <class 'montepy.surfaces.cylinder_on_axis.CylinderOnAxis'>
    >>> surf.radius
    5.0
    >>> mat = montepy.parse_data("m1 1001.80c 1")
    >>> type(mat)
-   foo
+   <class 'montepy.data_inputs.material.Material'>
 
 
 This object is still unlinked from other objects, and won't be kept with a problem.
@@ -1019,21 +1020,28 @@ on the element, not just the elemental nuclide.
     >>> montepy.Nuclide("B-0") in mat
     True
 
-For more complicated checks there is the :func:`~montepy.data_inputs.material.Material.contains`.
-This takes a plurality of nuclides as well as a threshold.
-This returns ``True`` if and only if the material contains *all* nuclides
+For more complicated checks there is the :func:`~montepy.data_inputs.material.Material.contains_all`, and 
+:func:`~montepy.data_inputs.material.Material.contains_any`.
+These functions take a plurality of nuclides as well as a threshold.
+The function ``contains_all`` returns ``True`` if and only if the material contains *all* nuclides
+with a fraction above the threshold.
+The function ``contains_any`` returns ``True`` if any of the material contains *any* nuclides
 with a fraction above the threshold.
 
 .. doctest::
 
-    >>> mat.contains("H-1.80c")
+    >>> mat.contains_all("H-1.80c")
     False
-    >>> mat.contains("U-235", "U-238", threshold=1.0)
+    >>> mat.contains_all("U-235", "U-238", threshold=1.0)
     True
-    >>> mat.contains("U-235.80c", "B-10")
+    >>> mat.contains_all("U-235.80c", "B-10")
     True
-    >>> mat.contains("U-235.80c", "B-10", threshold=1e-3)
+    >>> mat.contains_all("U-235.80c", "B-10", threshold=1e-3)
     False
+    >>> mat.contains_all("H-1.80c", "U-235.80c")
+    False
+    >>> mat.contains_any("H-1.80c", "U-235.80c")
+    True
 
 Finding Nuclides
 """"""""""""""""

--- a/montepy/__init__.py
+++ b/montepy/__init__.py
@@ -1,5 +1,5 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
-""" MontePy is a library for reading, editing, and writing MCNP input files.
+"""MontePy is a library for reading, editing, and writing MCNP input files.
 
 This creates a semantic understanding of the MCNP input file.
 start by running montepy.read_input().

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -724,6 +724,12 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
 
         .. note::
 
+            The difference between :func:`contains_all` and :func:`contains_any` is only for how they
+            handle being given multiple nuclides. This does not impact how given Elements will match 
+            daughter Nuclides. This is handled instead by ``strict``.
+        
+        .. note::
+
             For details on how to use the ``strict`` argument see the examples in: :func:`find`.
 
         .. versionadded:: 1.0.0

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -726,11 +726,6 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
 
             For details on how to use the ``strict`` argument see the examples in: :func:`find`.
 
-        .. note::
-
-            If a nuclide is in a material multiple times, and cumulatively exceeds the threshold,
-            but for each instance it appears it is below the threshold this method will return False.
-
         .. versionadded:: 1.0.0
 
         :param nuclides: a plurality of nuclides to check for.
@@ -781,11 +776,6 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         .. note::
 
             For details on how to use the ``strict`` argument see the examples in: :func:`find`.
-
-        .. note::
-
-            If a nuclide (or element) is in a material multiple times, and cumulatively exceeds the threshold,
-            but for each instance it appears it is below the threshold this method will return False.
 
         .. versionadded:: 1.0.0
 
@@ -857,27 +847,26 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         element_search = {}
         for nuclide in nuclide_finders:
             if isinstance(nuclide, Element):
-                element_search[nuclide] = False
+                element_search[nuclide] = 0.0
             if isinstance(nuclide, Nucleus):
-                nuclei_search[nuclide] = False
+                nuclei_search[nuclide] = 0.0
             if isinstance(nuclide, Nuclide):
-                nuclides_search[str(nuclide).lower()] = False
+                nuclides_search[str(nuclide).lower()] = 0.0
 
         for nuclide, fraction in self:
-            if fraction < threshold:
-                continue
             if str(nuclide).lower() in nuclides_search:
-                nuclides_search[str(nuclide).lower()] = True
+                nuclides_search[str(nuclide).lower()] += fraction
             if nuclide.nucleus in nuclei_search:
-                nuclei_search[nuclide.nucleus] = True
+                nuclei_search[nuclide.nucleus] += fraction
             if nuclide.element in element_search:
-                element_search[nuclide.element] = True
+                element_search[nuclide.element] += fraction
 
+        threshold_check = lambda x: x > threshold
         return bool_func(
             (
-                bool_func(nuclides_search.values()),
-                bool_func(nuclei_search.values()),
-                bool_func(element_search.values()),
+                bool_func(map(threshold_check, nuclides_search.values())),
+                bool_func(map(threshold_check, nuclei_search.values())),
+                bool_func(map(threshold_check, element_search.values())),
             )
         )
 

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -765,7 +765,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         Checks if this material contains any of the given nuclide.
 
         A boolean "or" is used for this comparison.
-        That is this material must contain all nuclides at or above the given threshold
+        That is, this material must contain any nuclides at or above the given threshold
         in order to return true.
 
         Examples
@@ -786,7 +786,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
 
         .. note::
 
-            If a nuclide is in a material multiple times, and cumulatively exceeds the threshold,
+            If a nuclide (or element) is in a material multiple times, and cumulatively exceeds the threshold,
             but for each instance it appears it is below the threshold this method will return False.
 
         .. versionadded:: 1.0.0

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -827,7 +827,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
     def _contains_arb(
         self,
         *nuclides: Union[Nuclide, Nucleus, Element, str, int],
-        bool_func: co.abc.Callable[co.abc.Iterable[bool]] = all,
+        bool_func: co.abc.Callable[co.abc.Iterable[bool]] = None,
         threshold: float = 0.0,
         strict: bool = False,
     ) -> bool:

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -606,7 +606,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         del self._components[idx]
 
     def __contains__(self, nuclide):
-        if not isinstance(nuclide, NuclideLike):
+        if not isinstance(nuclide, (Nuclide, Nucleus, Element, str, numbers.Integral)):
             raise TypeError(
                 f"Can only check if a Nuclide, Nucleus, Element, or str is in a material. {nuclide} given."
             )
@@ -807,7 +807,8 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
 
     @staticmethod
     def _promote_nuclide(nuclide, strict):
-        if not isinstance(nuclide, NuclideLike):
+        # This is necessary for python 3.9
+        if not isinstance(nuclide, (Nuclide, Nucleus, Element, str, numbers.Integral)):
             raise TypeError(
                 f"Nuclide must be a type that can be converted to a Nuclide. The allowed types are: "
                 f"Nuclide, Nucleus, str, int. {nuclide} given."

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -745,8 +745,8 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         :param threshold: the minimum concentration of a nuclide to be considered. The material components are not
             first normalized.
         :type threshold: float
-        :param strict: Whether to not let an elemental nuclide match all child isotopes, isomers, not have an isotope
-            match all isomers, nor have a blank library match all libraries.
+        :param strict: If True this does not let an elemental nuclide match all child isotopes, isomers, nor will an isotope
+            match all isomers, nor will a blank library match all libraries.
         :type strict: bool
 
         :return: whether or not this material contains all components given above the threshold.

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -686,7 +686,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
             raise TypeError(
                 f"Nuclide must of type Nuclide, str, or int. {nuclide} of type {type(nuclide)} given."
             )
-        nuclide = self._promote_nuclide(nuclide, False)
+        nuclide = self._promote_nuclide(nuclide, True)
         self.append((nuclide, fraction))
 
     def contains_all(

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -36,6 +36,8 @@ This is used for adding new material components.
 By default all components made from scratch are added to their own line with this many leading spaces.
 """
 
+NuclideLike = Union[Nuclide, Nucleus, Element, str, int]
+
 
 class _DefaultLibraries:
     """
@@ -603,7 +605,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         del self._components[idx]
 
     def __contains__(self, nuclide):
-        if not isinstance(nuclide, (Nuclide, Nucleus, Element, str)):
+        if not isinstance(nuclide, NuclideLike):
             raise TypeError(
                 f"Can only check if a Nuclide, Nucleus, Element, or str is in a material. {nuclide} given."
             )
@@ -669,7 +671,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         for nuclide, _ in self:
             nuclide.library = new_library
 
-    def add_nuclide(self, nuclide: Union[Nuclide, str, int], fraction: float):
+    def add_nuclide(self, nuclide: NuclideLike, fraction: float):
         """
         Add a new component to this material of the given nuclide, and fraction.
 
@@ -684,17 +686,12 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
             raise TypeError(
                 f"Nuclide must of type Nuclide, str, or int. {nuclide} of type {type(nuclide)} given."
             )
-        if not isinstance(fraction, (float, int)):
-            raise TypeError(
-                f"Fraction must be a numerical value. {fraction} of type {type(fraction)}"
-            )
-        if isinstance(nuclide, (str, int)):
-            nuclide = Nuclide(nuclide)
+        nuclide = self._promote_nuclide(nuclide, False)
         self.append((nuclide, fraction))
 
     def contains_all(
         self,
-        *nuclides: Union[Nuclide, Nucleus, Element, str, int],
+        *nuclides: NuclideLike,
         threshold: float = 0.0,
         strict: bool = False,
     ) -> bool:
@@ -757,7 +754,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
 
     def contains_any(
         self,
-        *nuclides: Union[Nuclide, Nucleus, Element, str, int],
+        *nuclides: NuclideLike,
         threshold: float = 0.0,
         strict: bool = False,
     ) -> bool:
@@ -813,7 +810,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
 
     @staticmethod
     def _promote_nuclide(nuclide, strict):
-        if not isinstance(nuclide, (str, int, Element, Nucleus, Nuclide)):
+        if not isinstance(nuclide, NuclideLike):
             raise TypeError(
                 f"Nuclide must be a type that can be converted to a Nuclide. The allowed types are: "
                 f"Nuclide, Nucleus, str, int. {nuclide} given."

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -1008,6 +1008,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         A: Union[int, slice] = None,
         meta_state: Union[int, slice] = None,
         library: Union[str, slice] = None,
+        strict: bool = False,
     ) -> Generator[tuple[int, tuple[Nuclide, float]]]:
         """
         Finds all components that meet the given criteria.
@@ -1087,9 +1088,13 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
             raise TypeError(
                 f"library must a str or a slice. {library} of type {type(library)} given."
             )
+        if not isinstance(strict, bool):
+            raise TypeError(
+                f"strict must be a bool. {strict} of type {type(strict)} given."
+            )
         if name:
             fancy_nuclide = Nuclide(name)
-            if fancy_nuclide.A == 0:
+            if fancy_nuclide.A == 0 and not strict:
                 element = fancy_nuclide.element
                 fancy_nuclide = None
         else:
@@ -1099,6 +1104,13 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         else:
             first_filter = self.__prep_filter(fancy_nuclide)
 
+        # create filter for defaults if strict
+        if strict:
+            # if strict and element switch to A=0
+            if element and A is None:
+                A = 0
+            if library is None:
+                library = ""
         filters = [
             first_filter,
             self.__prep_element_filter(element),
@@ -1121,6 +1133,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         A: Union[int, slice] = None,
         meta_state: Union[int, slice] = None,
         library: Union[str, slice] = None,
+        strict: bool = False,
     ) -> Generator[float]:
         """
         A wrapper for :func:`find` that only returns the fractions of the components.
@@ -1167,7 +1180,9 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         :returns: a generator of fractions whose nuclide matches the criteria.
         :rtype: Generator[float]
         """
-        for _, (_, fraction) in self.find(name, element, A, meta_state, library):
+        for _, (_, fraction) in self.find(
+            name, element, A, meta_state, library, strict
+        ):
             yield fraction
 
     def __bool__(self):

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -781,6 +781,10 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
             )
         if threshold < 0.0:
             raise ValueError(f"Threshold must be positive or zero. {threshold} given.")
+        if not isinstance(strict, bool):
+            raise TypeError(
+                f"Strict must be bool. {strict} of type: {type(strict)} given."
+            )
 
         # fail fast
         for nuclide in nuclides:

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -696,6 +696,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         nuclide: Union[Nuclide, Nucleus, Element, str, int],
         *args: Union[Nuclide, Nucleus, Element, str, int],
         threshold: float = 0.0,
+        strict: bool = False,
     ) -> bool:
         """
         Checks if this material contains multiple nuclides.
@@ -732,6 +733,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
 
             If a nuclide is in a material multiple times, and cumulatively exceeds the threshold,
             but for each instance it appears it is below the threshold this method will return False.
+
         .. versionadded:: 1.0.0
 
         :param nuclide: the first nuclide to check for.
@@ -741,6 +743,9 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         :param threshold: the minimum concentration of a nuclide to be considered. The material components are not
             first normalized.
         :type threshold: float
+        :param strict: Whether to not let an elemental nuclide match all child isotopes, isomers, not have an isotope
+            match all isomers, nor have a blank library match all libraries.
+        :type strict: bool
 
         :return: whether or not this material contains all components given above the threshold.
         :rtype: bool
@@ -759,9 +764,13 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
             if isinstance(nuclide, (str, int)):
                 nuclide = Nuclide(nuclide)
             # treat elemental as element
-            if isinstance(nuclide, (Nucleus, Nuclide)) and nuclide.A == 0:
+            if (
+                isinstance(nuclide, (Nucleus, Nuclide))
+                and nuclide.A == 0
+                and not strict
+            ):
                 nuclide = nuclide.element
-            if isinstance(nuclide, Nuclide) and not str(nuclide.library):
+            if isinstance(nuclide, Nuclide) and not str(nuclide.library) and not strict:
                 nuclide = nuclide.nucleus
             nuclides.append(nuclide)
 

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -698,31 +698,10 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         threshold: float = 0.0,
         strict: bool = False,
     ) -> bool:
-        return self._contains_arb(
-            *nuclides, bool_func=all, threshold=threshold, strict=strict
-        )
-
-    def contains_any(
-        self,
-        *nuclides: Union[Nuclide, Nucleus, Element, str, int],
-        threshold: float = 0.0,
-        strict: bool = False,
-    ) -> bool:
-        return self._contains_arb(
-            *nuclides, bool_func=any, threshold=threshold, strict=strict
-        )
-
-    def _contains_arb(
-        self,
-        *nuclides: Union[Nuclide, Nucleus, Element, str, int],
-        bool_func: co.abc.Callable[co.abc.Iterable[bool]] = all,
-        threshold: float = 0.0,
-        strict: bool = False,
-    ) -> bool:
         """
-        Checks if this material contains multiple nuclides.
+        Checks if this material contains of all of the given nuclides.
 
-        A boolean and is used for this comparison.
+        A boolean "and" is used for this comparison.
         That is this material must contain all nuclides at or above the given threshold
         in order to return true.
 
@@ -736,18 +715,13 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
 
             # try to find LEU materials
             for mat in problem.materials:
-                if mat.contains("U-235", threshold=0.02):
+                if mat.contains_all("U-235", threshold=0.02):
                     # your code here
-                    pass
-
-            # try to find any fissile materials
-            for mat in problem.materials:
-                if mat.contains("U-235", "U-233", "Pu-239", threshold=1e-6):
                     pass
 
             # try to find a uranium
             for mat in problem.materials:
-                if mat.contains("U"):
+                if mat.contains_all("U"):
                     pass
 
         .. note::
@@ -761,7 +735,63 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
 
         .. versionadded:: 1.0.0
 
-        :param nuclides: a plurality of other nuclides to check for.
+        :param nuclides: a plurality of nuclides to check for.
+        :type nuclides: Union[Nuclide, Nucleus, Element, str, int]
+        :param threshold: the minimum concentration of a nuclide to be considered. The material components are not
+            first normalized.
+        :type threshold: float
+        :param strict: If True this does not let an elemental nuclide match all child isotopes, isomers, nor will an isotope
+            match all isomers, nor will a blank library match all libraries.
+        :type strict: bool
+
+        :return: whether or not this material contains all components given above the threshold.
+        :rtype: bool
+
+        :raises TypeError: if any argument is of the wrong type.
+        :raises ValueError: if the fraction is not positive or zero, or if nuclide cannot be interpreted as a Nuclide.
+
+        """
+        return self._contains_arb(
+            *nuclides, bool_func=all, threshold=threshold, strict=strict
+        )
+
+    def contains_any(
+        self,
+        *nuclides: Union[Nuclide, Nucleus, Element, str, int],
+        threshold: float = 0.0,
+        strict: bool = False,
+    ) -> bool:
+        """
+        Checks if this material contains any of the given nuclide.
+
+        A boolean "or" is used for this comparison.
+        That is this material must contain all nuclides at or above the given threshold
+        in order to return true.
+
+        Examples
+        ^^^^^^^^
+
+        .. testcode::
+
+            import montepy
+            problem = montepy.read_input("tests/inputs/test.imcnp")
+
+            # try to find any fissile materials
+            for mat in problem.materials:
+                if mat.contains_any("U-235", "U-233", "Pu-239", threshold=1e-6):
+                    pass
+        .. note::
+
+            For details on how to use the ``strict`` argument see the examples in: :func:`find`.
+
+        .. note::
+
+            If a nuclide is in a material multiple times, and cumulatively exceeds the threshold,
+            but for each instance it appears it is below the threshold this method will return False.
+
+        .. versionadded:: 1.0.0
+
+        :param nuclides: a plurality of nuclides to check for.
         :type nuclides: Union[Nuclide, Nucleus, Element, str, int]
         :param threshold: the minimum concentration of a nuclide to be considered. The material components are not
             first normalized.

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -692,9 +692,30 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
             nuclide = Nuclide(nuclide)
         self.append((nuclide, fraction))
 
-    def contains(
+    def contains_all(
         self,
         *nuclides: Union[Nuclide, Nucleus, Element, str, int],
+        threshold: float = 0.0,
+        strict: bool = False,
+    ) -> bool:
+        return self._contains_arb(
+            *nuclides, bool_func=all, threshold=threshold, strict=strict
+        )
+
+    def contains_any(
+        self,
+        *nuclides: Union[Nuclide, Nucleus, Element, str, int],
+        threshold: float = 0.0,
+        strict: bool = False,
+    ) -> bool:
+        return self._contains_arb(
+            *nuclides, bool_func=any, threshold=threshold, strict=strict
+        )
+
+    def _contains_arb(
+        self,
+        *nuclides: Union[Nuclide, Nucleus, Element, str, int],
+        bool_func: co.abc.Callable[co.abc.Iterable[bool]] = all,
         threshold: float = 0.0,
         strict: bool = False,
     ) -> bool:
@@ -811,11 +832,11 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
                 nuclei_search[nuclide.nucleus] = True
             if nuclide.element in element_search:
                 element_search[nuclide.element] = True
-        return all(
+        return bool_func(
             (
-                all(nuclides_search.values()),
-                all(nuclei_search.values()),
-                all(element_search.values()),
+                bool_func(nuclides_search.values()),
+                bool_func(nuclei_search.values()),
+                bool_func(element_search.values()),
             )
         )
 

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -37,7 +37,7 @@ This is used for adding new material components.
 By default all components made from scratch are added to their own line with this many leading spaces.
 """
 
-NuclideLike = Union[Nuclide, Nucleus, Element, str, int]
+NuclideLike = Union[Nuclide, Nucleus, Element, str, numbers.Integral]
 
 
 class _DefaultLibraries:
@@ -610,7 +610,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
             raise TypeError(
                 f"Can only check if a Nuclide, Nucleus, Element, or str is in a material. {nuclide} given."
             )
-        if isinstance(nuclide, str):
+        if isinstance(nuclide, (str, numbers.Integral)):
             nuclide = Nuclide(nuclide)
         # switch to elemental
         if isinstance(nuclide, (Nucleus, Nuclide)) and nuclide.A == 0:
@@ -725,9 +725,9 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         .. note::
 
             The difference between :func:`contains_all` and :func:`contains_any` is only for how they
-            handle being given multiple nuclides. This does not impact how given Elements will match 
+            handle being given multiple nuclides. This does not impact how given Elements will match
             daughter Nuclides. This is handled instead by ``strict``.
-        
+
         .. note::
 
             For details on how to use the ``strict`` argument see the examples in: :func:`find`.

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -1178,7 +1178,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         :type meta_state: int, slice
         :param library: the libraries to limit the search to.
         :type library: str, slice
-        :param strict: whether to strictly match elements as only elements (when no A is given), and only match blank
+        :param strict: When true this will strictly match elements as only elements (when no A is given), and only match blank
             libraries when no library is given.
         :type strict: bool
 

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -4,6 +4,7 @@ import collections as co
 import copy
 import itertools
 import math
+import numbers
 import re
 from typing import Generator, Union
 import warnings
@@ -832,7 +833,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         strict: bool = False,
     ) -> bool:
         nuclide_finders = []
-        if not isinstance(threshold, float):
+        if not isinstance(threshold, numbers.Real):
             raise TypeError(
                 f"Threshold must be a float. {threshold} of type: {type(threshold)} given"
             )
@@ -949,7 +950,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
         """
 
         def setter(old_val, new_val):
-            if not isinstance(new_val, float):
+            if not isinstance(new_val, numbers.Real):
                 raise TypeError(
                     f"Value must be set to a float. {new_val} of type {type(new_val)} given."
                 )

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -694,8 +694,7 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
 
     def contains(
         self,
-        nuclide: Union[Nuclide, Nucleus, Element, str, int],
-        *args: Union[Nuclide, Nucleus, Element, str, int],
+        *nuclides: Union[Nuclide, Nucleus, Element, str, int],
         threshold: float = 0.0,
         strict: bool = False,
     ) -> bool:
@@ -741,10 +740,8 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
 
         .. versionadded:: 1.0.0
 
-        :param nuclide: the first nuclide to check for.
-        :type nuclide: Union[Nuclide, Nucleus, Element, str, int]
-        :param args: a plurality of other nuclides to check for.
-        :type args: Union[Nuclide, Nucleus, Element, str, int]
+        :param nuclides: a plurality of other nuclides to check for.
+        :type nuclides: Union[Nuclide, Nucleus, Element, str, int]
         :param threshold: the minimum concentration of a nuclide to be considered. The material components are not
             first normalized.
         :type threshold: float
@@ -760,7 +757,17 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
 
         """
         nuclides = []
-        for nuclide in [nuclide] + list(args):
+        if not isinstance(threshold, float):
+            raise TypeError(
+                f"Threshold must be a float. {threshold} of type: {type(threshold)} given"
+            )
+        if threshold < 0.0:
+            raise ValueError(f"Threshold must be positive or zero. {threshold} given.")
+        if not isinstance(strict, bool):
+            raise TypeError(
+                f"Strict must be bool. {strict} of type: {type(strict)} given."
+            )
+        for nuclide in nuclides:
             if not isinstance(nuclide, (str, int, Element, Nucleus, Nuclide)):
                 raise TypeError(
                     f"Nuclide must be a type that can be converted to a Nuclide. The allowed types are: "
@@ -778,17 +785,6 @@ See <https://www.montepy.org/migrations/migrate0_1.html> for more information ""
             if isinstance(nuclide, Nuclide) and not str(nuclide.library) and not strict:
                 nuclide = nuclide.nucleus
             nuclides.append(nuclide)
-
-        if not isinstance(threshold, float):
-            raise TypeError(
-                f"Threshold must be a float. {threshold} of type: {type(threshold)} given"
-            )
-        if threshold < 0.0:
-            raise ValueError(f"Threshold must be positive or zero. {threshold} given.")
-        if not isinstance(strict, bool):
-            raise TypeError(
-                f"Strict must be bool. {strict} of type: {type(strict)} given."
-            )
 
         # fail fast
         for nuclide in nuclides:

--- a/montepy/materials.py
+++ b/montepy/materials.py
@@ -40,6 +40,7 @@ class Materials(NumberedDataObjectCollection):
             int,
         ],
         threshold: float = 0.0,
+        strict: bool = False,
     ) -> Generator[Material]:
         """
         Get all materials that contain these nuclides.
@@ -70,6 +71,9 @@ class Materials(NumberedDataObjectCollection):
         :param threshold: the minimum concentration of a nuclide to be considered. The material components are not
             first normalized.
         :type threshold: float
+        :param strict: If True this does not let an elemental nuclide match all child isotopes, isomers, nor will an isotope
+            match all isomers, nor will a blank library match all libraries.
+        :type strict: bool
 
         :return: A generator of all matching materials
         :rtype: Generator[Material]
@@ -110,7 +114,7 @@ class Materials(NumberedDataObjectCollection):
         # optimize by most hashable and fail fast
         nuclides = sorted(nuclides, key=sort_by_type)
         for material in self:
-            if material.contains(*nuclides, threshold=threshold):
+            if material.contains(*nuclides, threshold=threshold, strict=strict):
                 # maybe? Maybe not?
                 # should Materials act like a set?
                 yield material

--- a/montepy/materials.py
+++ b/montepy/materials.py
@@ -32,14 +32,7 @@ class Materials(NumberedDataObjectCollection):
 
     def get_containing(
         self,
-        nuclide: Union[
-            montepy.data_inputs.nuclide.Nuclide,
-            montepy.data_inputs.nuclide.Nucleus,
-            montepy.Element,
-            str,
-            int,
-        ],
-        *args: Union[
+        *nuclides: Union[
             montepy.data_inputs.nuclide.Nuclide,
             montepy.data_inputs.nuclide.Nucleus,
             montepy.Element,
@@ -72,10 +65,8 @@ class Materials(NumberedDataObjectCollection):
 
         .. versionadded:: 1.0.0
 
-        :param nuclide: the first nuclide to check for.
-        :type nuclide: Union[Nuclide, Nucleus, Element, str, int]
-        :param args: a plurality of other nuclides to check for.
-        :type args: Union[Nuclide, Nucleus, Element, str, int]
+        :param nuclides: a plurality of other nuclides to check for.
+        :type nuclides: Union[Nuclide, Nucleus, Element, str, int]
         :param threshold: the minimum concentration of a nuclide to be considered. The material components are not
             first normalized.
         :type threshold: float
@@ -86,8 +77,10 @@ class Materials(NumberedDataObjectCollection):
         :raises TypeError: if any argument is of the wrong type.
         :raises ValueError: if the fraction is not positive or zero, or if nuclide cannot be interpreted as a Nuclide.
         """
+        # TODO collision here
+        # TODO other type enforcement
         nuclides = []
-        for nuclide in [nuclide] + list(args):
+        for nuclide in nuclides:
             if not isinstance(
                 nuclide,
                 (

--- a/montepy/materials.py
+++ b/montepy/materials.py
@@ -1,6 +1,7 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
 
 from __future__ import annotations
+import collections as co
 import copy
 from typing import Generator, Union
 
@@ -30,7 +31,7 @@ class Materials(NumberedDataObjectCollection):
     def __init__(self, objects=None, problem=None):
         super().__init__(Material, objects, problem)
 
-    def get_containing(
+    def get_containing_any(
         self,
         *nuclides: Union[
             montepy.data_inputs.nuclide.Nuclide,
@@ -43,7 +44,7 @@ class Materials(NumberedDataObjectCollection):
         strict: bool = False,
     ) -> Generator[Material]:
         """
-        Get all materials that contain these nuclides.
+        Get all materials that contain any of these these nuclides.
 
         This uses :func:`~montepy.data_inputs.material.Material.contains` under the hood.
         See that documentation for more guidance.
@@ -57,7 +58,7 @@ class Materials(NumberedDataObjectCollection):
 
             import montepy
             problem = montepy.read_input("foo.imcnp")
-            for mat in problem.materials.get_containing("H-1", "O-16", threshold = 0.3):
+            for mat in problem.materials.get_containing_any("H-1", "U-235", threshold = 0.3):
                 print(mat)
 
         .. testoutput::
@@ -66,7 +67,7 @@ class Materials(NumberedDataObjectCollection):
 
         .. versionadded:: 1.0.0
 
-        :param nuclides: a plurality of other nuclides to check for.
+        :param nuclides: a plurality of nuclides to check for.
         :type nuclides: Union[Nuclide, Nucleus, Element, str, int]
         :param threshold: the minimum concentration of a nuclide to be considered. The material components are not
             first normalized.
@@ -81,27 +82,81 @@ class Materials(NumberedDataObjectCollection):
         :raises TypeError: if any argument is of the wrong type.
         :raises ValueError: if the fraction is not positive or zero, or if nuclide cannot be interpreted as a Nuclide.
         """
-        # TODO collision here
-        # TODO other type enforcement
-        nuclides = []
+        return self._contains_arb(
+            *nuclides, bool_func=any, threshold=threshold, strict=strict
+        )
+
+    def get_containing_all(
+        self,
+        *nuclides: Union[
+            montepy.data_inputs.nuclide.Nuclide,
+            montepy.data_inputs.nuclide.Nucleus,
+            montepy.Element,
+            str,
+            int,
+        ],
+        threshold: float = 0.0,
+        strict: bool = False,
+    ) -> Generator[Material]:
+        """
+        Get all materials that contain all of these nuclides.
+
+        This uses :func:`~montepy.data_inputs.material.Material.contains` under the hood.
+        See that documentation for more guidance.
+
+        Examples
+        ^^^^^^^^
+
+        One example would to be find all water bearing materials:
+
+        .. testcode::
+
+            import montepy
+            problem = montepy.read_input("foo.imcnp")
+            for mat in problem.materials.get_containing_all("H-1", "O-16", threshold = 0.3):
+                print(mat)
+
+        .. testoutput::
+
+            MATERIAL: 1, ['hydrogen', 'oxygen']
+
+        .. versionadded:: 1.0.0
+
+        :param nuclides: a plurality of nuclides to check for.
+        :type nuclides: Union[Nuclide, Nucleus, Element, str, int]
+        :param threshold: the minimum concentration of a nuclide to be considered. The material components are not
+            first normalized.
+        :type threshold: float
+        :param strict: If True this does not let an elemental nuclide match all child isotopes, isomers, nor will an isotope
+            match all isomers, nor will a blank library match all libraries.
+        :type strict: bool
+
+        :return: A generator of all matching materials
+        :rtype: Generator[Material]
+
+        :raises TypeError: if any argument is of the wrong type.
+        :raises ValueError: if the fraction is not positive or zero, or if nuclide cannot be interpreted as a Nuclide.
+        """
+        return self._contains_arb(
+            *nuclides, bool_func=all, threshold=threshold, strict=strict
+        )
+
+    def _contains_arb(
+        self,
+        *nuclides: Union[
+            montepy.data_inputs.nuclide.Nuclide,
+            montepy.data_inputs.nuclide.Nucleus,
+            montepy.Element,
+            str,
+            int,
+        ],
+        bool_func: co.abc.Callable[co.abc.Iterable[bool]],
+        threshold: float = 0.0,
+        strict: bool = False,
+    ) -> Generator[Material]:
+        nuclide_finders = []
         for nuclide in nuclides:
-            if not isinstance(
-                nuclide,
-                (
-                    str,
-                    int,
-                    montepy.Element,
-                    montepy.data_inputs.nuclide.Nucleus,
-                    montepy.Nuclide,
-                ),
-            ):
-                raise TypeError(
-                    f"nuclide must be of type str, int, Element, Nucleus, or Nuclide. "
-                    f"{nuclide} of type {type(nuclide)} given."
-                )
-            if isinstance(nuclide, (str, int)):
-                nuclide = montepy.Nuclide(nuclide)
-            nuclides.append(nuclide)
+            nuclide_finders.append(Material._promote_nuclide(nuclide, strict))
 
         def sort_by_type(nuclide):
             type_map = {
@@ -112,9 +167,14 @@ class Materials(NumberedDataObjectCollection):
             return type_map[type(nuclide)]
 
         # optimize by most hashable and fail fast
-        nuclides = sorted(nuclides, key=sort_by_type)
+        nuclide_finders = sorted(nuclide_finders, key=sort_by_type)
         for material in self:
-            if material.contains(*nuclides, threshold=threshold, strict=strict):
+            if material._contains_arb(
+                *nuclide_finders,
+                bool_func=bool_func,
+                threshold=threshold,
+                strict=strict,
+            ):
                 # maybe? Maybe not?
                 # should Materials act like a set?
                 yield material

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -268,9 +268,14 @@ class TestMaterial:
         assert is_in == big_material.contains(content, strict=strict)
         with pytest.raises(TypeError):
             5 in big_material
+        with pytest.raises(TypeError):
+            big_material.contains("H", strict=5)
 
     def test_material_multi_contains(_, big_material):
         assert big_material.contains("1001", "U-235", "Pu-239", threshold=0.01)
+        assert not big_material.contains(
+            "1001", "U-235", "Pu-239", threshold=0.01, strict=True
+        )
         assert not big_material.contains("1001", "U-235", "Pu-239", threshold=0.07)
         assert not big_material.contains("U-235", "B-10")
 
@@ -305,6 +310,17 @@ class TestMaterial:
             ({"name": "U235m1"}, 1),
             ({"element": Element(1)}, 6),
             ({"element": "H"}, 6),
+            ({"element": "H", "strict": True}, 0),
+            ({"element": "H", "A": 1, "strict": True}, 0),
+            (
+                {
+                    "element": "H",
+                    "A": 1,
+                    "library": slice("00c", "05c"),
+                    "strict": True,
+                },
+                2,
+            ),
             ({"element": slice(92, 95)}, 5),
             ({"A": 1}, 4),
             ({"A": slice(235, 240)}, 5),
@@ -342,6 +358,8 @@ class TestMaterial:
             list(big_material.find(element=1.23))
         with pytest.raises(TypeError):
             list(big_material.find(library=5))
+        with pytest.raises(TypeError):
+            list(big_material.find(strict=5))
 
     def test_material_str(_):
         in_str = "M20 1001.80c 0.5 8016.80c 0.4 94239.80c 0.1"

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -251,6 +251,7 @@ class TestMaterial:
         "content, strict, is_in",
         [
             ("1001.80c", False, True),
+            (1001, False, True),
             ("H-1", False, True),
             (Element(1), False, True),
             (Nucleus(Element(1), 1), False, True),
@@ -273,7 +274,7 @@ class TestMaterial:
         assert is_in == big_material.contains_all(content, strict=strict)
         assert is_in == big_material.contains_any(content, strict=strict)
         with pytest.raises(TypeError):
-            5 in big_material
+            {} in big_material
         with pytest.raises(TypeError):
             big_material.contains_all("H", strict=5)
         with pytest.raises(TypeError):

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -270,32 +270,41 @@ class TestMaterial:
     def test_material_contains(_, big_material, content, strict, is_in):
         if not strict:
             assert is_in == (content in big_material), "Contains didn't work properly"
-        assert is_in == big_material.contains(content, strict=strict)
+        assert is_in == big_material.contains_all(content, strict=strict)
+        assert is_in == big_material.contains_any(content, strict=strict)
         with pytest.raises(TypeError):
             5 in big_material
         with pytest.raises(TypeError):
-            big_material.contains("H", strict=5)
+            big_material.contains_all("H", strict=5)
+        with pytest.raises(TypeError):
+            big_material.contains_any("H", strict=5)
 
     def test_material_multi_contains(_, big_material):
-        assert big_material.contains("1001", "U-235", "Pu-239", threshold=0.01)
-        assert not big_material.contains(
+        # contains all
+        assert big_material.contains_all("1001", "U-235", "Pu-239", threshold=0.01)
+        assert not big_material.contains_all(
             "1001", "U-235", "Pu-239", threshold=0.01, strict=True
         )
-        assert not big_material.contains("1001", "U-235", "Pu-239", threshold=0.07)
-        assert not big_material.contains("U-235", "B-10")
+        assert not big_material.contains_all("1001", "U-235", "Pu-239", threshold=0.07)
+        assert not big_material.contains_all("U-235", "B-10")
+        # contains any
+        assert not big_material.contains_any("C", "B", "F")
+        print("sadness")
+        assert big_material.contains_any("h-1", "C", "B")
 
     def test_material_contains_bad(_):
         mat = Material()
-        with pytest.raises(TypeError):
-            mat.contains(mat)
-        with pytest.raises(TypeError):
-            mat.contains("1001", mat)
-        with pytest.raises(ValueError):
-            mat.contains("hi")
-        with pytest.raises(TypeError):
-            mat.contains("1001", threshold="hi")
-        with pytest.raises(ValueError):
-            mat.contains("1001", threshold=-1.0)
+        for method in [mat.contains_all, mat.contains_any]:
+            with pytest.raises(TypeError):
+                method(mat)
+            with pytest.raises(TypeError):
+                method("1001", mat)
+            with pytest.raises(ValueError):
+                method("hi")
+            with pytest.raises(TypeError):
+                method("1001", threshold="hi")
+            with pytest.raises(ValueError):
+                method("1001", threshold=-1.0)
 
     def test_material_normalize(_, big_material):
         # make sure it's not an invalid starting condition

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -36,6 +36,7 @@ class TestMaterial:
             "am242",
             "am242m1",
             "Pu239",
+            "Ni-0.60c",
         ]
         mat = Material()
         mat.number = 1
@@ -246,21 +247,25 @@ class TestMaterial:
             mat.append((Nuclide("1001.80c"), -1.0))
 
     @pytest.mark.parametrize(
-        "content, is_in",
+        "content, strict, is_in",
         [
-            ("1001.80c", True),
-            ("H-1", True),
-            (Element(1), True),
-            (Nucleus(Element(1), 1), True),
-            (Element(43), False),
-            ("B-10.00c", False),
-            ("H", True),
-            (Nucleus(Element(5), 10), False),
+            ("1001.80c", False, True),
+            ("H-1", False, True),
+            (Element(1), False, True),
+            (Nucleus(Element(1), 1), False, True),
+            (Element(43), False, False),
+            ("B-10.00c", False, False),
+            ("H", False, True),
+            ("H", True, False),
+            (Nucleus(Element(5), 10), False, False),
+            ("Ni", False, True),
+            ("Ni-0.60c", True, True),
         ],
     )
-    def test_material_contains(_, big_material, content, is_in):
-        assert is_in == (content in big_material), "Contains didn't work properly"
-        assert is_in == big_material.contains(content)
+    def test_material_contains(_, big_material, content, strict, is_in):
+        if not strict:
+            assert is_in == (content in big_material), "Contains didn't work properly"
+        assert is_in == big_material.contains(content, strict=strict)
         with pytest.raises(TypeError):
             5 in big_material
 
@@ -304,10 +309,10 @@ class TestMaterial:
             ({"A": 1}, 4),
             ({"A": slice(235, 240)}, 5),
             ({"A": slice(232, 243, 2)}, 5),
-            ({"A": slice(None)}, 15),
-            ({"meta_state": 0}, 13),
+            ({"A": slice(None)}, 16),
+            ({"meta_state": 0}, 14),
             ({"meta_state": 1}, 2),
-            ({"meta_state": slice(0, 2)}, 15),
+            ({"meta_state": slice(0, 2)}, 16),
             ({"library": "80c"}, 3),
             ({"library": slice("00c", "10c")}, 2),
         ],

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -35,6 +35,7 @@ class TestMaterial:
             "u238",
             "am242",
             "am242m1",
+            "Co60m2.50c",
             "Pu239",
             "Ni-0.60c",
         ]
@@ -259,7 +260,11 @@ class TestMaterial:
             ("H", True, False),
             (Nucleus(Element(5), 10), False, False),
             ("Ni", False, True),
+            ("Ni", True, False),  # test wrong library
             ("Ni-0.60c", True, True),
+            ("Co-60", False, False),
+            ("Co-60", True, False),
+            ("Co-60m2.50c", True, True),
         ],
     )
     def test_material_contains(_, big_material, content, strict, is_in):
@@ -325,7 +330,7 @@ class TestMaterial:
             ({"A": 1}, 4),
             ({"A": slice(235, 240)}, 5),
             ({"A": slice(232, 243, 2)}, 5),
-            ({"A": slice(None)}, 16),
+            ({"A": slice(None)}, 17),
             ({"meta_state": 0}, 14),
             ({"meta_state": 1}, 2),
             ({"meta_state": slice(0, 2)}, 16),

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -736,13 +736,30 @@ class TestMaterials:
             (("B",), 1.0, 0),
         ],
     )
-    def test_get_containing(_, m0_prob, nuclides, threshold, num):
-        ret = list(m0_prob.materials.get_containing(*nuclides, threshold=threshold))
+    def test_get_containing_all(_, m0_prob, nuclides, threshold, num):
+        ret = list(m0_prob.materials.get_containing_all(*nuclides, threshold=threshold))
         assert len(ret) == num
         for mat in ret:
             assert isinstance(mat, montepy.Material)
         with pytest.raises(TypeError):
-            next(m0_prob.materials.get_containing(m0_prob))
+            next(m0_prob.materials.get_containing_all(m0_prob))
+
+    @pytest.mark.parametrize(
+        "nuclides, threshold, num",
+        [
+            (("26054", "26056"), 1.0, 1),
+            ((montepy.Nuclide("H-1"),), 0.0, 1),
+            (("B",), 1.0, 0),
+            (("U-235", "H-1"), 0.0, 2),
+        ],
+    )
+    def test_get_containing_any(_, m0_prob, nuclides, threshold, num):
+        ret = list(m0_prob.materials.get_containing_any(*nuclides, threshold=threshold))
+        assert len(ret) == num
+        for mat in ret:
+            assert isinstance(mat, montepy.Material)
+        with pytest.raises(TypeError):
+            next(m0_prob.materials.get_containing_any(m0_prob))
 
     @pytest.fixture
     def h2o(_):


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This is a feature implementation for `contains`, `get_containing`, and `find`. The topline is that there is a new `strict` argument that switches from implicit to explicit matching. So with `strict=True` `"H"` only matches `1000` and not `1001.80c` nor `1000.80c`. The other main thing was adding some feedback from @gonuke.

This feedback splint `contains` (and `get_containing`) to be: `contains_all` and `contains_any`. This should be clearer to users, and be more useful. The main use case of `contains_any` might be:

``` python
fissile = list(problem.material.get_containing_any("U-235", "U-233", "Pu-239",...)
```

Fixes #642

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).
- [x] I have formatted my code with `black` version 25.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [x] I have documented all added classes and methods.
- [ ] ~For infrastructure updates, I have updated the developer's guide.~
- [x] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--663.org.readthedocs.build/en/663/

<!-- readthedocs-preview montepy end -->