### PR TITLE
Allow any Real type for floating point numbers and any Integral type for integer numbers during type enforcement

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -22,7 +22,7 @@ MontePy Changelog
 * Automatically added children objects, e.g., the surfaces in a cell, to the problem when the cell is added to the problem (:issue:`63`).
 * Added ability to parse all MCNP objects from a string (:issue:`88`).
 * Added function: :func:`~montepy.mcnp_problem.MCNP_Problem.parse` to parse arbitrary MCNP object (:issue:`88`).
-* An error is now raised when typos in object attributes are used, e.g., ``cell.number`` (:issue:`508`).
+* An error is now raised when typos in object attributes are used, e.g., ``cell.nubmer`` (:issue:`508`).
 * Warnings are no longer raised for comments that exceed the maximum line lengths (:issue:`188`).
 * Particle type exceptions are now warnings, not errors (:issue:`381`).
 * Allow any ``Real`` type for floating point numbers and any ``Integral`` type for integer numbers during type enforcement (:issue:`679`).

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -22,9 +22,10 @@ MontePy Changelog
 * Automatically added children objects, e.g., the surfaces in a cell, to the problem when the cell is added to the problem (:issue:`63`).
 * Added ability to parse all MCNP objects from a string (:issue:`88`).
 * Added function: :func:`~montepy.mcnp_problem.MCNP_Problem.parse` to parse arbitrary MCNP object (:issue:`88`).
-* An error is now raised when typos in object attributes are used, e.g., ``cell.nubmer`` (:issue:`508`).
+* An error is now raised when typos in object attributes are used, e.g., ``cell.number`` (:issue:`508`).
 * Warnings are no longer raised for comments that exceed the maximum line lengths (:issue:`188`).
 * Particle type exceptions are now warnings, not errors (:issue:`381`).
+* Allow any ``Real`` type for floating point numbers and any ``Integral`` type for integer numbers during type enforcement (:issue:`679`).
 
 
 **Bugs Fixed**

--- a/montepy/cell.py
+++ b/montepy/cell.py
@@ -1,13 +1,11 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 import copy
 import itertools
-import numbers
 from typing import Union
+from numbers import Integral, Real
 
-import montepy
 from montepy.cells import Cells
-from montepy.constants import BLANK_SPACE_CONTINUE
 from montepy.data_inputs import importance, fill, lattice_input, universe_input, volume
 from montepy.data_inputs.data_parser import PREFIX_MATCHES
 from montepy.input_parser.cell_parser import CellParser
@@ -442,7 +440,7 @@ class Cell(Numbered_MCNP_Object):
 
     @atom_density.setter
     def atom_density(self, density: float):
-        if not isinstance(density, numbers.Number):
+        if not isinstance(density, Real):
             raise TypeError("Atom density must be a number.")
         elif density < 0:
             raise ValueError("Atom density must be a positive number.")
@@ -467,7 +465,7 @@ class Cell(Numbered_MCNP_Object):
 
     @mass_density.setter
     def mass_density(self, density: float):
-        if not isinstance(density, numbers.Number):
+        if not isinstance(density, Real):
             raise TypeError("Mass density must be a number.")
         elif density < 0:
             raise ValueError("Mass density must be a positive number.")
@@ -591,7 +589,7 @@ class Cell(Numbered_MCNP_Object):
         new_deleting_dict = {}
 
         def get_num(obj):
-            if isinstance(obj, int):
+            if isinstance(obj, Integral):
                 return obj
             return obj.number
 
@@ -800,11 +798,11 @@ class Cell(Numbered_MCNP_Object):
             )
         if not isinstance(clone_region, bool):
             raise TypeError(f"clone_region must be a boolean. {clone_region} given.")
-        if not isinstance(starting_number, (int, type(None))):
+        if not isinstance(starting_number, (Integral, type(None))):
             raise TypeError(
                 f"Starting_number must be an int. {type(starting_number)} given."
             )
