### PR TITLE
Updated canonical URL for RTD multi-version.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -53,7 +53,7 @@ favicons = [
 ]
 html_logo = "monty.svg"
 
-html_baseurl = "https://www.montepy.org/"
+html_baseurl = "https://www.montepy.org/en/stable/"
 html_extra_path = ["robots.txt", "foo.imcnp"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This updates a shpinx setting to update the canonical URL to be valid. Canonical URLs is how Search engines decide which page to show when multiple versions exist. Right now this looks like:

``` html
<html lang="en" data-content_root="./" >
  <head>
...
    <link rel="canonical" href="https://www.montepy.org/starting.html" />
...
```

The update building on RTD now looks like:

``` html 
<html lang="en" data-content_root="./" >
  <head>
...
    <link rel="canonical" href="https://www.montepy.org/en/stable/starting.html" />
...
```

Related to: https://github.com/openmc-dev/openmc/pull/3324

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).
- [ ] I have formatted my code with `black` version 25.
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--672.org.readthedocs.build/en/672/

<!-- readthedocs-preview montepy end -->