### PR TITLE
Allow setting multi-universe fills

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -38,6 +38,7 @@ MontePy Changelog
 * Fixed bug that wouldn't allow cloning most surfaces (:issue:`704`).
 * Fixed bug that crashed when some cells were not assigned to any universes (:issue:`705`).
 * Fixed bug where setting ``surf.is_reflecting`` to ``False`` did not always get exported properly (:issue:`709`).
+* Fixed bug where setting multiple universes for a cell fill not being properly exported (:issue:`714`).
  
 **Breaking Changes**
 

--- a/montepy/data_inputs/fill.py
+++ b/montepy/data_inputs/fill.py
@@ -1,5 +1,8 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024 - 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 import itertools as it
+from numbers import Integral, Real
+import numpy as np
+
 from montepy.data_inputs.cell_modifier import CellModifierInput, InitInput
 from montepy.data_inputs.transform import Transform
 from montepy.errors import *
@@ -9,7 +12,14 @@ from montepy.input_parser import syntax_node
 from montepy.mcnp_object import MCNP_Object
 from montepy.universe import Universe
 from montepy.utilities import *
-import numpy as np
+
+
+def _verify_3d_index(self, indices):
+    for index in indices:
+        if not isinstance(index, Integral):
+            raise TypeError(f"Index values for fill must be an int. {index} given.")
+    if len(indices) != 3:
+        raise ValueError(f"3 values must be given for fill. {indices} given")
 
 
 class Fill(CellModifierInput):
@@ -269,7 +279,12 @@ class Fill(CellModifierInput):
     def universes(self):
         self._universes = None
 
-    @property
+    @make_prop_pointer(
+        "_min_index",
+        (list, np.ndarray),
+        validator=_verify_3d_index,
+        deletable=True,
+    )
     def min_index(self):
         """The minimum indices of the matrix in each dimension.
 
@@ -280,9 +295,14 @@ class Fill(CellModifierInput):
         :class:`numpy.ndarry`
             the minimum indices of the matrix for complex fills
         """
-        return self._min_index
+        pass
 
-    @property
+    @make_prop_pointer(
+        "_max_index",
+        (list, np.ndarray),
+        validator=_verify_3d_index,
+        deletable=True,
+    )
     def max_index(self):
         """The maximum indices of the matrix in each dimension.
 
@@ -293,7 +313,7 @@ class Fill(CellModifierInput):
         :class:`numpy.ndarry`
             the maximum indices of the matrix for complex fills
         """
-        return self._max_index
+        pass
 
     @property
     def multiple_universes(self):

--- a/montepy/data_inputs/fill.py
+++ b/montepy/data_inputs/fill.py
@@ -271,20 +271,23 @@ class Fill(CellModifierInput):
     def universes(self, value):
         if not isinstance(value, (np.ndarray, type(None))):
             raise TypeError(f"Universes must be set to an array. {value} given.")
-        if len(value.shape) != 3:
+        if value.ndim != 3:
             raise ValueError(
                 f"3D array must be given for fill.universes. Array of shape: {value.shape} given."
             )
-        if value.dtype != np.object_ or any(
-            map(lambda x: not isinstance(x, (Universe, type(None))), value.flatten())
-        ):
+
+        def is_universes(array):
+            type_checker = lambda x: isinstance(x, (Universe, type(None)))
+            return map(type_checker, array.flat)
+
+        if value.dtype != np.object_ or not all(is_universes(value)):
             raise TypeError(
                 f"All values in array must be a Universe (or None). {value} given."
             )
         self.multiple_universes = True
         if self.min_index is None:
             self.min_index = np.array([0] * 3)
-        self.max_index = self.min_index + np.array(value.shape) - np.array([1, 1, 1])
+        self.max_index = self.min_index + np.array(value.shape) - 1
         self._universes = value
 
     @universes.deleter

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -1,4 +1,4 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024 - 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from hypothesis import given, strategies as st
 import pytest
 from unittest import TestCase
@@ -402,7 +402,7 @@ class TestFill(TestCase):
         end = np.array(indices) + np.array(width)
         fill.max_index = end
         assert fill.min_index == indices
-        assert fill.max_index == end
+        assert (fill.max_index == end).all()
 
     def test_fill_index_bad_setter(self):
         fill = self.simple_fill
@@ -435,10 +435,14 @@ class TestFill(TestCase):
         self.verify_export(fill)
 
     def verify_export(self, fill):
-        output = fill.format_for_mcnp_input((6,3,0))
+        output = fill.format_for_mcnp_input((6, 3, 0))
         print(output)
-        cell = montepy.Cell("1 0 -2 "+ "\n".join(output))
-        for attr in ["multiple_universes", "old_universe_numbers", "old_universe_number"]:
+        cell = montepy.Cell("1 0 -2 " + "\n".join(output))
+        for attr in [
+            "multiple_universes",
+            "old_universe_numbers",
+            "old_universe_number",
+        ]:
             old_val = getattr(fill, attr)
             if "old" in attr:
                 if "s":

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -374,6 +374,10 @@ class TestFill(TestCase):
         with self.assertRaises(TypeError):
             fill.universes = "hi"
         fill.multiple_universes = False
+        with pytest.raises(ValueError):
+            fill.universes = np.array([1, 2])
+        with pytest.raises(TypeError):
+            fill.universes = np.array([[[1]]])
 
     def test_fill_str(self):
         input = Input(["1 0 -1 fill=0:1 0:1 0:1 1 2 3 4 5 6 7 8"], BlockType.CELL)


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This fixes a "bug" where setting `Fill.universes` was not properly exported. There was previously... an effort to implement this, which was not successful. This changed:

1. Making sure `min_index` and `max_index` is always accessible without crashing
2. Setting `min_index` and `max_index` whenever `universes` is set.
3. setting `mulitple_universes=True` whenever `universes` is set. 
4. `_update_cell_values` works properly. 

Fixes #714

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).
- [x] I have formatted my code with `black` version 25.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--717.org.readthedocs.build/en/717/

<!-- readthedocs-preview montepy end -->