### PR TITLE
Rename Cell.lattice -> Cell.lattice_type and deprecate Cell.lattice

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -28,6 +28,7 @@ MontePy Changelog
 * Added :func:`~montepy.data_inputs.material.Material.clear` to ``Material`` to clear out all nuclides (:issue:`665`).
 * Allow any ``Real`` type for floating point numbers and any ``Integral`` type for integer numbers during type enforcement (:issue:`679`).
 * Avoided multiple ``LineExpansionWarnings`` coming from the same object on export (:issue:`198`).
+* Renamed `Cell.lattice` to `Cell.lattice_type` as well as `Lattice` to `LatticeType`, with deprecation warnings (:issue:`728`).
 
 **Bugs Fixed**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -28,7 +28,7 @@ MontePy Changelog
 * Added :func:`~montepy.data_inputs.material.Material.clear` to ``Material`` to clear out all nuclides (:issue:`665`).
 * Allow any ``Real`` type for floating point numbers and any ``Integral`` type for integer numbers during type enforcement (:issue:`679`).
 * Avoided multiple ``LineExpansionWarnings`` coming from the same object on export (:issue:`198`).
-* Renamed `Cell.lattice` to `Cell.lattice_type` as well as `Lattice` to `LatticeType`, with deprecation warnings (:issue:`728`).
+* Renamed `Cell.lattice` to `Cell.lattice_type`, `Lattice` to `LatticeType`, and `LatticeType.HEXAHEDRA` to `LatticeType.HEXAHEDRAL` with deprecation warnings (:issue:`728`).
 
 **Bugs Fixed**
 

--- a/montepy/__init__.py
+++ b/montepy/__init__.py
@@ -18,7 +18,7 @@ from montepy.data_inputs.material import Material
 from montepy.data_inputs.transform import Transform
 from montepy.data_inputs.nuclide import Library, Nuclide
 from montepy.data_inputs.element import Element
-from montepy.data_inputs.lattice import Lattice
+from montepy.data_inputs.lattice import LatticeType
 from montepy.data_inputs.thermal_scattering import ThermalScatteringLaw
 from montepy.data_inputs.data_parser import parse_data
 

--- a/montepy/cell.py
+++ b/montepy/cell.py
@@ -28,6 +28,13 @@ def _link_geometry_to_cell(self, geom):
     geom._add_new_children_to_cell(geom)
 
 
+def _lattice_deprecation_warning():
+    warnings.warn(
+        message="Cell.lattice is deprecated in favor of Cell.lattice_type",
+        category=DeprecationWarning,
+    )
+
+
 class Cell(Numbered_MCNP_Object):
     """Object to represent a single MCNP cell defined in CSG.
 
@@ -294,7 +301,7 @@ class Cell(Numbered_MCNP_Object):
         return self._universe.old_number
 
     @property
-    def lattice(self):
+    def lattice_type(self):
         """The type of lattice being used by the cell.
 
         Returns
@@ -304,13 +311,28 @@ class Cell(Numbered_MCNP_Object):
         """
         return self._lattice.lattice
 
+    @lattice_type.setter
+    def lattice_type(self, value):
+        self._lattice.lattice = value
+
+    @lattice_type.deleter
+    def lattice_type(self):
+        self._lattice.lattice = None
+
+    @property
+    def lattice(self):
+        _lattice_deprecation_warning()
+        return self.lattice_type
+
     @lattice.setter
     def lattice(self, value):
-        self._lattice.lattice = value
+        _lattice_deprecation_warning()
+        self.lattice_type = value
 
     @lattice.deleter
     def lattice(self):
-        self._lattice.lattice = None
+        _lattice_deprecation_warning()
+        self.lattice_type = None
 
     @property
     def volume(self):

--- a/montepy/data_inputs/lattice.py
+++ b/montepy/data_inputs/lattice.py
@@ -1,9 +1,17 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024 - 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from enum import Enum, unique
+from warnings import warn
+
+
+def _lattice_deprecation_warning():
+    warn(
+        message="lattice.Lattice is deprecated in favor of lattice.LatticeType",
+        category=DeprecationWarning,
+    )
 
 
 @unique
-class Lattice(Enum):
+class LatticeType(Enum):
     """Represents the options for the lattice ``LAT``."""
 
     HEXAHEDRA = 1
@@ -13,3 +21,17 @@ class Lattice(Enum):
     """
     HEXAGONAL = 2
     """Hexagonal prism are solids with eight faces."""
