### PR TITLE
Made lazy mcnp format string

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -28,6 +28,10 @@ MontePy Changelog
 * Added :func:`~montepy.data_inputs.material.Material.clear` to ``Material`` to clear out all nuclides (:issue:`665`).
 * Allow any ``Real`` type for floating point numbers and any ``Integral`` type for integer numbers during type enforcement (:issue:`679`).
 * Avoided multiple ``LineExpansionWarnings`` coming from the same object on export (:issue:`198`).
+* Added ``mcnp_str`` function to all ``MCNP_Object`` to quickly get the string that would be printed in the MCNP input
+  file (:issue:`700`).
+* Added ``montepy.MCNP_VERSION`` as an easy way to set the default MCNP version to target for reading and writing input
+  files (:issue:`700`).
 
 **Bugs Fixed**
 

--- a/montepy/__init__.py
+++ b/montepy/__init__.py
@@ -12,6 +12,8 @@ from . import input_parser
 from . import constants
 import importlib.metadata
 
+from .constants import DEFAULT_VERSION as MCNP_VERSION
+
 # data input promotion
 
 from montepy.data_inputs.material import Material

--- a/montepy/data_inputs/cell_modifier.py
+++ b/montepy/data_inputs/cell_modifier.py
@@ -239,7 +239,12 @@ class CellModifierInput(DataInputAbstract):
         """
         return self._tree.format()
 
-    def format_for_mcnp_input(self, mcnp_version, has_following=False):
+    def format_for_mcnp_input(
+        self,
+        mcnp_version: tuple[int],
+        has_following: bool = False,
+        always_print: bool = True,
+    ):
         """Creates a string representation of this MCNP_Object that can be
         written to file.
 
@@ -247,6 +252,10 @@ class CellModifierInput(DataInputAbstract):
         ----------
         mcnp_version : tuple
             The tuple for the MCNP version that must be exported to.
+        has_following: bool
+            If true this is followed by another input, and a new line will be inserted if this ends in a comment.
+        always_print: bool
+            If true this will always produce a result irrespective of ``print_in_data_block``.
 
         Returns
         -------
@@ -266,7 +275,7 @@ class CellModifierInput(DataInputAbstract):
         Boolean logic
         A= self.in_Cell_block
         B = print_in_data_block
-        C = is_worth_pring
+        C = is_worth_printing
 
         Logic:
             1. A!BC + !ABC
@@ -275,7 +284,11 @@ class CellModifierInput(DataInputAbstract):
             4. C * (A != B)
         """
         # print in either block
-        if (self.in_cell_block != print_in_data_block) and self._is_worth_printing:
+        if (
+            always_print
+            or (self.in_cell_block != print_in_data_block)
+            and self._is_worth_printing
+        ):
             self._update_values()
             return self.wrap_string_for_mcnp(
                 self._format_tree(),
@@ -284,3 +297,27 @@ class CellModifierInput(DataInputAbstract):
                 suppress_blank_end=not self.in_cell_block,
             )
         return []
+
+    def mcnp_str(self, mcnp_version: tuple[int] = None):
+        """Returns a string of this input as it would appear in an MCNP input file.
+
+        ..versionadded:: 1.0.0
+
+        Parameters
+        ----------
+        mcnp_version: tuple[int]
+            The tuple for the MCNP version that must be exported to.
+
+        Returns
+        -------
+        str
+            The string that would have been printed in a file
+
+        TODO: cellmodifier
+        """
+        if mcnp_version is None:
+            if self._problem is not None:
+                mcnp_version = self._problem.mcnp_version
+            else:
+                mcnp_version = montepy.MCNP_VERSION
+        return "\n".join(self.format_for_mcnp_input(mcnp_version, always_print=True))

--- a/montepy/data_inputs/cell_modifier.py
+++ b/montepy/data_inputs/cell_modifier.py
@@ -273,7 +273,7 @@ class CellModifierInput(DataInputAbstract):
 
         """
         Boolean logic
