### PR TITLE
Handled issue with fill matrices iterating in the wrong order. 

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -39,6 +39,7 @@ MontePy Changelog
 * Fixed bug that crashed when some cells were not assigned to any universes (:issue:`705`).
 * Fixed bug where setting ``surf.is_reflecting`` to ``False`` did not always get exported properly (:issue:`709`). 
 * Fixed bug where setting multiple universes for a cell fill not being properly exported (:issue:`714`).
+* Fixed bug where the ``i`` ("x") and ``k`` ("z") dimensions of multiple universe matrix ``fills`` were switched (:issue:`726`).
  
 **Breaking Changes**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -40,6 +40,7 @@ MontePy Changelog
 * Fixed bug where setting ``surf.is_reflecting`` to ``False`` did not always get exported properly (:issue:`709`). 
 * Fixed bug where setting multiple universes for a cell fill not being properly exported (:issue:`714`).
 * Fixed bug where the ``i`` ("x") and ``k`` ("z") dimensions of multiple universe matrix ``fills`` were switched (:issue:`726`).
+* Fixed bug 549 — corrected blank importance printing issue (:issue:`549`).
  
 **Breaking Changes**
 
@@ -72,12 +73,6 @@ MontePy Changelog
 
 0.5 releases
 ============
-
-#Next Version#
---------------
-**Bug Fixes**
-
-* Fixed bug 549 – corrected blank importance printing issue (:issue:`549`).
 
 0.5.5
 --------------

--- a/montepy/data_inputs/fill.py
+++ b/montepy/data_inputs/fill.py
@@ -199,9 +199,9 @@ class Fill(CellModifierInput):
                 )
         self._old_numbers = np.zeros(self._sizes, dtype=np.dtype(int))
         words = iter(words[9:])
-        for i in self._axis_range(0):
+        for k in self._axis_range(2):
             for j in self._axis_range(1):
-                for k in self._axis_range(2):
+                for i in self._axis_range(0):
                     val = next(words)
                     try:
                         val._convert_to_int()

--- a/montepy/data_inputs/fill.py
+++ b/montepy/data_inputs/fill.py
@@ -586,10 +586,9 @@ class Fill(CellModifierInput):
 
         if self.multiple_universes:
             payload = []
-            for i in self._axis_range(0):
-                for j in self._axis_range(1):
-                    for k in self._axis_range(2):
-                        payload.append(self.universes[i][j][k].number)
+            get_number = np.vectorize(lambda u: u.number)
+            # fortran flatten ensures that it is: i1,j1,k1  i2,j1,k1 ....
+            payload = get_number(self.universes).flatten("f").tolist()
         else:
             payload = [
                 (

--- a/montepy/data_inputs/fill.py
+++ b/montepy/data_inputs/fill.py
@@ -587,8 +587,7 @@ class Fill(CellModifierInput):
         if self.multiple_universes:
             payload = []
             get_number = np.vectorize(lambda u: u.number)
-            # fortran flatten ensures that it is: i1,j1,k1  i2,j1,k1 ....
-            payload = get_number(self.universes).flatten("f").tolist()
+            payload = get_number(self.universes).T.ravel()
         else:
             payload = [
                 (

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -285,7 +285,7 @@ class TestFill(TestCase):
         self.assertIsNone(fill.universe)
         self.assertEqual(fill.min_index[0], 0)
         self.assertEqual(fill.max_index[2], 1)
-        answer = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+        answer = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]).T
         self.assertTrue((fill.old_universe_numbers == answer).all())
         # test string universe
         with self.assertRaises(ValueError):

--- a/tests/test_universe_integration.py
+++ b/tests/test_universe_integration.py
@@ -1,4 +1,5 @@
 import io
+import numpy as np
 from pathlib import Path
 import pytest
 from tests.test_cell_problem import verify_export as cell_verify
@@ -107,3 +108,15 @@ def test_no_universe(cp_simple_problem):
     prob.print_in_data_block["u"] = True
     with io.StringIO() as fh:
         prob.write_problem(fh)
+
+
+def test_fill_multi_universe_order(cells):
+    for cell in cells:
+        numbers = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]).repeat(2, axis=2)
+        make_uni = lambda n: montepy.Universe(n)
+        unis = np.vectorize(make_uni)(numbers)
+        cell.fill.universes = unis
+        output = cell.format_for_mcnp_input((6, 2, 0))
+        words = " ".join(output).split()
+        new_universes = list(map(int, words[7:]))
+        assert (numbers.flatten("f") == new_universes).all()


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This is a fix for a misinterpretation of how iteration works essentially in `fill`. As discussed in section 5.5.5.3.1 of the 6.3.0 manual:

> Cell-card Form: FILL i1:i2 j1:j2 k1:k2 n1,1,1 n2,1,1 . . . ni1,j1,k1. . . ni2,j2,k2

This implies that you iterate over x, then y, then z: 

This is confirmed by the vignette (section 5.5.5.3.2):

```
FILL=0:2 1:2 0:1 4 4 2 $ i=0,1,2 for j=1 & k=0
               2 0 4 0 $ i=0,1,2 for j=2 & k=0
               3 0 3 3 $ i=0,1,2 for j=1 & k=1
               4 4 4 0 $ i=0,1,2 for j=2 & k=1
```

Mentally this is what I was trying to accomplish, but I foolishly tried to do:

``` python

for i in x_range:
    for j in y_range:
        for k in z_range:
```

When it should have been:

``` python
for k in z_range:
    for j in y_range:
        for i in x_range:
```

The latter fixed this. For exporting I switched to `np.flatten` to clean up the code. 

I did have to change one of the tests. This is because 3D arrays are really confusing to write out. 
The input in question is `Fill = 0:1 0: 0:1 1 2 3 4 5 6 7 8`, which feels like it should be:

``` python
array([[[1, 2],
        [3, 4]],

       [[5, 6],
        [7, 8]]])
```
However, in 3D matrices the lists `[1,2]` are in z not X, so this should actually be: 

``` python
array([[[1, 5],
        [3, 7]],

       [[2, 6],
        [4, 8]]])
```

However, these two matrices are the transposes of each other. 


Fixes #726

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).
- [x] I have formatted my code with `black` version 25.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--727.org.readthedocs.build/en/727/

<!-- readthedocs-preview montepy end -->