+
+
+class Lattice(Enum):
+    """Deprecated"""
+
+    @property
+    def HEXAHEDRA(self):
+        _lattice_deprecation_warning()
+        return LatticeType.HEXAHEDRA
+
+    @property
+    def HEXAGONAL(self):
+        _lattice_deprecation_warning()
+        return LatticeType.HEXAGONAL

--- a/montepy/data_inputs/lattice.py
+++ b/montepy/data_inputs/lattice.py
@@ -3,18 +3,11 @@ from enum import Enum, unique
 from warnings import warn
 
 
-def _lattice_deprecation_warning():
-    warn(
-        message="lattice.Lattice is deprecated in favor of lattice.LatticeType",
-        category=DeprecationWarning,
-    )
-
-
 @unique
 class LatticeType(Enum):
     """Represents the options for the lattice ``LAT``."""
 
-    HEXAHEDRA = 1
+    HEXAHEDRAL = 1
     """Hexhedra are solids with six faces.
 
     One such solid is a rectangular prism.
@@ -23,15 +16,24 @@ class LatticeType(Enum):
     """Hexagonal prism are solids with eight faces."""
 
 
-class Lattice(Enum):
-    """Deprecated"""
+class __DeprecatedLattice:
+    """Helper for deprecated Enum behavior"""
 
     @property
     def HEXAHEDRA(self):
-        _lattice_deprecation_warning()
-        return LatticeType.HEXAHEDRA
+        warn(
+            message="Lattice.HEXAHEDRA is deprecated in favor of LatticeType.HEXAHEDRAL",
+            category=DeprecationWarning,
+        )
+        return LatticeType.HEXAHEDRAL
 
     @property
     def HEXAGONAL(self):
-        _lattice_deprecation_warning()
+        warn(
+            message="Lattice.HEXAGONAL is deprecated in favor of LatticeType.HEXAGONAL",
+            category=DeprecationWarning,
+        )
         return LatticeType.HEXAGONAL
+
+
+Lattice = __DeprecatedLattice()

--- a/montepy/data_inputs/lattice_input.py
+++ b/montepy/data_inputs/lattice_input.py
@@ -2,7 +2,7 @@
 import itertools
 
 from montepy.data_inputs.cell_modifier import CellModifierInput, InitInput
-from montepy.data_inputs.lattice import Lattice
+from montepy.data_inputs.lattice import LatticeType
 from montepy.errors import *
 from montepy.input_parser.mcnp_input import Jump
 from montepy.input_parser import syntax_node
@@ -39,7 +39,7 @@ class LatticeInput(CellModifierInput):
                 try:
                     val = value["data"][0]
                     val._convert_to_int()
-                    val._convert_to_enum(Lattice, int)
+                    val._convert_to_enum(LatticeType, int)
                 except ValueError as e:
                     raise ValueError("Cell Lattice must be 1 or 2")
                 self._lattice = val
@@ -49,7 +49,7 @@ class LatticeInput(CellModifierInput):
             for word in words:
                 try:
                     word._convert_to_int()
-                    word._convert_to_enum(Lattice, int)
+                    word._convert_to_enum(LatticeType, int)
                     self._lattice.append(word)
                 except ValueError:
                     raise MalformedInputError(
@@ -59,7 +59,7 @@ class LatticeInput(CellModifierInput):
     def _generate_default_cell_tree(self):
         list_node = syntax_node.ListNode("number sequence")
         data = self._generate_default_node(int, None)
-        data._convert_to_enum(Lattice, True, int)
+        data._convert_to_enum(LatticeType, True, int)
         list_node.append(data)
         classifier = syntax_node.ClassifierNode()
         classifier.prefix = self._generate_default_node(
@@ -91,13 +91,15 @@ class LatticeInput(CellModifierInput):
         if self.in_cell_block:
             return self.lattice is not None
 
-    @make_prop_val_node("_lattice", (Lattice, int, type(None)), Lattice, deletable=True)
+    @make_prop_val_node(
+        "_lattice", (LatticeType, int, type(None)), LatticeType, deletable=True
+    )
     def lattice(self):
         """The type of lattice being used.
 
         Returns
         -------
