### PR TITLE
Fixed bug with bad rounding for floating point value nodes on export

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Fixes # (issue number)
 ### General Checklist
 
 - [ ] I have performed a self-review of my own code.
-- [ ] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).
+- [ ] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
 - [ ] I have formatted my code with `black` version 25.
 - [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,13 @@ MontePy Changelog
 1.0 releases
 ============
 
+#Next Version#
+--------------
+
+**Bugs Fixed**
+
+* Fixed bug where MontePy would overly agressively round outputs and remove the user's intent(:issue:`756`).
+
 1.0.0
 --------------
 

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -968,8 +968,6 @@ class ValueNode(SyntaxNodeBase):
             "as_int": False,
             "int_tolerance": 1e-6,
             "is_scientific": True,
-            "rel_eps": 1e-6,
-            "abs_eps": 1e-9,
         },
         int: {"value_length": 0, "zero_padding": 0, "sign": "-"},
         str: {"value_length": 0},
@@ -1259,23 +1257,6 @@ class ValueNode(SyntaxNodeBase):
             )
         return self.value != self._og_value
 
-    def _avoid_rounding_truncation(self):
-        if self._formatter["is_scientific"]:
-            pass
-        else:
-            precision = self._formatter["precision"]
-            val = self.value
-        while True:
-            if not math.isclose(
-                val,
-                round(val, precision),
-                rel_tol=self._formatter["rel_eps"],
-                abs_tol=self._formatter["abs_eps"],
-            ):
-                precision += 1
-            break
-        self._formatter["precision"] = precision
-
     def format(self):
         if not self._value_changed:
             return f"{self._token}{self.padding.format() if self.padding else ''}"
@@ -1292,7 +1273,6 @@ class ValueNode(SyntaxNodeBase):
             )
         elif self._type == float:
             # default to python general if new value
-            self._avoid_rounding_truncation()
             if not self._is_reversed:
                 temp = "{value:0={sign}{zero_padding}.{precision}g}".format(
                     value=value, **self._formatter

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -1260,10 +1260,17 @@ class ValueNode(SyntaxNodeBase):
         return self.value != self._og_value
 
     def _avoid_rounding_truncation(self):
+        """
+        Detects when not enough digits are in original input to preserve precision.
+
+        This will update the precision in the formatter to the necessary
+        value to preserve the precision.
+        """
+        precision = self._formatter["precision"]
         if self._formatter["is_scientific"]:
-            pass
+            exp = math.floor(math.log10(abs(self.value)))
+            val = self.value / 10**exp
         else:
-            precision = self._formatter["precision"]
             val = self.value
         while True:
             if not math.isclose(

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -968,6 +968,8 @@ class ValueNode(SyntaxNodeBase):
             "as_int": False,
             "int_tolerance": 1e-6,
             "is_scientific": True,
+            "rel_eps": 1e-6,
+            "abs_eps": 1e-9,
         },
         int: {"value_length": 0, "zero_padding": 0, "sign": "-"},
         str: {"value_length": 0},
@@ -1257,6 +1259,23 @@ class ValueNode(SyntaxNodeBase):
             )
         return self.value != self._og_value
 
+    def _avoid_rounding_truncation(self):
+        if self._formatter["is_scientific"]:
+            pass
+        else:
+            precision = self._formatter["precision"]
+            val = self.value
+        while True:
+            if not math.isclose(
+                val,
+                round(val, precision),
+                rel_tol=self._formatter["rel_eps"],
+                abs_tol=self._formatter["abs_eps"],
+            ):
+                precision += 1
+            break
+        self._formatter["precision"] = precision
+
     def format(self):
         if not self._value_changed:
             return f"{self._token}{self.padding.format() if self.padding else ''}"
@@ -1273,6 +1292,7 @@ class ValueNode(SyntaxNodeBase):
             )
         elif self._type == float:
             # default to python general if new value
