### PR TITLE
Fixed bug where lat, fill, universe not always exporting. 

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -33,6 +33,7 @@ MontePy Changelog
 
 * Made it so that a material created from scratch can be written to file (:issue:`512`).
 * Added support for parsing materials with parameters mixed throughout the definition (:issue:`182`).
+* Fixed bug where setting a lattice would print as ``LAT=None``. Also switched ``CellModifier`` to print in the cell block by default (:issue:`699`). 
  
 **Breaking Changes**
 

--- a/doc/source/starting.rst
+++ b/doc/source/starting.rst
@@ -607,6 +607,11 @@ This acts like a dictionary where the key is the MCNP card name.
 So to make cell importance data show up in the cell block just run:
 ``problem.print_in_data_block["imp"] = False``.
 
+.. note::
+
+   The default for :func:`~montepy.mcnp_problem.MCNP_Problem.print_in_data_block` is ``False``,
+   that is to print the data in the cell block if this was not set in the input file or by the user.
+
 Density
 ^^^^^^^
 This gets a bit more complicated.

--- a/montepy/_cell_data_control.py
+++ b/montepy/_cell_data_control.py
@@ -15,7 +15,7 @@ class CellDataPrintController:
             try:
                 return self._print_data[key.lower()]
             except KeyError:
-                return True
+                return False
         else:
             raise KeyError(f"{key} is not a supported cell modifier in MCNP")
 

--- a/montepy/_cell_data_control.py
+++ b/montepy/_cell_data_control.py
@@ -12,10 +12,7 @@ class CellDataPrintController:
         if not isinstance(key, str):
             raise TypeError("Key must be a str")
         if key.upper() in montepy.Cell._ALLOWED_KEYWORDS:
-            try:
-                return self._print_data[key.lower()]
-            except KeyError:
-                return False
+            return self._print_data.get(key.lower(), False)
         else:
             raise KeyError(f"{key} is not a supported cell modifier in MCNP")
 

--- a/montepy/cell.py
+++ b/montepy/cell.py
@@ -143,6 +143,8 @@ class Cell(Numbered_MCNP_Object):
         self._density_node.is_negatable_float = True
         if self.old_mat_number != 0:
             self._is_atom_dens = not self._density_node.is_negative
+        else:
+            self._is_atom_dens = None
         self._parse_geometry()
         self._parse_keyword_modifiers()
 

--- a/montepy/data_inputs/lattice_input.py
+++ b/montepy/data_inputs/lattice_input.py
@@ -33,8 +33,7 @@ class LatticeInput(CellModifierInput):
         value: syntax_node.SyntaxNode = None,
     ):
         super().__init__(input, in_cell_block, key, value)
-        self._lattice = self._generate_default_node(int, None)
-        self._lattice._convert_to_enum(Lattice, True, int)
+        self._lattice = self._tree["data"][0]
         if self.in_cell_block:
             if key:
                 try:

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -277,9 +277,19 @@ class MCNP_Problem:
 
         ``problem.print_in_data_block["Imp"] = True``
 
+
+        .. note::
+           
+           The default for this is ``False``,
+           that is to print the data in the cell block if this was not set in the input file or by the user.
+    
+        .. versionchanged:: 1.0.0
+
+            Default value changed to ``False``
+
         Returns
         -------