-        if not isinstance(step, (int, type(None))):
+        if not isinstance(step, (Integral, type(None))):
             raise TypeError(f"step must be an int. {type(step)} given.")
         if starting_number is not None and starting_number <= 0:
             raise ValueError(f"starting_number must be >= 1. {starting_number} given.")
@@ -832,7 +830,7 @@ class Cell(Numbered_MCNP_Object):
         memo = {}
 
         def num(obj):
-            if isinstance(obj, int):
+            if isinstance(obj, Integral):
                 return obj
             return obj.number
 

--- a/montepy/cell.py
+++ b/montepy/cell.py
@@ -1,4 +1,4 @@
-# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 import copy
 import itertools

--- a/montepy/cells.py
+++ b/montepy/cells.py
@@ -1,4 +1,4 @@
-# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 import montepy
 from montepy.numbered_object_collection import NumberedObjectCollection
 from montepy.errors import *

--- a/montepy/cells.py
+++ b/montepy/cells.py
@@ -1,8 +1,9 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 import montepy
 from montepy.numbered_object_collection import NumberedObjectCollection
 from montepy.errors import *
 import warnings
+from numbers import Integral
 
 
 class Cells(NumberedObjectCollection):
@@ -64,9 +65,9 @@ class Cells(NumberedObjectCollection):
             raise TypeError("vacuum_cells must be a list or set")
         cells_buff = set()
         for cell in vacuum_cells:
-            if not isinstance(cell, (montepy.Cell, int)):
+            if not isinstance(cell, (montepy.Cell, Integral)):
                 raise TypeError("vacuum cell must be a Cell or a cell number")
-            if isinstance(cell, int):
+            if isinstance(cell, Integral):
                 cells_buff.add(self[cell])
             else:
                 cells_buff.add(cell)
@@ -214,11 +215,11 @@ class Cells(NumberedObjectCollection):
         :rtype: type(self)
 
         """
-        if not isinstance(starting_number, (int, type(None))):
+        if not isinstance(starting_number, (Integral, type(None))):
             raise TypeError(
                 f"Starting_number must be an int. {type(starting_number)} given."
             )
-        if not isinstance(step, (int, type(None))):
+        if not isinstance(step, (Integral, type(None))):
             raise TypeError(f"step must be an int. {type(step)} given.")
         if starting_number is not None and starting_number <= 0:
             raise ValueError(f"starting_number must be >= 1. {starting_number} given.")

--- a/montepy/data_inputs/element.py
+++ b/montepy/data_inputs/element.py
@@ -1,7 +1,8 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 from montepy.errors import *
 from montepy._singleton import SingletonGroup
+from numbers import Integral
 
 MAX_Z_NUM = 118
 
@@ -23,7 +24,7 @@ class Element(SingletonGroup):
     __slots__ = "_Z"
 
     def __init__(self, Z: int):
-        if not isinstance(Z, int):
+        if not isinstance(Z, Integral):
             raise TypeError(f"Z must be an int. {Z} of type {type(Z)} given.")
         self._Z = Z
         if Z not in self.__Z_TO_SYMBOL:

--- a/montepy/data_inputs/element.py
+++ b/montepy/data_inputs/element.py
@@ -1,4 +1,4 @@
-# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 from montepy.errors import *
 from montepy._singleton import SingletonGroup

--- a/montepy/data_inputs/material.py
+++ b/montepy/data_inputs/material.py
@@ -1,4 +1,4 @@
-# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 import collections as co
 import copy

--- a/montepy/data_inputs/nuclide.py
+++ b/montepy/data_inputs/nuclide.py
@@ -1,4 +1,4 @@
-# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from montepy.constants import MAX_ATOMIC_SYMBOL_LENGTH
 from montepy._singleton import SingletonGroup
 from montepy.data_inputs.element import Element

--- a/montepy/data_inputs/nuclide.py
+++ b/montepy/data_inputs/nuclide.py
@@ -1,17 +1,15 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from montepy.constants import MAX_ATOMIC_SYMBOL_LENGTH
 from montepy._singleton import SingletonGroup
 from montepy.data_inputs.element import Element
-from montepy.errors import *
 from montepy.utilities import *
 from montepy.input_parser.syntax_node import PaddingNode, ValueNode
 from montepy.particle import LibraryType
 
-import collections
 from functools import total_ordering
 import re
 from typing import Union
-import warnings
+from numbers import Real, Integral
 
 DEFAULT_NUCLIDE_WIDTH = 11
 """
