### PR TITLE
Fixed detection of vertical mode in cell defintions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,6 +42,6 @@ Fixes # (issue number)
 
 Ensure that:
 
-- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
+- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
 - [ ] The PR covers all relevant aspects according to the development guidelines.
 - [ ] 100% coverage of the patch is achieved, or justification for a variance is given.

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,7 +15,7 @@ MontePy Changelog
 
 **Bugs Fixed**
 
-* Fixed bug where MontePy would overly agressively round outputs and remove the user's intent (:issue:`756`).
+* Fixed bug where MontePy would overly aggressively round outputs and remove the user's intent (:issue:`756`).
 * Fixed bug where a cell complement in the first five characters causes a spurious vertical mode detection (:issue:`753`).
 
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,7 +15,8 @@ MontePy Changelog
 
 **Bugs Fixed**
 
-* Fixed bug where MontePy would overly agressively round outputs and remove the user's intent(:issue:`756`).
+* Fixed bug where MontePy would overly agressively round outputs and remove the user's intent (:issue:`756`).
+* Fixed bug where a cell complement in the first five characters causes a spurious vertical mode detection (:issue:`753`).
 
 
 1.0.0

--- a/montepy/cell.py
+++ b/montepy/cell.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 import copy
 import itertools
-from typing import Union
 from numbers import Integral, Real
+import sly
+from typing import Union
 import warnings
 
 from montepy.cells import Cells
@@ -139,7 +140,25 @@ class Cell(Numbered_MCNP_Object):
         self._density_node = self._generate_default_node(float, None)
         self._surfaces = Surfaces()
         self._complements = Cells()
-        super().__init__(input, self._parser, number)
+        try:
+            super().__init__(input, self._parser, number)
+        # Add more information to issue that parser can't access
+        except UnsupportedFeature as e:
+            base_mesage = e.message
+            token = sly.lex.Token()
+            token.value = ""
+            lineno = 0
+            index = 0
+            for lineno, line in enumerate(input.input_lines):
+                if "like" in line.lower():
+                    index = line.lower().index("like")
+                    # get real capitalization
+                    token.value = line[index : index + 5]
+                    break
+            err = {"message": "", "token": token, "line": lineno + 1, "index": index}
+
+            raise UnsupportedFeature(base_mesage, input, [err]) from e
+
         if not input:
             self._generate_default_tree(number)
         self._old_number = copy.deepcopy(self._tree["cell_num"])

--- a/montepy/errors.py
+++ b/montepy/errors.py
@@ -173,12 +173,15 @@ class ParticleTypeNotInCell(ParticleTypeWarning):
     pass
 
 
-class UnsupportedFeature(NotImplementedError):
+class UnsupportedFeature(ParsingError):
     """Raised when MCNP syntax that is not supported is found"""
 
-    def __init__(self, message):
+    def __init__(self, message, input=None, error_queue=None):
         self.message = message
-        super().__init__(self.message)
+        if input is not None:
+            super().__init__(input, message, error_queue)
+        else:
+            super(ParsingError, self).__init__(self, message)
 
 
 class UnknownElement(ValueError):

--- a/montepy/input_parser/input_syntax_reader.py
+++ b/montepy/input_parser/input_syntax_reader.py
@@ -192,7 +192,13 @@ def read_data(fh, mcnp_version, block_type=None, recursion=False):
         ):
             yield from flush_input()
         # die if it is a vertical syntax format
-        if "#" in line[0:BLANK_SPACE_CONTINUE] and not line_is_comment:
+        start_o_line = line[0:BLANK_SPACE_CONTINUE]
+        # eliminate comments, and inputs that use # for other syntax
+        if (
+            "#" in start_o_line
+            and not line_is_comment
+            and start_o_line.strip().startswith("#")
+        ):
             input_raw_lines.append(line.rstrip())
             input = next(flush_input())
             lineno = 1

--- a/montepy/input_parser/input_syntax_reader.py
+++ b/montepy/input_parser/input_syntax_reader.py
@@ -199,7 +199,7 @@ def read_data(fh, mcnp_version, block_type=None, recursion=False):
             token = sly.lex.Token()
             token.value = "#"
             index = line[0:BLANK_SPACE_CONTINUE].index("#")