-        Lattice
+        LatticeType
         """
         pass
 

--- a/tests/test_cell_problem.py
+++ b/tests/test_cell_problem.py
@@ -346,7 +346,7 @@ def verify_export(cell):
         "number",
         "old_mat_number",
         "old_universe_number",
-        "lattice",
+        "lattice_type",
         "mass_density",
         "atom_density",
         "is_atom_dens",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -887,8 +887,8 @@ def test_universe_repr(simple_problem):
 def test_lattice_format_data(simple_problem):
     problem = copy.deepcopy(simple_problem)
     cells = problem.cells
-    cells[1].lattice = 1
-    cells[99].lattice = 2
+    cells[1].lattice_type = 1
+    cells[99].lattice_type = 2
     problem.print_in_data_block["lat"] = True
     answer = "LAT 1 2J 2"
     output = cells._lattice.format_for_mcnp_input((6, 2, 0))
@@ -908,9 +908,9 @@ def test_lattice_push_to_cells(simple_problem):
     for cell, answer in zip(problem.cells, lattices):
         print(cell.number, answer)
         if isinstance(answer, int):
-            assert cell.lattice.value == answer
+            assert cell.lattice_type.value == answer
         else:
-            assert cell.lattice is None
+            assert cell.lattice_type is None
 
 
 def test_universe_problem_parsing(universe_problem):

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -61,7 +61,7 @@ class TestValueNode:
 
     def test_valuenode_convert_to_enum(self):
         node = syntax_node.ValueNode("1", float)
-        lat = montepy.data_inputs.lattice.Lattice
+        lat = montepy.data_inputs.lattice.LatticeType
         node._convert_to_enum(lat)
         assert node.type == lat
         assert node.value == lat(1)
@@ -298,7 +298,7 @@ class TestValueNode:
                 assert node.format() == answer
 
     def test_value_enum_format(self):
-        lat = montepy.data_inputs.lattice.Lattice
+        lat = montepy.data_inputs.lattice.LatticeType
         st = montepy.surfaces.surface_type.SurfaceType
         for input, val, enum_class, args, answer, expand in [
             (

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -4,7 +4,6 @@ import pytest
 from unittest import TestCase
 
 import copy
-from montepy.constants import DEFAULT_VERSION
 from montepy.input_parser import syntax_node
 import montepy
 from montepy.cell import Cell
@@ -157,66 +156,66 @@ class TestLattice(TestCase):
 
     def test_lattice_init(self):
         lattice = self.lattice
-        self.assertEqual(lattice.lattice, LatticeType(1))
+        assert lattice.lattice == LatticeType(1)
         tree = copy.deepcopy(self.tree)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tree["data"].nodes.pop()
             tree["data"].append(syntax_node.ValueNode("hi", str))
-            lattice = LatticeInput(in_cell_block=True, key="lat", value=tree)
-        with self.assertRaises(ValueError):
+            LatticeInput(in_cell_block=True, key="lat", value=tree)
+        with pytest.raises(ValueError):
             tree["data"].nodes.pop()
             tree["data"].append(syntax_node.ValueNode("5", float))
-            lattice = LatticeInput(in_cell_block=True, key="lat", value=tree)
+            LatticeInput(in_cell_block=True, key="lat", value=tree)
         lattices = [1, 2, None, None]
         input = Input(["Lat " + " ".join(list(map(str, lattices)))], BlockType.DATA)
         lattice = LatticeInput(input)
         for answer, lattice in zip(lattices, lattice._lattice):
-            self.assertEqual(LatticeType(answer), lattice.value)
-        with self.assertRaises(MalformedInputError):
+            assert LatticeType(answer) == lattice.value
+        with pytest.raises(MalformedInputError):
             card = Input(["Lat 3"], BlockType.DATA)
             LatticeInput(card)
-        with self.assertRaises(MalformedInputError):
+        with pytest.raises(MalformedInputError):
             card = Input(["Lat str"], BlockType.DATA)
             LatticeInput(card)
 
     def test_lattice_setter(self):
         lattice = copy.deepcopy(self.lattice)
         lattice.lattice = LatticeType(2)
-        self.assertEqual(LatticeType(2), lattice.lattice)
+        assert LatticeType(2) == lattice.lattice
         lattice.lattice = 1
-        self.assertEqual(LatticeType(1), lattice.lattice)
+        assert LatticeType(1) == lattice.lattice
         lattice.lattice = None
-        self.assertIsNone(lattice.lattice)
-        with self.assertRaises(TypeError):
+        assert lattice.lattice is None
+        with pytest.raises(TypeError):
             lattice.lattice = "hi"
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             lattice.lattice = -1
 
     def test_lattice_deleter(self):
         lattice = self.lattice
         del lattice.lattice
-        self.assertIsNone(lattice.lattice)
+        assert lattice.lattice is None
 
     def test_lattice_merge(self):
         lattice = self.lattice
-        with self.assertRaises(MalformedInputError):
+        with pytest.raises(MalformedInputError):
             lattice.merge(lattice)
 
     def test_lattice_cell_format(self):
         lattice = self.lattice
         output = lattice.format_for_mcnp_input(DEFAULT_VERSION)
-        self.assertIn("lat=1", output[0])
+        assert"lat=1" in output[0]
         lattice.lattice = None
         output = lattice.format_for_mcnp_input(DEFAULT_VERSION)
-        self.assertEqual(output, [])
+        assert output == []
 
     def test_lattice_repr(self):
         lattice = self.lattice
         out = repr(lattice)
-        self.assertIn("in_cell: True", out)
-        self.assertIn("set_in_block: True", out)
-        self.assertIn("Lattice_values : LatticeType.HEXAHEDRAL", out)
+        assert"in_cell: True" in out
+        assert"set_in_block: True" in out
+        assert "Lattice_values : LatticeType.HEXAHEDRAL" in out
 
     def test_deprecated_lattice(self):
         with pytest.warns(DeprecationWarning, match="HEXAGONAL"):

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -216,7 +216,7 @@ class TestLattice(TestCase):
         out = repr(lattice)
         self.assertIn("in_cell: True", out)
         self.assertIn("set_in_block: True", out)
-        self.assertIn("Lattice_values : LatticeType.HEXAHEDRA", out)
+        self.assertIn("Lattice_values : LatticeType.HEXAHEDRAL", out)
 
 
 class TestFill(TestCase):

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -218,6 +218,19 @@ class TestLattice(TestCase):
         self.assertIn("set_in_block: True", out)
         self.assertIn("Lattice_values : LatticeType.HEXAHEDRAL", out)
 
+    def test_deprecated_lattice(self):
+        with pytest.warns(DeprecationWarning, match="HEXAGONAL"):
+            montepy.data_inputs.lattice.Lattice.HEXAGONAL
+        with pytest.warns(DeprecationWarning, match="HEXAHEDRAL"):
+            lattype = montepy.data_inputs.lattice.Lattice.HEXAHEDRA
+        cell = montepy.Cell()
+        with pytest.warns(DeprecationWarning):
+            cell.lattice = lattype
+        with pytest.warns(DeprecationWarning):
+            str(cell.lattice)
+        with pytest.warns(DeprecationWarning):
+            del cell.lattice
+
 
 class TestFill(TestCase):
     def setUp(self):

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -205,7 +205,7 @@ class TestLattice(TestCase):
     def test_lattice_cell_format(self):
         lattice = self.lattice
         output = lattice.format_for_mcnp_input(DEFAULT_VERSION)
-        assert"lat=1" in output[0]
+        assert "lat=1" in output[0]
         lattice.lattice = None
         output = lattice.format_for_mcnp_input(DEFAULT_VERSION)
         assert output == []
@@ -213,8 +213,8 @@ class TestLattice(TestCase):
     def test_lattice_repr(self):
         lattice = self.lattice
         out = repr(lattice)
-        assert"in_cell: True" in out
-        assert"set_in_block: True" in out
+        assert "in_cell: True" in out
+        assert "set_in_block: True" in out
         assert "Lattice_values : LatticeType.HEXAHEDRAL" in out
 
     def test_deprecated_lattice(self):

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -14,7 +14,7 @@ from montepy.input_parser.block_type import BlockType
 from montepy.input_parser.mcnp_input import Input, Jump
 from montepy.universe import Universe
 from montepy.data_inputs.fill import Fill
-from montepy.data_inputs.lattice import Lattice
+from montepy.data_inputs.lattice import LatticeType
 from montepy.data_inputs.lattice_input import LatticeInput
 from montepy.data_inputs.universe_input import UniverseInput
 import numpy as np
@@ -157,7 +157,7 @@ class TestLattice(TestCase):
 
     def test_lattice_init(self):
         lattice = self.lattice
-        self.assertEqual(lattice.lattice, Lattice(1))
+        self.assertEqual(lattice.lattice, LatticeType(1))
         tree = copy.deepcopy(self.tree)
         with self.assertRaises(ValueError):
             tree["data"].nodes.pop()
@@ -171,7 +171,7 @@ class TestLattice(TestCase):
         input = Input(["Lat " + " ".join(list(map(str, lattices)))], BlockType.DATA)
         lattice = LatticeInput(input)
         for answer, lattice in zip(lattices, lattice._lattice):
-            self.assertEqual(Lattice(answer), lattice.value)
+            self.assertEqual(LatticeType(answer), lattice.value)
         with self.assertRaises(MalformedInputError):
             card = Input(["Lat 3"], BlockType.DATA)
             LatticeInput(card)
@@ -181,10 +181,10 @@ class TestLattice(TestCase):
 
     def test_lattice_setter(self):
         lattice = copy.deepcopy(self.lattice)
-        lattice.lattice = Lattice(2)
-        self.assertEqual(Lattice(2), lattice.lattice)
+        lattice.lattice = LatticeType(2)
+        self.assertEqual(LatticeType(2), lattice.lattice)
         lattice.lattice = 1
-        self.assertEqual(Lattice(1), lattice.lattice)
+        self.assertEqual(LatticeType(1), lattice.lattice)
         lattice.lattice = None
         self.assertIsNone(lattice.lattice)
         with self.assertRaises(TypeError):
@@ -216,7 +216,7 @@ class TestLattice(TestCase):
         out = repr(lattice)
         self.assertIn("in_cell: True", out)
         self.assertIn("set_in_block: True", out)
-        self.assertIn("Lattice_values : Lattice.HEXAHEDRA", out)
+        self.assertIn("Lattice_values : LatticeType.HEXAHEDRA", out)
 
 
 class TestFill(TestCase):

--- a/tests/test_universe_integration.py
+++ b/tests/test_universe_integration.py
@@ -5,6 +5,7 @@ import pytest
 from tests.test_cell_problem import verify_export as cell_verify
 
 import montepy
+import montepy.data_inputs.lattice
 from montepy import Cell
 from montepy import Universe
 
@@ -54,7 +55,7 @@ def test_fill_setter(cells):
 
 def test_lattice_setter(cells):
     for basic_cell in cells:
-        basic_cell.lattice_type = montepy.data_inputs.lattice.LatticeType.HEXAHEDRA
+        basic_cell.lattice_type = montepy.data_inputs.lattice.LatticeType.HEXAHEDRAL
         cell_verify(basic_cell)
 
 
@@ -62,7 +63,7 @@ def test_uni_fill_latt_setter(cells):
     for basic_cell in cells:
         base_uni = montepy.Universe(1)
         lat_uni = montepy.Universe(2)
-        basic_cell.lattice_type = montepy.data_inputs.lattice.LatticeType.HEXAHEDRA
+        basic_cell.lattice_type = montepy.data_inputs.lattice.LatticeType.HEXAHEDRAL
         basic_cell.fill.universe = base_uni
         basic_cell.universe = lat_uni
         cell_verify(basic_cell)
@@ -90,7 +91,7 @@ def test_mc_workshop_edge_case():
     unit_cell.geometry &= -z_top_surf & +z_bot_surf
     unit_cell.importance.neutron = 1.0
     # set fill and stuff
-    unit_cell.lattice_type = montepy.data_inputs.lattice.LatticeType.HEXAHEDRA
+    unit_cell.lattice_type = montepy.data_inputs.lattice.LatticeType.HEXAHEDRAL
     unit_cell.fill.universe = universe
     # assign to own universe
     lat_universe = montepy.Universe(5)

--- a/tests/test_universe_integration.py
+++ b/tests/test_universe_integration.py
@@ -54,7 +54,7 @@ def test_fill_setter(cells):
 
 def test_lattice_setter(cells):
     for basic_cell in cells:
-        basic_cell.lattice_type = montepy.data_inputs.lattice.Lattice.HEXAHEDRA
+        basic_cell.lattice_type = montepy.data_inputs.lattice.LatticeType.HEXAHEDRA
         cell_verify(basic_cell)
 
 
@@ -62,7 +62,7 @@ def test_uni_fill_latt_setter(cells):
     for basic_cell in cells:
         base_uni = montepy.Universe(1)
         lat_uni = montepy.Universe(2)
-        basic_cell.lattice_type = montepy.data_inputs.lattice.Lattice.HEXAHEDRA
+        basic_cell.lattice_type = montepy.data_inputs.lattice.LatticeType.HEXAHEDRA
         basic_cell.fill.universe = base_uni
         basic_cell.universe = lat_uni
         cell_verify(basic_cell)
@@ -90,7 +90,7 @@ def test_mc_workshop_edge_case():
     unit_cell.geometry &= -z_top_surf & +z_bot_surf
     unit_cell.importance.neutron = 1.0
     # set fill and stuff
-    unit_cell.lattice_type = montepy.data_inputs.lattice.Lattice.HEXAHEDRA
+    unit_cell.lattice_type = montepy.data_inputs.lattice.LatticeType.HEXAHEDRA
     unit_cell.fill.universe = universe
     # assign to own universe
     lat_universe = montepy.Universe(5)

--- a/tests/test_universe_integration.py
+++ b/tests/test_universe_integration.py
@@ -54,7 +54,7 @@ def test_fill_setter(cells):
 
 def test_lattice_setter(cells):
     for basic_cell in cells:
-        basic_cell.lattice = montepy.data_inputs.lattice.Lattice.HEXAHEDRA
+        basic_cell.lattice_type = montepy.data_inputs.lattice.Lattice.HEXAHEDRA
         cell_verify(basic_cell)
 
 
@@ -62,7 +62,7 @@ def test_uni_fill_latt_setter(cells):
     for basic_cell in cells:
         base_uni = montepy.Universe(1)
         lat_uni = montepy.Universe(2)
-        basic_cell.lattice = montepy.data_inputs.lattice.Lattice.HEXAHEDRA
+        basic_cell.lattice_type = montepy.data_inputs.lattice.Lattice.HEXAHEDRA
         basic_cell.fill.universe = base_uni
         basic_cell.universe = lat_uni
         cell_verify(basic_cell)
@@ -90,7 +90,7 @@ def test_mc_workshop_edge_case():
     unit_cell.geometry &= -z_top_surf & +z_bot_surf
     unit_cell.importance.neutron = 1.0
     # set fill and stuff
-    unit_cell.lattice = montepy.data_inputs.lattice.Lattice.HEXAHEDRA
+    unit_cell.lattice_type = montepy.data_inputs.lattice.Lattice.HEXAHEDRA
     unit_cell.fill.universe = universe
     # assign to own universe
     lat_universe = montepy.Universe(5)


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

Fixes #728.

Replaces the `Cell.lattice` property with `Cell.lattice_type`; `lattice.Lattice` with `lattice.LatticeType`; and `HEXAHEDRA` with `HEXAHEDRAL`.

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).
- [x] I have formatted my code with `black` version 25.


---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--730.org.readthedocs.build/en/730/

<!-- readthedocs-preview montepy end -->