@@ -221,12 +219,12 @@ class Nucleus(SingletonGroup):
             )
         self._element = element
 
-        if not isinstance(A, int):
+        if not isinstance(A, Integral):
             raise TypeError(f"A number must be an int. {A} given.")
         if A < 0:
             raise ValueError(f"A cannot be negative. {A} given.")
         self._A = A
-        if not isinstance(meta_state, (int, type(None))):
+        if not isinstance(meta_state, (Integral, type(None))):
             raise TypeError(f"Meta state must be an int. {meta_state} given.")
         if A == 0 and meta_state != 0:
             raise ValueError(
@@ -328,7 +326,7 @@ class Nucleus(SingletonGroup):
 
     def __lt__(self, other):
         if not isinstance(other, type(self)):
-            raise TypeError("")
+            raise TypeError
         return (self.Z, self.A, self.meta_state) < (other.Z, other.A, other.meta_state)
 
     def __str__(self):
@@ -446,7 +444,7 @@ class Nuclide:
     :param node: The ValueNode to build this off of. Should only be used by MontePy.
     :type node: ValueNode
 
-    :raises TypeError: if an parameter is the wrong type.
+    :raises TypeError: if a parameter is the wrong type.
     :raises ValueError: if non-sensical values are given.
     """
 
@@ -487,7 +485,7 @@ class Nuclide:
         self._library = Library("")
         ZAID = ""
 
-        if not isinstance(name, (str, int, Element, Nucleus, Nuclide, type(None))):
+        if not isinstance(name, (str, Integral, Element, Nucleus, Nuclide, type(None))):
             raise TypeError(
                 f"Name must be str, int, Element, or Nucleus. {name} of type {type(name)} given."
             )
@@ -739,7 +737,7 @@ class Nuclide:
         A = 0
         isomer = 0
         library = ""
-        if isinstance(identifier, (int, float)):
+        if isinstance(identifier, Real):
             if identifier > _ZAID_A_ADDER:
                 parts = Nuclide._parse_zaid(int(identifier))
                 element, A, isomer = (

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -1,4 +1,4 @@
-# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from abc import ABC, abstractmethod
 import re
 import warnings

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -1,10 +1,13 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from abc import ABC, abstractmethod
+import re
+import warnings
 import collections
 import copy
 import itertools as it
 import enum
 import math
+from numbers import Integral, Real
 
 from montepy import input_parser
 from montepy import constants
@@ -14,8 +17,6 @@ from montepy.input_parser.shortcuts import Shortcuts
 from montepy.geometry_operators import Operator
 from montepy.particle import Particle
 from montepy.utilities import fortran_float
-import re
-import warnings
 
 
 class SyntaxNodeBase(ABC):
@@ -1091,7 +1092,7 @@ class ValueNode(SyntaxNodeBase):
             token = self._token
             if isinstance(token, input_parser.mcnp_input.Jump):
                 token = "J"
-            if isinstance(token, (int, float)):
+            if isinstance(token, (Integral, Real)):
                 token = str(token)
             self._formatter["value_length"] = len(token)
             if self.padding:
@@ -1115,7 +1116,7 @@ class ValueNode(SyntaxNodeBase):
 
     def _reverse_engineer_float(self):
         token = self._token
-        if isinstance(token, float):
+        if isinstance(token, Real):
             token = str(token)
         if isinstance(token, input_parser.mcnp_input.Jump):
             token = "J"
@@ -1378,7 +1379,7 @@ class ValueNode(SyntaxNodeBase):
             self.padding = PaddingNode(" ")
 
     def __eq__(self, other):
-        if not isinstance(other, (type(self), str, int, float)):
+        if not isinstance(other, (type(self), str, Real)):
             return False
         if isinstance(other, ValueNode):
             other_val = other.value

--- a/montepy/materials.py
+++ b/montepy/materials.py
@@ -1,9 +1,10 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 
 from __future__ import annotations
 import collections as co
 import copy
 from typing import Generator, Union
+from numbers import Integral, Real
 
 import montepy
 from montepy.numbered_object_collection import NumberedDataObjectCollection
@@ -292,7 +293,7 @@ class Materials(NumberedDataObjectCollection):
         if not isinstance(fractions, list):
             raise TypeError(f"fractions must be a list. {fractions} given.")
         for frac in fractions:
-            if not isinstance(frac, float):
+            if not isinstance(frac, Real):
                 raise TypeError(f"fraction in fractions must be a float. {frac} given.")
             if frac < 0.0:
                 raise ValueError(f"Fraction cannot be negative. {frac} given.")
@@ -300,7 +301,7 @@ class Materials(NumberedDataObjectCollection):
             raise ValueError(
                 f"Length of materials and fractions don't match. The lengths are, materials: {len(materials)}, fractions: {len(fractions)}"
             )
-        if not isinstance(starting_number, (int, type(None))):
+        if not isinstance(starting_number, (Integral, type(None))):
             raise TypeError(
                 f"starting_number must be an int. {starting_number} of type {type(starting_number)} given."
             )
@@ -308,7 +309,7 @@ class Materials(NumberedDataObjectCollection):
             raise ValueError(
                 f"starting_number must be positive. {starting_number} given."
             )
-        if not isinstance(step, (int, type(None))):
+        if not isinstance(step, (Integral, type(None))):
             raise TypeError(f"step must be an int. {step} of type {type(step)} given.")
         if step is not None and step <= 0:
             raise ValueError(f"step must be positive. {step} given.")

--- a/montepy/materials.py
+++ b/montepy/materials.py
@@ -1,4 +1,4 @@
-# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 
 from __future__ import annotations
 import collections as co

--- a/montepy/numbered_mcnp_object.py
+++ b/montepy/numbered_mcnp_object.py
@@ -1,4 +1,4 @@
-# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 from abc import abstractmethod
 import copy

--- a/montepy/numbered_mcnp_object.py
+++ b/montepy/numbered_mcnp_object.py
@@ -1,12 +1,11 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 from abc import abstractmethod
 import copy
 import itertools
 from typing import Union
+from numbers import Integral
 
-
-from montepy.errors import NumberConflictError
 from montepy.mcnp_object import MCNP_Object, InitInput
 import montepy
 from montepy.utilities import *
@@ -61,7 +60,7 @@ class Numbered_MCNP_Object(MCNP_Object):
 
     def _load_init_num(self, number):
         if number is not None:
-            if not isinstance(number, int):
+            if not isinstance(number, Integral):
                 raise TypeError(
                     f"Number must be an int. {number} of type {type(number)} given."
                 )
@@ -146,11 +145,11 @@ class Numbered_MCNP_Object(MCNP_Object):
         :rtype: type(self)
 
         """
-        if not isinstance(starting_number, (int, type(None))):
+        if not isinstance(starting_number, (Integral, type(None))):
             raise TypeError(
                 f"Starting_number must be an int. {type(starting_number)} given."
             )
-        if not isinstance(step, (int, type(None))):
+        if not isinstance(step, (Integral, type(None))):
             raise TypeError(f"step must be an int. {type(step)} given.")
         if starting_number is not None and starting_number <= 0:
             raise ValueError(f"starting_number must be >= 1. {starting_number} given.")

--- a/montepy/numbered_mcnp_object.py
+++ b/montepy/numbered_mcnp_object.py
@@ -72,7 +72,7 @@ class Numbered_MCNP_Object(MCNP_Object):
     """
     """
 
-    @make_prop_val_node("_number", int, validator=_number_validator)
+    @make_prop_val_node("_number", Integral, validator=_number_validator)
     def number(self):
         """
         The current number of the object that will be written out to a new input.

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -1,9 +1,10 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
-from abc import ABC, abstractmethod
+from abc import ABC
 import itertools as it
 import typing
 import weakref
+from numbers import Integral
 
 import montepy
 from montepy.numbered_mcnp_object import Numbered_MCNP_Object
@@ -229,7 +230,7 @@ class NumberedObjectCollection(ABC):
         :type number: int
         :raises NumberConflictError: if this number is in use.
         """
-        if not isinstance(number, int):
+        if not isinstance(number, Integral):
             raise TypeError("The number must be an int")
         conflict = False
         # only can trust cache if being
@@ -282,7 +283,7 @@ class NumberedObjectCollection(ABC):
         :return: the final elements
         :rtype: Numbered_MCNP_Object
         """
-        if not isinstance(pos, int):
+        if not isinstance(pos, Integral):
             raise TypeError("The index for popping must be an int")
         obj = self._objects[pos]
         self.__internal_delete(obj)
@@ -362,11 +363,11 @@ class NumberedObjectCollection(ABC):
         :rtype: type(self)
 
         """
-        if not isinstance(starting_number, (int, type(None))):
+        if not isinstance(starting_number, (Integral, type(None))):
             raise TypeError(
                 f"Starting_number must be an int. {type(starting_number)} given."
             )
-        if not isinstance(step, (int, type(None))):
+        if not isinstance(step, (Integral, type(None))):
             raise TypeError(f"step must be an int. {type(step)} given.")
         if starting_number is not None and starting_number <= 0:
             raise ValueError(f"starting_number must be >= 1. {starting_number} given.")
@@ -550,7 +551,7 @@ class NumberedObjectCollection(ABC):
         """
         if not isinstance(obj, self._obj_class):
             raise TypeError(f"object being appended must be of type: {self._obj_class}")
-        if not isinstance(step, int):
+        if not isinstance(step, Integral):
             raise TypeError("The step number must be an int")
         number = obj.number
         if self._problem:
@@ -585,9 +586,9 @@ class NumberedObjectCollection(ABC):
         :returns: an available number
         :rtype: int
         """
-        if not isinstance(start_num, (int, type(None))):
+        if not isinstance(start_num, (Integral, type(None))):
             raise TypeError("start_num must be an int")
-        if not isinstance(step, (int, type(None))):
+        if not isinstance(step, (Integral, type(None))):
             raise TypeError("step must be an int")
         if start_num is None:
             start_num = self.starting_number
@@ -611,7 +612,7 @@ class NumberedObjectCollection(ABC):
         :param step: how much to increase the last number by
         :type step: int
         """
-        if not isinstance(step, int):
+        if not isinstance(step, Integral):
             raise TypeError("step must be an int")
         if step <= 0:
             raise ValueError("step must be > 0")
@@ -657,7 +658,7 @@ class NumberedObjectCollection(ABC):
     def __getitem__(self, i):
         if isinstance(i, slice):
             return self.__get_slice(i)
-        elif not isinstance(i, int):
+        elif not isinstance(i, Integral):
             raise TypeError("index must be an int or slice")
         ret = self.get(i)
         if ret is None:
@@ -665,13 +666,13 @@ class NumberedObjectCollection(ABC):
         return ret
 
     def __delitem__(self, idx):
-        if not isinstance(idx, int):
+        if not isinstance(idx, Integral):
             raise TypeError("index must be an int")
         obj = self[idx]
         self.__internal_delete(obj)
 
     def __setitem__(self, key, newvalue):
-        if not isinstance(key, int):
+        if not isinstance(key, Integral):
             raise TypeError("index must be an int")
         self.append(newvalue)
 

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -1,4 +1,4 @@
-# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 from abc import ABC
 import itertools as it

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -385,7 +385,7 @@ class NumberedObjectCollection(ABC):
             starting_number = new_obj.number + step
         return type(self)(objs)
 
-    @make_prop_pointer("_start_num", int, validator=_enforce_positive)
+    @make_prop_pointer("_start_num", Integral, validator=_enforce_positive)
     def starting_number(self):
         """
         The starting number to use when an object is cloned.
@@ -395,7 +395,7 @@ class NumberedObjectCollection(ABC):
         """
         pass
 
-    @make_prop_pointer("_step", int, validator=_enforce_positive)
+    @make_prop_pointer("_step", Integral, validator=_enforce_positive)
     def step(self):
         """
         The step size to use to find a valid number during cloning.

--- a/montepy/surfaces/cylinder_par_axis.py
+++ b/montepy/surfaces/cylinder_par_axis.py
@@ -1,4 +1,4 @@
-# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from .surface_type import SurfaceType
 from .surface import Surface, InitInput
 from montepy.errors import *

--- a/montepy/surfaces/cylinder_par_axis.py
+++ b/montepy/surfaces/cylinder_par_axis.py
@@ -1,8 +1,10 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from .surface_type import SurfaceType
 from .surface import Surface, InitInput
 from montepy.errors import *
 from montepy.utilities import *
+
+from numbers import Real
 
 
 def _enforce_positive_radius(self, value):
@@ -70,14 +72,12 @@ class CylinderParAxis(Surface):
         if len(coordinates) != 2:
             raise ValueError("coordinates must have exactly two elements")
         for val in coordinates:
-            if not isinstance(val, (float, int)):
+            if not isinstance(val, Real):
                 raise TypeError(f"Coordinate must be a number. {val} given.")
         for i, val in enumerate(coordinates):
             self._coordinates[i].value = val
 
-    @make_prop_val_node(
-        "_radius", (float, int), float, validator=_enforce_positive_radius
-    )
+    @make_prop_val_node("_radius", (Real,), float, validator=_enforce_positive_radius)
     def radius(self):
         """
         The radius of the cylinder.

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -1,4 +1,4 @@
-# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 import montepy
 from montepy.errors import *

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -1,4 +1,4 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 import montepy
 from montepy.errors import *
@@ -10,6 +10,8 @@ from montepy.input_parser.syntax_node import (
     CommentNode,
 )
 from montepy.utilities import *
+
+from numbers import Integral
 
 
 class HalfSpace:
@@ -578,7 +580,7 @@ class UnitHalfSpace(HalfSpace):
                 side = "+"
         else:
             side = "-"
-        if isinstance(self.divider, int):
+        if isinstance(self.divider, Integral):
             div = self.divider
         else:
             div = self.divider.number
@@ -643,7 +645,7 @@ class UnitHalfSpace(HalfSpace):
         if self._is_cell:
             container = cells
             par_container = self._cell.complements
-        if isinstance(self.divider, int):
+        if isinstance(self.divider, Integral):
             try:
                 self._divider = container[self._divider]
                 if self._divider not in par_container:
@@ -659,7 +661,7 @@ class UnitHalfSpace(HalfSpace):
 
     def _ensure_has_nodes(self):
         if self.node is None:
-            if isinstance(self.divider, int):
+            if isinstance(self.divider, Integral):
                 num = self.divider
             else:
                 num = self.divider.number
@@ -670,7 +672,7 @@ class UnitHalfSpace(HalfSpace):
             self._node = node
 
     def _update_node(self):
-        if isinstance(self.divider, int):
+        if isinstance(self.divider, Integral):
             self._node.value = self.divider
         else:
             self._node.value = self.divider.number
@@ -721,7 +723,7 @@ class UnitHalfSpace(HalfSpace):
         """
 
         def num(obj):
-            if isinstance(obj, int):
+            if isinstance(obj, Integral):
                 return obj
             return obj.number
 

--- a/montepy/surfaces/surface.py
+++ b/montepy/surfaces/surface.py
@@ -1,4 +1,4 @@
-# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 import copy
 from typing import Union

--- a/montepy/surfaces/surface.py
+++ b/montepy/surfaces/surface.py
@@ -1,13 +1,12 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 import copy
-import re
 from typing import Union
+from numbers import Real
 
 import montepy
 from montepy.errors import *
 from montepy.data_inputs import transform
-from montepy.input_parser import syntax_node
 from montepy.input_parser.surface_parser import SurfaceParser
 from montepy.numbered_mcnp_object import Numbered_MCNP_Object, InitInput
 from montepy.surfaces import half_space
@@ -156,7 +155,7 @@ class Surface(Numbered_MCNP_Object):
         if len(constants) != len(self._surface_constants):
             raise ValueError(f"Cannot change the length of the surface constants.")
         for constant in constants:
-            if not isinstance(constant, float):
+            if not isinstance(constant, Real):
                 raise TypeError(
                     f"The surface constant provided: {constant} must be a float"
                 )

--- a/montepy/universe.py
+++ b/montepy/universe.py
@@ -1,10 +1,12 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 import montepy
 from montepy.cells import Cells
 from montepy.input_parser.mcnp_input import Input
 from montepy.input_parser.block_type import BlockType
 from montepy.input_parser import syntax_node
 from montepy.numbered_mcnp_object import Numbered_MCNP_Object
+
+from numbers import Integral
 
 
 class Universe(Numbered_MCNP_Object):
@@ -18,7 +20,7 @@ class Universe(Numbered_MCNP_Object):
 
     def __init__(self, number: int):
         self._number = self._generate_default_node(int, -1)
-        if not isinstance(number, int):
+        if not isinstance(number, Integral):
             raise TypeError("number must be int")
         if number < 0:
             raise ValueError(f"Universe number must be ≥ 0. {number} given.")

--- a/montepy/universe.py
+++ b/montepy/universe.py
@@ -1,4 +1,4 @@
-# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 import montepy
 from montepy.cells import Cells
 from montepy.input_parser.mcnp_input import Input

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -1,0 +1,23 @@
+# Copyright 2025, Battelle Energy Alliance, LLC All Rights Reserved.
+
+import montepy
+import pytest
+import numpy as np
+
+
+def test_cell_integral():
+    montepy.Cell(number=3)
+    montepy.Cell(number=np.uint8(1))
+    with pytest.raises(TypeError):
+        montepy.Cell(number=5.0)
+
+
+def test_cell_real():
+    c = montepy.Cell()
+    c.atom_density = 1
+    c.mass_density = np.float32(1.2e-3)
+
+
+def test_surf_coeff_real():
+    cx = montepy.CylinderParAxis()
+    cx.coordinates = (0, np.int16(-1.23))


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

Previously, floating point numbers were enforced as the `float` type and integer numbers were enforced as the `int` type during `isinstance(...)` checking. Now, floating point numbers can be any `Real` type, such as `int`, `uint8`, and `float64`. Similarly, integer numbers can be any `Integral` type, such as `uint8` and `int64`. This leverages the builtin `numbers` module.

Fixes #679.

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).
- [x] I have formatted my code with `black` version 25.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

### Additional Notes for Reviewers

Ensure that:

- [x] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
- [x] The PR covers all relevant aspects according to the development guidelines.
- [x] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--680.org.readthedocs.build/en/680/

<!-- readthedocs-preview montepy end -->