+            self._avoid_rounding_truncation()
             if not self._is_reversed:
                 temp = "{value:0={sign}{zero_padding}.{precision}g}".format(
                     value=value, **self._formatter

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -1276,16 +1276,13 @@ class ValueNode(SyntaxNodeBase):
             val = self.value / 10**exp
         else:
             val = self.value
-        while True:
-            if not math.isclose(
-                val,
-                round(val, precision),
-                rel_tol=self._formatter["rel_eps"],
-                abs_tol=self._formatter["abs_eps"],
-            ):
-                precision += 1
-            else:
-                break
+        while not math.isclose(
+            val,
+            round(val, precision),
+            rel_tol=self._formatter["rel_eps"],
+            abs_tol=self._formatter["abs_eps"],
+        ):
+            precision += 1
         self._formatter["precision"] = precision
 
     def format(self):

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -1268,7 +1268,11 @@ class ValueNode(SyntaxNodeBase):
         """
         precision = self._formatter["precision"]
         if self._formatter["is_scientific"]:
-            exp = math.floor(math.log10(abs(self.value)))
+            # Remember that you can test for equality to 0 with floats safely
+            if self.value != 0:
+                exp = math.floor(math.log10(abs(self.value)))
+            else:
+                exp = 0
             val = self.value / 10**exp
         else:
             val = self.value

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -1280,7 +1280,8 @@ class ValueNode(SyntaxNodeBase):
                 abs_tol=self._formatter["abs_eps"],
             ):
                 precision += 1
-            break
+            else:
+                break
         self._formatter["precision"] = precision
 
     def format(self):

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -222,6 +222,7 @@ class TestValueNode:
             # test bad rounding
             ("1", float, 1.5, "1.5", True),
             ("1.0", float, 1.05, "1.05", True),
+            ("1.0", float, 1.056, "1.056", True),
             ("-1.23", float, 4.56, " 4.56", False),
             ("1.0e-2", float, 2, "2.0e+0", False),
             # bad rounding

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -16,6 +16,10 @@ from montepy.particle import Particle
 import warnings
 
 
+lat = montepy.data_inputs.lattice.LatticeType
+st = montepy.surfaces.surface_type.SurfaceType
+
+
 class TestValueNode:
     def test_valuenoode_init(self):
         for type, token, answer in [
@@ -209,98 +213,74 @@ class TestValueNode:
         node.value = "foo"
         assert node._value_changed
 
-    def test_value_float_format(self):
-        for input, val, answer, expand in [
-            ("1.23", 1.23, "1.23", False),
-            ("1.23", 4.56, "4.56", False),
-            (1.23, 4.56, "4.56", False),
-            ("-1.23", 4.56, " 4.56", False),
-            ("1.0e-2", 2, "2.0e+0", False),
-            ("1.602-19", 6.02e23, "6.020+23", False),
-            ("1.602-0019", 6.02e23, "6.020+0023", False),
-            (Jump(), 5.4, "5.4 ", True),
-            ("1", 2, "2", False),
-            ("0.5", 0, "0.0", False),
-        ]:
-            print("in:", input, "new value:", val, "answer:", answer)
-            node = syntax_node.ValueNode(input, float)
-            node.value = val
-            if expand:
-                warnings.simplefilter("default")
-                with pytest.warns(LineExpansionWarning):
-                    assert node.format() == answer
-            else:
-                # change warnings to errors to ensure not raised
-                warnings.resetwarnings()
-                warnings.simplefilter("error")
+    @pytest.mark.parametrize(
+        "input, val_type, val, answer, expand",
+        [
+            ("1.23", float, 1.23, "1.23", False),
+            ("1.23", float, 4.56, "4.56", False),
+            (1.23, float, 4.56, "4.56", False),
+            ("-1.23", float, 4.56, " 4.56", False),
+            ("1.0e-2", float, 2, "2.0e+0", False),
+            ("1.602-19", float, 6.02e23, "6.020+23", False),
+            ("1.602-0019", float, 6.02e23, "6.020+0023", False),
+            (Jump(), float, 5.4, "5.4 ", True),
+            ("1", float, 2, "2", False),
+            ("0.5", float, 0, "0.0", False),
+            ("hi", str, "foo", "foo", True),
+            ("hi", str, None, "", False),
+        ],
+    )
+    def test_value_float_format(_, input, val_type, val, answer, expand):
+        node = syntax_node.ValueNode(input, val_type)
+        node.value = val
+        if expand:
+            warnings.simplefilter("default")
+            with pytest.warns(LineExpansionWarning):
                 assert node.format() == answer
+        else:
+            # change warnings to errors to ensure not raised
+            warnings.resetwarnings()
+            warnings.simplefilter("error")
+            assert node.format() == answer
 
-        for padding, val, answer, expand in [
-            ([" "], 10, "10.0 ", True),
-            (["  "], 10, "10.0 ", False),
-            (["\n"], 10, "10.0\n", False),
-            ([" ", "\n", "c hi"], 10, "10.0\nc hi", False),
-            (["  ", "\n"], 10, "10.0 \n", False),
-        ]:
-            print("padding", padding, "new_val", val, "answer", answer)
-            pad_node = syntax_node.PaddingNode(padding[0])
-            for pad in padding[1:]:
-                pad_node.append(pad)
-            node = syntax_node.ValueNode("1.0", float, pad_node)
-            node.value = val
-            if expand:
-                warnings.simplefilter("default")
-                with pytest.warns(LineExpansionWarning):
-                    assert node.format() == answer
-            else:
-                # change warnings to errors to ensure not raised
-                warnings.resetwarnings()
-                warnings.simplefilter("error")
+    @pytest.mark.parametrize(
+        "padding, val_type, val, answer, expand",
+        [
+            ([" "], float, 10, "10.0 ", True),
+            (["  "], float, 10, "10.0 ", False),
+            (["\n"], float, 10, "10.0\n", False),
+            ([" ", "\n", "c hi"], float, 10, "10.0\nc hi", False),
+            (["  ", "\n"], float, 10, "10.0 \n", False),
+            ([" "], str, "foo", "foo ", True),
+            (["  "], str, "foo", "foo ", False),
+            (["\n"], str, "foo", "foo\n", False),
+            ([" ", "\n", "c hi"], str, "foo", "foo\nc hi", False),
+            (["  ", "\n"], str, "foo", "foo \n", False),
+        ],
+    )
+    def test_value_gen_padding_format(_, padding, val_type, val, answer, expand):
+        pad_node = syntax_node.PaddingNode(padding[0])
+        for pad in padding[1:]:
+            pad_node.append(pad)
+        if val_type == float:
+            default = "1.0"
+        elif val_type == str:
+            default = "hi"
+        node = syntax_node.ValueNode(default, val_type, pad_node)
+        node.value = val
+        if expand:
+            warnings.simplefilter("default")
+            with pytest.warns(LineExpansionWarning):
                 assert node.format() == answer
+        else:
+            # change warnings to errors to ensure not raised
+            warnings.resetwarnings()
+            warnings.simplefilter("error")
+            assert node.format() == answer
 
-    def test_value_str_format(self):
-        for input, val, answer, expand in [
-            ("hi", "foo", "foo", True),
-            ("hi", None, "", False),
-        ]:
-            node = syntax_node.ValueNode(input, str)
-            node.value = val
-            if expand:
-                warnings.simplefilter("default")
-                with pytest.warns(LineExpansionWarning):
-                    assert node.format() == answer
-            else:
-                # change warnings to errors to ensure not raised
-                warnings.resetwarnings()
-                warnings.simplefilter("error")
-                assert node.format() == answer
-        for padding, val, answer, expand in [
-            ([" "], "foo", "foo ", True),
-            (["  "], "foo", "foo ", False),
-            (["\n"], "foo", "foo\n", False),
-            ([" ", "\n", "c hi"], "foo", "foo\nc hi", False),
-            (["  ", "\n"], "foo", "foo \n", False),
-        ]:
-            print("padding", padding, "new_val", val, "answer", answer)
-            pad_node = syntax_node.PaddingNode(padding[0])
-            for pad in padding[1:]:
-                pad_node.append(pad)
-            node = syntax_node.ValueNode("hi", str, pad_node)
-            node.value = val
-            if expand:
-                warnings.simplefilter("default")
-                with pytest.warns(LineExpansionWarning):
-                    assert node.format() == answer
-            else:
-                # change warnings to errors to ensure not raised
-                warnings.resetwarnings()
-                warnings.simplefilter("error")
-                assert node.format() == answer
-
-    def test_value_enum_format(self):
-        lat = montepy.data_inputs.lattice.LatticeType
-        st = montepy.surfaces.surface_type.SurfaceType
-        for input, val, enum_class, args, answer, expand in [
+    @pytest.mark.parametrize(
+        "input, val, enum_class, args, answer, expand",
+        [
             (
                 "1",
                 lat.HEXAGONAL,
@@ -318,19 +298,21 @@ class TestValueNode:
                 False,
             ),
             ("p", st.PZ, st, {"format_type": str, "switch_to_upper": True}, "PZ", True),
-        ]:
-            node = syntax_node.ValueNode(input, args["format_type"])
-            node._convert_to_enum(enum_class, **args)
-            node.value = val
-            if expand:
-                warnings.simplefilter("default")
-                with pytest.warns(LineExpansionWarning):
-                    assert node.format() == answer
-            else:
-                # change warnings to errors to ensure not raised
-                warnings.resetwarnings()
-                warnings.simplefilter("error")
+        ],
+    )
+    def test_value_enum_format(_, input, val, enum_class, args, answer, expand):
+        node = syntax_node.ValueNode(input, args["format_type"])
+        node._convert_to_enum(enum_class, **args)
+        node.value = val
+        if expand:
+            warnings.simplefilter("default")
+            with pytest.warns(LineExpansionWarning):
                 assert node.format() == answer
+        else:
+            # change warnings to errors to ensure not raised
+            warnings.resetwarnings()
+            warnings.simplefilter("error")
+            assert node.format() == answer
 
     def test_value_comments(self):
         value_node = syntax_node.ValueNode("1", int)

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -219,8 +219,13 @@ class TestValueNode:
             ("1.23", float, 1.23, "1.23", False),
             ("1.23", float, 4.56, "4.56", False),
             (1.23, float, 4.56, "4.56", False),
+            # test bad rounding
+            ("1", float, 1.5, "1.5", True),
+            ("1.0", float, 1.05, "1.05", True),
             ("-1.23", float, 4.56, " 4.56", False),
             ("1.0e-2", float, 2, "2.0e+0", False),
+            # bad rounding
+            ("1.0e-2", float, 1.01e-3, "1.01e-3", True),
             ("1.602-19", float, 6.02e23, "6.020+23", False),
             ("1.602-0019", float, 6.02e23, "6.020+0023", False),
             (Jump(), float, 5.4, "5.4 ", True),


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This fixes the bug with MontePy rounding out changes. This bug came from MontePy trying to match the user's original intent.

This was solved by adding a `rel_eps` and `abs_eps` to the formatter which defaults to `1e-6` and `1e-9` respectively. Making this user settable is a later task: #103. The general approach used is:

1. round to the number of digits from `precision`
2. Compare to the user-set value using `math.isclose` using `rel_eps` and `abs_eps`.
3. If they are not close add another digit of precision and repeat.

I tried to think of away that was not iterative using `log` and `exp` but got stuck. It's really easy to tell the most significant digit, but rather hard to find the least significant digit from my quick research. 

Fixes #756 

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://idaholab.github.io/MontePy/developing.html).
- [x] I have formatted my code with `black` version 25.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [x] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--757.org.readthedocs.build/en/757/

<!-- readthedocs-preview montepy end -->