-        A= self.in_Cell_block
+        A = self.in_Cell_block
         B = print_in_data_block
         C = is_worth_printing
 

--- a/montepy/data_inputs/cell_modifier.py
+++ b/montepy/data_inputs/cell_modifier.py
@@ -318,7 +318,8 @@ class CellModifierInput(DataInputAbstract):
                 mcnp_version = self._problem.mcnp_version
             else:
                 mcnp_version = montepy.MCNP_VERSION
-        with warnings.catch_warnings(action="ignore"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
             return "\n".join(
                 self.format_for_mcnp_input(mcnp_version, always_print=True)
             )

--- a/montepy/data_inputs/cell_modifier.py
+++ b/montepy/data_inputs/cell_modifier.py
@@ -1,4 +1,4 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024 - 2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from abc import abstractmethod
 import montepy
 from montepy.data_inputs.data_input import DataInputAbstract, InitInput
@@ -318,4 +318,7 @@ class CellModifierInput(DataInputAbstract):
                 mcnp_version = self._problem.mcnp_version
             else:
                 mcnp_version = montepy.MCNP_VERSION
-        return "\n".join(self.format_for_mcnp_input(mcnp_version, always_print=True))
+        with warnings.catch_warnings(action="ignore"):
+            return "\n".join(
+                self.format_for_mcnp_input(mcnp_version, always_print=True)
+            )

--- a/montepy/data_inputs/cell_modifier.py
+++ b/montepy/data_inputs/cell_modifier.py
@@ -243,7 +243,7 @@ class CellModifierInput(DataInputAbstract):
         self,
         mcnp_version: tuple[int],
         has_following: bool = False,
-        always_print: bool = True,
+        always_print: bool = False,
     ):
         """Creates a string representation of this MCNP_Object that can be
         written to file.
@@ -284,10 +284,8 @@ class CellModifierInput(DataInputAbstract):
             4. C * (A != B)
         """
         # print in either block
