### PR TITLE
Added deprecation guidelines to developers guide

### DIFF
--- a/doc/source/dev_standards.rst
+++ b/doc/source/dev_standards.rst
@@ -22,7 +22,8 @@ The version tag shall match the regular expression:
 These tags will be applied by a maintainer during the release process,
 and cannot be applied by normal users.
 
-MontePy follows the semantic versioning standard, and the PyPA specification for version specifiers to the best of our abilities. 
+MontePy follows the `semantic versioning standard <https://semver.org/>`_ 
+and the `PyPA specification for version specifiers <https://packaging.python.org/en/latest/specifications/version-specifiers/>`_ to the best of our abilities. 
 
 The version numbers can be read as ``<Major>.<minor>.<patch>``.
 Here is a quick summary of release types used, that is not meant to be authoritative:
@@ -30,16 +31,12 @@ Here is a quick summary of release types used, that is not meant to be authorita
 * **Major release**: This is a release that break backwards compatibility.
 * **Minor release**: This is a release the adds a new feature. 
 * **Patch release**: This is a bug-fix release only.
-* **post release**: This is a release that doesn't change any code. This will add an extra ``\.post\d+`` to the end of
+* **Post release**: This is a release that doesn't change any code. This will add an extra ``\.post\d+`` to the end of
   the *previous* version.
-* **alpha release**: This is a testing release. Generally this is preparing for a major release. 
+* **Alpha release**: This is a testing release. Generally this is preparing for a major release. 
   Features are not locked at this point, and may change.
   This is signified by adding ``a\d+`` to the end of the *next* release.
 
-Additional References:
-
-#. `Semantic versioning standard <https://semver.org/>`_
-#. `PyPA specification for Version specifiers <https://packaging.python.org/en/latest/specifications/version-specifiers/>`_
 
 Design Philosophy
 -----------------
@@ -255,7 +252,7 @@ Deprecation Guidelines
 Deprecation is an important part of the development life-cycle and a signal for users to help with migrations.
 Deprecations can occur either during a major release, or between major releases.
 The deprecation process is really part of a larger migration documentation process, 
-and provides a good last line of defense for users on how to migrate their code.
+and it provides a good last line of defense for users on how to migrate their code.
 
 .. note::
     
@@ -284,7 +281,8 @@ These are deprecations that are not during a major release. That is when the ver
 The guidelines are:
 
 #. Do not break anything
-#. Warn with a ``DeprecationWarning`` (or ``PendingDeprecationWarning``, or ``FutureWarning`` as appropriate)
+#. Warn with a ``DeprecationWarning`` (or ``PendingDeprecationWarning``, or ``FutureWarning`` as appropriate. `See the
+   guide on warnings <https://docs.python.org/3/library/warnings.html#warning-categories>`_.)
 #. Add clear documentation on the fact it is deprecated and what the alternative is.
 #. Clear these warnings and documentation notations at the next major release.
 

--- a/doc/source/dev_standards.rst
+++ b/doc/source/dev_standards.rst
@@ -17,16 +17,29 @@ Version information is stored in git tags,
 and retrieved using `setuptools scm <https://setuptools-scm.readthedocs.io/en/latest/>`_.
 The version tag shall match the regular expression:
 
-``v\d\.\d+\.\d+``.
+``v\d\.\d+\.\d+(a\d+|\.post\d+)?``.
 
 These tags will be applied by a maintainer during the release process,
 and cannot be applied by normal users.
 
-MontePy follows the semantic versioning standard to the best of our abilities. 
+MontePy follows the semantic versioning standard, and the PyPA specification for version specifiers to the best of our abilities. 
+
+The version numbers can be read as ``<Major>.<minor>.<patch>``.
+Here is a quick summary of release types used, that is not meant to be authoritative:
+
+* **Major release**: This is a release that break backwards compatibility.
+* **Minor release**: This is a release the adds a new feature. 
+* **Patch release**: This is a bug-fix release only.
+* **post release**: This is a release that doesn't change any code. This will add an extra ``\.post\d+`` to the end of
+  the *previous* version.
+* **alpha release**: This is a testing release. Generally this is preparing for a major release. 
+  Features are not locked at this point, and may change.
+  This is signified by adding ``a\d+`` to the end of the *next* release.
 
 Additional References:
 
 #. `Semantic versioning standard <https://semver.org/>`_