-            err = {"message": " Hi", "token": token, "line": lineno, "index": index}
+            err = {"message": "", "token": token, "line": lineno, "index": index}
             raise UnsupportedFeature(
                 "Vertical Input encountered, which is not supported by Montepy",
                 input,

--- a/montepy/input_parser/input_syntax_reader.py
+++ b/montepy/input_parser/input_syntax_reader.py
@@ -4,6 +4,7 @@ import itertools
 import io
 import re
 import os
+import sly
 import warnings
 
 from montepy.constants import *
@@ -192,7 +193,18 @@ def read_data(fh, mcnp_version, block_type=None, recursion=False):
             yield from flush_input()
         # die if it is a vertical syntax format
         if "#" in line[0:BLANK_SPACE_CONTINUE] and not line_is_comment:
-            raise UnsupportedFeature("Vertical Input format is not allowed")
+            input_raw_lines.append(line.rstrip())
+            input = next(flush_input())
+            lineno = 1
+            token = sly.lex.Token()
+            token.value = "#"
+            index = line[0:BLANK_SPACE_CONTINUE].index("#")
+            err = {"message": " Hi", "token": token, "line": lineno, "index": index}
+            raise UnsupportedFeature(
+                "Vertical Input encountered, which is not supported by Montepy",
+                input,
+                [err],
+            )
         # cut line down to allowed length
         old_line = line
         line = line[:line_length]

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -126,6 +126,8 @@ class MCNP_Object(ABC, metaclass=_ExceptionContextAdder):
                 self._tree = parser.parse(input.tokenize(), input)
                 self._input = input
             except ValueError as e:
+                if isinstance(e, UnsupportedFeature):
+                    raise e
                 raise MalformedInputError(
                     input, f"Error parsing object of type: {type(self)}: {e.args[0]}"
                 ).with_traceback(e.__traceback__)

--- a/tests/inputs/test_broken_mat_link.imcnp
+++ b/tests/inputs/test_broken_mat_link.imcnp
@@ -1,5 +1,7 @@
 Test case with missing materials
 1 1 0 -1
+C replicate bug with vertical mode detection: #753
+5 0 #1
 
 1 SO 5
 


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This fixes a bug where MontePy thinks that `5 0 #1` is a Vertical mode input. This is because the complement happens in the first five characters. The fix for this was rather simple, however the error messages are rather vague and useless so users are randomly trying to find vertical mode inputs in their model. This PR:

1. Changes `UnsupportedFeatureError` to be a subclass of `ParsingError`. This is a bit jank because in some contexts it isn't really. But I think for now this is good enough.
2. Provide enough information at exception time to Invoke the `ParsingError` pretty error messages.
3. Detect `#` that is part of different horizontal input by requiring the `#` be the first syntactic element on the line.

Fixes #753


### Example Error message:

``` python
                lineno = 1
                token = sly.lex.Token()
                token.value = "#"
                index = line[0:BLANK_SPACE_CONTINUE].index("#")
                print(lineno, index)
                err = {"message": " Hi", "token": token, "line": lineno, "index": index}
>               raise UnsupportedFeature(
                    "Vertical Input encountered, which is not supported by Montepy",
                    input,
                    [err],
                )
E               montepy.errors.UnsupportedFeature:     tests/inputs/test_broken_mat_link.imcnp, line 3
E
E                   >    3| 5 0 #1
E                         |     ^ not expected here.
E               There was an error parsing "#".
E                
E               Vertical Input encountered, which is not supported by Montepy

montepy/input_parser/input_syntax_reader.py:205: UnsupportedFeature
```

For `like but`:

``` python
                    break

            err = {"message": "", "token": token, "line": lineno + 1, "index": index}

>           raise UnsupportedFeature(base_mesage, input, [err]) from e
E           montepy.errors.UnsupportedFeature:     , line 0
E
E               >    0| 1 like 2
E                     |   ^^^^^ not expected here.
E           There was an error parsing "like ".
E
E           The like but feature is not supported
E
E           Error came from CELL: -1, mat: 0, DENS: None from an unknown file.
```
---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

<details > 

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [x] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--760.org.readthedocs.build/en/760/

<!-- readthedocs-preview montepy end -->