### PR TITLE
Tested new line line expansion bug, #721.

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -37,7 +37,7 @@ MontePy Changelog
 * Fixed bug where setting a lattice would print as ``LAT=None``. Also switched ``CellModifier`` to print in the cell block by default (:issue:`699`). 
 * Fixed bug that wouldn't allow cloning most surfaces (:issue:`704`).
 * Fixed bug that crashed when some cells were not assigned to any universes (:issue:`705`).
-* Fixed bug where setting ``surf.is_reflecting`` to ``False`` did not always get exported properly (:issue:`709`).
+* Fixed bug where setting ``surf.is_reflecting`` to ``False`` did not always get exported properly (:issue:`709`). 
 * Fixed bug where setting multiple universes for a cell fill not being properly exported (:issue:`714`).
  
 **Breaking Changes**

--- a/montepy/data_inputs/data_input.py
+++ b/montepy/data_inputs/data_input.py
@@ -127,7 +127,7 @@ class DataInputAbstract(MCNP_Object):
 
     @property
     def particle_classifiers(self):
-        """The particle class part of the card identifier as a parsed list.
+        """The particle class part of the input identifier as a parsed list.
 
         This is parsed from the input that was read.
 
@@ -145,10 +145,11 @@ class DataInputAbstract(MCNP_Object):
 
     @property
     def prefix(self):
-        """The text part of the card identifier parsed from the input.
+        """The text part of the input identifier parsed from the input.
 
-        For example: for a material like: m20 the prefix is 'm'
+        For example: for a material like: ``m20`` the prefix is ``m``.
         this will always be lower case.
+        Can also be called the mnemonic.
 
         Returns
         -------

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -387,8 +387,8 @@ The new input was:\n\n"""
                         f"The line exceeded the maximum length allowed by MCNP, and was split. The line was:\n{line}"
                     )
                     warning.cause = "line"
-                    warning.og_value = line
-                    warning.new_value = buffer
+                    warning.og_value = "1 line"
+                    warning.new_value = f"{len(buffer)} lines"
                     warnings.warn(
                         warning,
                         LineExpansionWarning,

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,4 +1,4 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024 - 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 import copy
 import io
 import numpy as np

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,13 +1,14 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
 import copy
 import io
+import numpy as np
+from pathlib import Path
+import pytest
+import os
+from unittest import TestCase
+
 import montepy
 from montepy.errors import *
-from pathlib import Path
-import os
-
-import pytest
-from unittest import TestCase
 
 
 class EdgeCaseTests(TestCase):
@@ -239,3 +240,13 @@ def test_trailing_comment_edge():
         Path("tests") / "inputs" / "test_trail_comment_edge.imcnp"
     )
     assert len(problem.cells[2].leading_comments) == 3
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_expanding_new_line():
+    problem = montepy.read_input(Path("tests") / "inputs" / "test_universe.imcnp")
+    fill = problem.cells[1].fill
+    universes = [montepy.Universe(n) for n in range(300)]
+    fill.universes = np.array([[universes]])
+    with io.StringIO() as fh, pytest.warns(montepy.errors.LineExpansionWarning):
+        problem.write_problem(fh)


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This fixes a bug that was found when a line has to be wrapped (and so a `LineExpansionWarning` is raised). The issue is that the warning meta data was assumed to be a string, but was actually a `list` of all strings in the new wrapped form. This switched them to being strings by just summarizing the change in the number of lines in that expansion. I believe this bug was introduced with #658.

Fixes #721

(Good thing we didn't ship yesterday). 

### Example Warning

``` python
In [1]: import montepy
   ...: import numpy as np
   ...: problem = montepy.read_input("tests/inputs/test_universe.imcnp")
   ...: fill = problem.cells[1].fill
   ...: universes = [montepy.Universe(n) for n in range(300)]
   ...: fill.universes = np.array([[universes]])
   ...: problem.write_problem("test.imcnp", overwrite=True)
/home/mgale/dev/montepy/montepy/mcnp_problem.py:552: LineExpansionWarning: The input starting on Line 2 of: test.imcnp expanded.
The new input is:
         2| C cells
         3| c
         4| 1 1 20
         5|          -1000  $ dollar comment
         6|      imp:n,p=1 trcl=5
         7|      u=1 FILL=0:0 0:0 0:299 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36
         8|       37 38 39
         9|       40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80
        10|       81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115
        11|      116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146
        12|       147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176
        13|      177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207
        14|       208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227 228 229 230 231 232 233 234 235 236 237
        15|      238 239 240 241 242 243 244 245 246 247 248 249 250 251 252 253 254 255 256 257 258 259 260 261 262 263 264 265 266 267 268
        16|       269 270 271 272 273 274 275 276 277 278 279 280 281 282 283 284 285 286 287 288 289 290 291 292 293 294 295 296 297 298
        17|      299

      old values      new values
    --------------- ---------------
                  1              10
             1 line        10 lines

  self._write_to_stream(fh)
/home/mgale/dev/montepy/montepy/mcnp_problem.py:552: LineExpansionWarning: The input starting on Line 2 of: test.imcnp expanded.
The new input is:
         2| C cells
         3| c
         4| 1 1 20
         5|          -1000  $ dollar comment
         6|      imp:n,p=1 trcl=5
         7|      u=1 FILL=0:0 0:0 0:299 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36
         8|       37 38 39
         9|       40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80
        10|       81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115
        11|      116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146
        12|       147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176
        13|      177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207
        14|       208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227 228 229 230 231 232 233 234 235 236 237
        15|      238 239 240 241 242 243 244 245 246 247 248 249 250 251 252 253 254 255 256 257 258 259 260 261 262 263 264 265 266 267 268
        16|       269 270 271 272 273 274 275 276 277 278 279 280 281 282 283 284 285 286 287 288 289 290 291 292 293 294 295 296 297 298
        17|      299

  self._write_to_stream(fh)
```

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).
- [x] I have formatted my code with `black` version 25.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--723.org.readthedocs.build/en/723/

<!-- readthedocs-preview montepy end -->