+#. `PyPA specification for Version specifiers <https://packaging.python.org/en/latest/specifications/version-specifiers/>`_
 
 Design Philosophy
 -----------------

--- a/doc/source/dev_standards.rst
+++ b/doc/source/dev_standards.rst
@@ -8,6 +8,7 @@ Here is a getting started guide to contributing.
 If you have any questions Micah and Travis are available to give input and answer your questions.
 Before contributing you should review the :ref:`scope` and design philosophy.
 
+.. _Versioning:
 
 Versioning
 ----------
@@ -234,3 +235,44 @@ Test Migration
 Currently the test suite does not conform to these standards fully.
 Help with making the migration to the new standards is appreciated.
 So don't think something is sacred about a test file that does not follow these conventions.
+
+Deprecation Guidelines
+----------------------
+
+Deprecation is an important part of the development life-cycle and a signal for users to help with migrations.
+Deprecations can occur either during a major release, or between major releases.
+The deprecation process is really part of a larger migration documentation process, 
+and provides a good last line of defense for users on how to migrate their code.
+
+.. note::
+    
+   See :ref:`Versioning` section for more details on release types.
+    
+
+Major Release Deprecations
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These are deprecations that occur during a major release. 
+Generally these are deprecations necessary for the release to work, and must be at versions: ``r"\d+\.0\.0``. 
+For these deprecations the guidelines are:
+
+#. Try not to break too much.
+#. Warn with a ``DeprecationWarning`` if the deprecated function is still usable. Otherwise ``raise`` it as an
+   ``Exception``.
+#. Add clear documentation on the fact it is deprecated and what the alternative is.
+#. Write a migration plan, preferably it should be part of the releases prior the major release.
+#. Only clear these ``DeprecationWarnings`` at the next major release.
+
+Mid-Major Release Deprecations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These are deprecations that are not during a major release. That is when the version matches:
+``r"(\d+\.[1-9]+\.\d+|\d+\.\d+\.[1-9]+)"``.
+The guidelines are:
+
+#. Do not break anything
+#. Warn with a ``DeprecationWarning`` (or ``PendingDeprecationWarning``, or ``FutureWarning`` as appropriate)
+#. Add clear documentation on the fact it is deprecated and what the alternative is.
+#. Clear these warnings and documentation notations at the next major release.
+
+

--- a/doc/source/dev_standards.rst
+++ b/doc/source/dev_standards.rst
@@ -263,7 +263,7 @@ Major Release Deprecations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 These are deprecations that occur during a major release. 
-Generally these are deprecations necessary for the release to work, and must be at versions: ``r"\d+\.0\.0``. 
+Generally these are deprecations necessary for the release to work, and must be at versions: ``Major.0.0``. 
 For these deprecations the guidelines are:
 
 #. Try not to break too much.
@@ -277,7 +277,7 @@ Mid-Major Release Deprecations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 These are deprecations that are not during a major release. That is when the version matches:
-``r"(\d+\.[1-9]+\.\d+|\d+\.\d+\.[1-9]+)"``.
+``Major.Minor.0`` or ``Major.Minor.Patch``.
 The guidelines are:
 
 #. Do not break anything

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -31,7 +31,7 @@ MontePy can be installed with pip:
    api/modules
 
 See Also
-========
+--------
 
 * `MontePy github Repository <https://github.com/idaholab/montepy>`_
 * `MontePy PyPI Project <https://pypi.org/project/montepy/>`_
@@ -41,7 +41,7 @@ See Also
 * `MCNP Forum <https://mcnp.discourse.group/>`_
 
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This updates documentation:

1. Gives deprecation guidelines.
2. Talks a bit more about versioning.
3. Fixed SEO issue with multiple `<h1>` tags on the home page. 

Fixes #729



### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--746.org.readthedocs.build/en/746/

<!-- readthedocs-preview montepy end -->