-        if (
-            always_print
-            or (self.in_cell_block != print_in_data_block)
-            and self._is_worth_printing
+        if always_print or (
+            self.in_cell_block != print_in_data_block and self._is_worth_printing
         ):
             self._update_values()
             return self.wrap_string_for_mcnp(

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -269,7 +269,8 @@ class MCNP_Object(ABC, metaclass=_ExceptionContextAdder):
                 mcnp_version = self._problem.mcnp_version
             else:
                 mcnp_version = montepy.MCNP_VERSION
-        return "\n".join(self.format_for_mcnp_input(mcnp_version))
+        with warnings.catch_warnings(action="ignore"):
+            return "\n".join(self.format_for_mcnp_input(mcnp_version))
 
     def _flush_line_expansion_warning(self, lines, ws):
         if not ws:

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -269,7 +269,8 @@ class MCNP_Object(ABC, metaclass=_ExceptionContextAdder):
                 mcnp_version = self._problem.mcnp_version
             else:
                 mcnp_version = montepy.MCNP_VERSION
-        with warnings.catch_warnings(action="ignore"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
             return "\n".join(self.format_for_mcnp_input(mcnp_version))
 
     def _flush_line_expansion_warning(self, lines, ws):

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -227,12 +227,12 @@ class MCNP_Object(ABC, metaclass=_ExceptionContextAdder):
         pass
 
     def format_for_mcnp_input(self, mcnp_version: tuple[int]) -> list[str]:
-        """Creates a string representation of this MCNP_Object that can be
+        """Creates a list of strings representing this MCNP_Object that can be
         written to file.
 
         Parameters
         ----------
-        mcnp_version : tuple
+        mcnp_version : tuple[int]
             The tuple for the MCNP version that must be exported to.
 
         Returns
@@ -248,6 +248,28 @@ class MCNP_Object(ABC, metaclass=_ExceptionContextAdder):
             lines = self.wrap_string_for_mcnp(self._tree.format(), mcnp_version, True)
         self._flush_line_expansion_warning(lines, ws)
         return lines
+
+        def mcnp_str(self, mcnp_version: tuple[int] = None):
+            """Returns a string of this input as it would appear in an MCNP input file.
+
+            ..versionadded:: 1.0.0
+
+            Parameters
+            ----------
+            mcnp_version: tuple[int]
+                The tuple for the MCNP version that must be exported to.
+
+            Returns
+            -------
+            str
+                The string that would have been printed in a file
+            """
+            if mcnp_version is None:
+                if self._problem is not None:
+                    mcnp_version = self._problem.mcnp_version
+                else:
+                    mcnp_version = montepy.MCNP_VERSION
+            return "\n".join(self.format_for_mcnp_input(mcnp_version))
 
     def _flush_line_expansion_warning(self, lines, ws):
         if not ws:

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -249,27 +249,27 @@ class MCNP_Object(ABC, metaclass=_ExceptionContextAdder):
         self._flush_line_expansion_warning(lines, ws)
         return lines
 
-        def mcnp_str(self, mcnp_version: tuple[int] = None):
-            """Returns a string of this input as it would appear in an MCNP input file.
+    def mcnp_str(self, mcnp_version: tuple[int] = None):
+        """Returns a string of this input as it would appear in an MCNP input file.
 
-            ..versionadded:: 1.0.0
+        ..versionadded:: 1.0.0
 
-            Parameters
-            ----------
-            mcnp_version: tuple[int]
-                The tuple for the MCNP version that must be exported to.
+        Parameters
+        ----------
+        mcnp_version: tuple[int]
+            The tuple for the MCNP version that must be exported to.
 
-            Returns
-            -------
-            str
-                The string that would have been printed in a file
-            """
-            if mcnp_version is None:
-                if self._problem is not None:
-                    mcnp_version = self._problem.mcnp_version
-                else:
-                    mcnp_version = montepy.MCNP_VERSION
-            return "\n".join(self.format_for_mcnp_input(mcnp_version))
+        Returns
+        -------
+        str
+            The string that would have been printed in a file
+        """
+        if mcnp_version is None:
+            if self._problem is not None:
+                mcnp_version = self._problem.mcnp_version
+            else:
+                mcnp_version = montepy.MCNP_VERSION
+        return "\n".join(self.format_for_mcnp_input(mcnp_version))
 
     def _flush_line_expansion_warning(self, lines, ws):
         if not ws:

--- a/tests/test_cell_problem.py
+++ b/tests/test_cell_problem.py
@@ -102,6 +102,8 @@ class TestCellClass(TestCase):
         self.assertEqual(
             repr(cell), "CELL: 1 \nVoid material \ndensity: 0.5 atom/b-cm\n"
         )
+        in_str = "1 0 -2 imp:n=1 "
+        cell = montepy.Cell(in_str)
         assert cell.mcnp_str() == in_str
 
     def test_cell_paremeters_no_eq(self):

--- a/tests/test_cell_problem.py
+++ b/tests/test_cell_problem.py
@@ -104,6 +104,8 @@ class TestCellClass(TestCase):
         )
         in_str = "1 0 -2 imp:n=1 "
         cell = montepy.Cell(in_str)
+        # change line length
+        montepy.MCNP_VERSION = (5, 1, 60)
         assert cell.mcnp_str() == in_str
 
     def test_cell_paremeters_no_eq(self):

--- a/tests/test_cell_problem.py
+++ b/tests/test_cell_problem.py
@@ -1,4 +1,4 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from hypothesis import given, note, strategies as st
 from unittest import TestCase
 import pytest
@@ -105,8 +105,10 @@ class TestCellClass(TestCase):
         in_str = "1 0 -2 imp:n=1 "
         cell = montepy.Cell(in_str)
         # change line length
+        old_version = montepy.MCNP_VERSION
         montepy.MCNP_VERSION = (5, 1, 60)
         assert cell.mcnp_str() == in_str
+        montepy.MCNP_VERSION = old_version
 
     def test_cell_paremeters_no_eq(self):
         in_str = f"1 0 -1 PWT 1.0"

--- a/tests/test_cell_problem.py
+++ b/tests/test_cell_problem.py
@@ -102,6 +102,7 @@ class TestCellClass(TestCase):
         self.assertEqual(
             repr(cell), "CELL: 1 \nVoid material \ndensity: 0.5 atom/b-cm\n"
         )
+        assert cell.mcnp_str() == in_str
 
     def test_cell_paremeters_no_eq(self):
         in_str = f"1 0 -1 PWT 1.0"
@@ -341,6 +342,7 @@ def test_bad_setattr():
 def verify_export(cell):
     output = cell.format_for_mcnp_input((6, 3, 0))
     print("cell output", output)
+    assert "\n".join(output) == cell.mcnp_str((6, 3, 0))
     new_cell = montepy.Cell("\n".join(output))
     for attr in {
         "number",

--- a/tests/test_importance.py
+++ b/tests/test_importance.py
@@ -137,9 +137,11 @@ class TestImportance:
         imp = cell_with_importance.importance
         s = str(imp)
         r = repr(imp)
+        ms = imp.mcnp_str()
         # Verify the string outputs are of type str
         assert isinstance(s, str)
         assert isinstance(r, str)
+        assert isinstance(ms, str)
 
     def test_str_repr_empty_importance(self):
         """

--- a/tests/test_universe_integration.py
+++ b/tests/test_universe_integration.py
@@ -133,9 +133,11 @@ def test_fill_long_mcnp_str_wrap(cells):
         prob = montepy.MCNP_Problem("")
         new_cell.link_to_problem(prob)
         for obj in [cell, cell.fill, new_cell, new_cell.fill]:
+            old_vers = montepy.MCNP_VERSION
+            montepy.MCNP_VERSION = (6, 3, 0)
+            prob.mcnp_version = montepy.MCNP_VERSION
             print(obj.mcnp_str(), len(obj.mcnp_str()))
             assert len(obj.mcnp_str().split("\n")) == 1
-            old_vers = montepy.MCNP_VERSION
             montepy.MCNP_VERSION = (6, 1, 0)
             prob.mcnp_version = montepy.MCNP_VERSION
             assert len(obj.mcnp_str().split("\n")) > 1

--- a/tests/test_universe_integration.py
+++ b/tests/test_universe_integration.py
@@ -121,3 +121,23 @@ def test_fill_multi_universe_order(cells):
         words = " ".join(output).split()
         new_universes = list(map(int, words[7:]))
         assert (numbers.flatten("f") == new_universes).all()
+
+
+def test_fill_long_mcnp_str_wrap(cells):
+    for cell in cells:
+        universe = montepy.Universe(1)
+        cell.fill.universes = np.full(
+            (7, 6, 1), universe
+        )  # length set to not wrap at 128, but do so at 80
+        new_cell = cell.clone()
+        prob = montepy.MCNP_Problem("")
+        new_cell.link_to_problem(prob)
+        for obj in [cell, cell.fill, new_cell, new_cell.fill]:
+            print(obj.mcnp_str(), len(obj.mcnp_str()))
+            assert len(obj.mcnp_str().split("\n")) == 1
+            old_vers = montepy.MCNP_VERSION
+            montepy.MCNP_VERSION = (6, 1, 0)
+            prob.mcnp_version = montepy.MCNP_VERSION
+            assert len(obj.mcnp_str().split("\n")) > 1
+            montepy.MCNP_VERSION = old_vers
+            prob.mcnp_version = montepy.MCNP_VERSION


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This provides a simple function `mcnp_str` which returns a string as the input would show up in the file. It also adds `montepy.MCNP_VERSION` to make it more obvious what the default version is. This works by just using the default version to run `"\n".join(self.format_for_mcnp_input(...))`. For `CellModifiers` this ensures that something always prints irrespective of `MCNP_Problem.print_in_data_block`, to avoid user confusion. 

Fixes #700 

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).
- [x] I have formatted my code with `black` version 25.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [x] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--731.org.readthedocs.build/en/731/

<!-- readthedocs-preview montepy end -->