-        bool
+        dict[str, bool]
         """
         return self._print_in_data_block
 

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -279,10 +279,10 @@ class MCNP_Problem:
 
 
         .. note::
-           
+
            The default for this is ``False``,
            that is to print the data in the cell block if this was not set in the input file or by the user.
-    
+
         .. versionchanged:: 1.0.0
 
             Default value changed to ``False``

--- a/tests/inputs/test_interp_edge.imcnp
+++ b/tests/inputs/test_interp_edge.imcnp
@@ -6,3 +6,4 @@ Surface interpolate edge case
 3 CZ 0
 4 CZ 0
 
+imp:n 0

--- a/tests/test_cell_problem.py
+++ b/tests/test_cell_problem.py
@@ -343,7 +343,7 @@ def verify_export(cell):
     print("cell output", output)
     new_cell = montepy.Cell("\n".join(output))
     for attr in {
-        "old_number",
+        "number",
         "old_mat_number",
         "old_universe_number",
         "lattice",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -889,6 +889,7 @@ def test_lattice_format_data(simple_problem):
     cells = problem.cells
     cells[1].lattice = 1
     cells[99].lattice = 2
+    problem.print_in_data_block["lat"] = True
     answer = "LAT 1 2J 2"
     output = cells._lattice.format_for_mcnp_input((6, 2, 0))
     assert answer in output[0]

--- a/tests/test_universe_integration.py
+++ b/tests/test_universe_integration.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+import pytest
+from tests.test_cell_problem import verify_export as cell_verify
+
+import montepy
+from montepy import Cell
+from montepy import Universe
+
+
+@pytest.fixture
+def basic_parsed_cell():
+    return Cell("1 0 -2 imp:n=1")
+
+
+@pytest.fixture
+def basic_cell():
+    cell = montepy.Cell(number=1)
+    sphere = montepy.Surface("1 SO 10.0")
+    cell.geometry = -sphere
+    cell.importance.neutron = 1.0
+    return cell
+
+
+@pytest.fixture
+def cells(basic_parsed_cell, basic_cell):
+    return (basic_parsed_cell, basic_cell)
+
+
+def test_universe_setter(cells):
+    for basic_cell in cells:
+        uni = Universe(5)
+        basic_cell.universe = uni
+        cell_verify(basic_cell)
+
+
+def test_fill_setter(cells):
+    for basic_cell in cells:
+        uni = Universe(5)
+        basic_cell.fill.universe = uni
+        cell_verify(basic_cell)
+
+
+def test_lattice_setter(cells):
+    for basic_cell in cells:
+        basic_cell.lattice = montepy.data_inputs.lattice.Lattice.HEXAHEDRA
+        cell_verify(basic_cell)
+
+
+def test_uni_fill_latt_setter(cells):
+    for basic_cell in cells:
+        base_uni = montepy.Universe(1)
+        lat_uni = montepy.Universe(2)
+        basic_cell.lattice = montepy.data_inputs.lattice.Lattice.HEXAHEDRA
+        basic_cell.fill.universe = base_uni
+        basic_cell.universe = lat_uni
+        cell_verify(basic_cell)
+
+
+def test_mc_workshop_edge_case():
+    problem = montepy.read_input(Path("demo") / "pin_cell.imcnp")
+    # grab surfaces
+    universe = montepy.Universe(1)
+    universe.claim(problem.cells)
+    problem.universes.append(universe)
+    surfs = problem.surfaces
+    right_surf = surfs[104]
+    left_surf = surfs[103]
+    y_top_surf = surfs[106]
+    y_bot_surf = surfs[105]
+    z_top_surf = surfs[102]
+    z_bot_surf = surfs[101]
+    # define cell
+    unit_cell = montepy.Cell()
+    unit_cell.number = problem.cells.request_number()
+    problem.cells.append(unit_cell)
+    unit_cell.geometry = -right_surf & +left_surf
+    unit_cell.geometry &= -y_top_surf & +y_bot_surf
+    unit_cell.geometry &= -z_top_surf & +z_bot_surf
+    unit_cell.importance.neutron = 1.0
+    # set fill and stuff
+    unit_cell.lattice = montepy.data_inputs.lattice.Lattice.HEXAHEDRA
+    unit_cell.fill.universe = universe
+    # assign to own universe
+    lat_universe = montepy.Universe(5)
+    problem.universes.append(lat_universe)
+    unit_cell.universe = lat_universe
+    cell_verify(unit_cell)


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This fixes a few bugs with `LAT`, `FILL`, and `U`. The first is that I was getting `LAT=None`. This was fixed by ensuring that everyone was pointing to the same node in the syntax tree.

The other issue is that `problem.print_in_data_block` defaults to `True` which causes confusion for users (me). This default behavior was changed to default to the Cell block. 

Fixes #699

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).
- [x] I have formatted my code with `black` version 25.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [x] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--701.org.readthedocs.build/en/701/

<!-- readthedocs-preview montepy end -->