### PR TITLE
General plane warning if more than 9 constants.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Micah D. Gale <micah.gale@inl.gov>
 Travis J. Labossiere-Hickman <Travis.LabossiereHickman@inl.gov>
 Brenna A. Carbno <brenna.carbno@inl.gov>
 Benjaminas M. <BenjaminasDev@outlook.com>
+Ferney P. <Paul.Ferney@inl.gov>

--- a/doc/source/_test_for_missing_docs.py
+++ b/doc/source/_test_for_missing_docs.py
@@ -9,7 +9,7 @@ ignored = {
     "_version.py",
     "__main__.py",
     "_cell_data_control.py",
-    "_singleton.py"
+    "_singleton.py",
 }
 
 base = os.path.join("..", "..")

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -12,6 +12,7 @@ MontePy Changelog
 
 * Added ``Universe.filled_cells``, a generator that yields the cells filled with that universe instance (:issue:`361`).
 * Added ``__eq__`` dunder method to ``Universe`` to support equality comparisons (:issue:`361`).
+* Changed general plane constants checker to support more than 9 constants (:issue:`761`).
 
 **Bugs Fixed**
 

--- a/montepy/errors.py
+++ b/montepy/errors.py
@@ -247,3 +247,10 @@ def add_line_number_to_exception(error, broken_robot):
     args = (message,) + args[1:]
     error.args = args
     raise error.with_traceback(trace)
+
+
+class SurfaceConstantsWarning(UserWarning):
+    """Raised when the constants of a Surface are non-conform, but do not raise an error with MCNP."""
+
+    def __init__(self, message):
+        self.message = message

--- a/montepy/surfaces/general_plane.py
+++ b/montepy/surfaces/general_plane.py
@@ -40,16 +40,11 @@ class GeneralPlane(Surface):
 
     def _enforce_constants(self, _validation_call=False):
         if len(self.surface_constants) not in {4, 9}:
+            message = f"A GeneralPlane must have either 4 or 9 surface constants. {len(self.surface_constants)} constants are provided."
             if len(self.surface_constants) < 9:
                 if not _validation_call:
-                    raise ValueError(
-                        "A GeneralPlane must have either 4 or 9 surface constants"
-                    )
+                    raise ValueError(message)
                 else:
-                    raise IllegalState(
-                        "A GeneralPlane must have either 4 or 9 surface constants"
-                    )
+                    raise IllegalState(message)
             else:
-                warnings.warn(
-                    f"A GeneralPlane must have either 4 or 9 surface constants. {len(self.surface_constants)} constants are provided."
-                )
+                warnings.warn(message, SurfaceConstantsWarning)

--- a/montepy/surfaces/general_plane.py
+++ b/montepy/surfaces/general_plane.py
@@ -32,17 +32,17 @@ class GeneralPlane(Surface):
         if input:
             if self.surface_type != SurfaceType.P:
                 raise ValueError("A GeneralPlane must be a surface of type P")
-            if len(self.surface_constants)>9:
-                warnings.warn(f"There were {len(self.surface_constants)} constants. A GeneralPlane must have either 4 or 9 surface constants. MontePy will ignore extra constants provided.")
-                super().__init__(input, number, max_constants=9)
-            elif len(self.surface_constants) not in {4, 9}:
-                raise ValueError(
-                    "A GeneralPlane must have either 4 or 9 surface constants"
-                )
+            self._enforce_constants()
 
     def validate(self):
         super().validate()
+        self._enforce_constants()
+
+    def _enforce_constants(self):
         if len(self.surface_constants) not in {4, 9}:
-            raise IllegalState(
-                f"Surface: {self.number} does not have constants set properly."
-            )
+            if len(self.surface_constants)<9:
+                raise ValueError(
+                    "A GeneralPlane must have either 4 or 9 surface constants"
+                )
+            else:
+                warnings.warn(f"A GeneralPlane must have either 4 or 9 surface constants. {len(self.surface_constants)} constants are provided.")

--- a/montepy/surfaces/general_plane.py
+++ b/montepy/surfaces/general_plane.py
@@ -41,7 +41,7 @@ class GeneralPlane(Surface):
     def _enforce_constants(self, _validation_call=False):
         if len(self.surface_constants) not in {4, 9}:
             if len(self.surface_constants) < 9:
-                if _validation_call:
+                if not _validation_call:
                     raise ValueError(
                         "A GeneralPlane must have either 4 or 9 surface constants"
                     )

--- a/montepy/surfaces/general_plane.py
+++ b/montepy/surfaces/general_plane.py
@@ -1,5 +1,6 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
 from typing import Union
+import warnings
 
 import montepy
 from montepy.errors import *
@@ -31,7 +32,10 @@ class GeneralPlane(Surface):
         if input:
             if self.surface_type != SurfaceType.P:
                 raise ValueError("A GeneralPlane must be a surface of type P")
-            if len(self.surface_constants) not in {4, 9}:
+            if len(self.surface_constants)>9:
+                warnings.warn(f"There were {len(self.surface_constants)} constants. A GeneralPlane must have either 4 or 9 surface constants. MontePy will ignore extra constants provided.")
+                super().__init__(input, number, max_constants=9)
+            elif len(self.surface_constants) not in {4, 9}:
                 raise ValueError(
                     "A GeneralPlane must have either 4 or 9 surface constants"
                 )

--- a/montepy/surfaces/general_plane.py
+++ b/montepy/surfaces/general_plane.py
@@ -36,14 +36,19 @@ class GeneralPlane(Surface):
 
     def validate(self):
         super().validate()
-        self._enforce_constants()
+        self._enforce_constants(_validation_call=True)
 
-    def _enforce_constants(self):
+    def _enforce_constants(self, _validation_call=False):
         if len(self.surface_constants) not in {4, 9}:
             if len(self.surface_constants) < 9:
-                raise ValueError(
-                    "A GeneralPlane must have either 4 or 9 surface constants"
-                )
+                if _validation_call:
+                    raise ValueError(
+                        "A GeneralPlane must have either 4 or 9 surface constants"
+                    )
+                else:
+                    raise IllegalState(
+                        "A GeneralPlane must have either 4 or 9 surface constants"
+                    )
             else:
                 warnings.warn(
                     f"A GeneralPlane must have either 4 or 9 surface constants. {len(self.surface_constants)} constants are provided."

--- a/montepy/surfaces/general_plane.py
+++ b/montepy/surfaces/general_plane.py
@@ -40,9 +40,11 @@ class GeneralPlane(Surface):
 
     def _enforce_constants(self):
         if len(self.surface_constants) not in {4, 9}:
-            if len(self.surface_constants)<9:
+            if len(self.surface_constants) < 9:
                 raise ValueError(
                     "A GeneralPlane must have either 4 or 9 surface constants"
                 )
             else:
-                warnings.warn(f"A GeneralPlane must have either 4 or 9 surface constants. {len(self.surface_constants)} constants are provided.")
+                warnings.warn(
+                    f"A GeneralPlane must have either 4 or 9 surface constants. {len(self.surface_constants)} constants are provided."
+                )

--- a/montepy/surfaces/surface.py
+++ b/montepy/surfaces/surface.py
@@ -1,7 +1,7 @@
 # Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 import copy
-from typing import Union, Optional
+from typing import Union
 from numbers import Real
 
 import montepy
@@ -35,7 +35,6 @@ class Surface(Numbered_MCNP_Object):
         self,
         input: InitInput = None,
         number: int = None,
-        max_constants: Optional[int] = None,
     ):
         self._CHILD_OBJ_MAP = {
             "periodic_surface": Surface,
@@ -94,11 +93,8 @@ class Surface(Numbered_MCNP_Object):
                     f"{self._surface_type.value} could not be parsed as a surface type mnemonic.",
                 )
             # parse the parameters
-            for i, entry in enumerate(self._tree["data"]):
-                if max_constants is None:
-                    self._surface_constants.append(entry)
-                elif i < max_constants:
-                    self._surface_constants.append(entry)
+            for entry in self._tree["data"]:
+                self._surface_constants.append(entry)
 
     @make_prop_val_node("_surface_type", (SurfaceType, str), SurfaceType)
     def surface_type(self):

--- a/montepy/surfaces/surface.py
+++ b/montepy/surfaces/surface.py
@@ -1,7 +1,7 @@
 # Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 import copy
-from typing import Union
+from typing import Union, Optional
 from numbers import Real
 
 import montepy
@@ -35,6 +35,7 @@ class Surface(Numbered_MCNP_Object):
         self,
         input: InitInput = None,
         number: int = None,
+        max_constants: Optional[int] = None,
     ):
         self._CHILD_OBJ_MAP = {
             "periodic_surface": Surface,
@@ -93,8 +94,11 @@ class Surface(Numbered_MCNP_Object):
                     f"{self._surface_type.value} could not be parsed as a surface type mnemonic.",
                 )
             # parse the parameters
-            for entry in self._tree["data"]:
-                self._surface_constants.append(entry)
+            for i, entry in enumerate(self._tree["data"]):
+                if max_constants is None:
+                    self._surface_constants.append(entry)
+                elif i < max_constants:
+                    self._surface_constants.append(entry)
 
     @make_prop_val_node("_surface_type", (SurfaceType, str), SurfaceType)
     def surface_type(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ authors = [
 	{name = "Micah Gale", email = "mgale@montepy.org"},
 	{name = "Travis Labossiere-Hickman", email = "Travis.LabossiereHickman@inl.gov"},
 	{name = "Brenna Carbno", email="brenna.carbno@inl.gov"},
-	{name = "Benjaminas Marcinkevicius", email="BenjaminasDev@outlook.com"}
+	{name = "Benjaminas Marcinkevicius", email="BenjaminasDev@outlook.com"},
+	{name = "Paul Ferney", email="Paul.Ferney@inl.gov"}
 ]
 keywords = ["MCNP", "neutronics", "imcnp", "input file", "monte carlo", "radiation transport"]
 license = {file="LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 	{name = "Travis Labossiere-Hickman", email = "Travis.LabossiereHickman@inl.gov"},
 	{name = "Brenna Carbno", email="brenna.carbno@inl.gov"},
 	{name = "Benjaminas Marcinkevicius", email="BenjaminasDev@outlook.com"},
-	{name = "Paul Ferney", email="Paul.Ferney@inl.gov"}
+	{name = "Paul Ferney", email="Paul.Ferney@inl.gov"},
 ]
 keywords = ["MCNP", "neutronics", "imcnp", "input file", "monte carlo", "radiation transport"]
 license = {file="LICENSE"}

--- a/tests/test_surfaces.py
+++ b/tests/test_surfaces.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 import montepy
-from montepy.errors import MalformedInputError
+from montepy.errors import MalformedInputError, SurfaceConstantsWarning
 from montepy.input_parser.block_type import BlockType
 from montepy.input_parser.mcnp_input import Input
 from montepy.surfaces.axis_plane import AxisPlane
@@ -208,7 +208,6 @@ class testSurfaces(TestCase):
             ("13 cz 0", CylinderOnAxis),
             ("14 px 1.e-3", AxisPlane),
             ("15 PY .1", AxisPlane),
-            ("16 p 0. 0. 0. 0. 0. 1. 0. 1. 1. 0. 1. 0.", GeneralPlane),
         ]
         for in_str, surf_plane in testers:
             card = Input([in_str], BlockType.SURFACE)
@@ -262,6 +261,20 @@ class testSurfaces(TestCase):
         self.assertEqual(surf.location, 10.0)
         with self.assertRaises(TypeError):
             surf.location = "hi"
+
+    def test_general_plane_constants(self):
+        error_inputs = ['16 P 0. 0. 0. 0. 0. 1. 0.']
+        warn_inputs = ['17 p 0. 0. 0. 0. 0. 1. 0. 1. 1. 0. 1. 0.']
+        for error_input in error_inputs:
+            with self.assertRaises(ValueError):
+                surf = montepy.surfaces.general_plane.GeneralPlane(
+                    Input([error_input], BlockType.SURFACE)
+                )
+        for warn_input in warn_inputs:
+            with self.assertRaises(SurfaceConstantsWarning):
+                surf = montepy.surfaces.general_plane.GeneralPlane(
+                    Input([warn_input], BlockType.SURFACE)
+                )
 
     def test_cylinder_axis_radius_setter(self):
         in_str = "1 CZ 5.0"

--- a/tests/test_surfaces.py
+++ b/tests/test_surfaces.py
@@ -263,8 +263,8 @@ class testSurfaces(TestCase):
             surf.location = "hi"
 
     def test_general_plane_constants(self):
-        error_inputs = ['16 P 0. 0. 0. 0. 0. 1. 0.']
-        warn_inputs = ['17 p 0. 0. 0. 0. 0. 1. 0. 1. 1. 0. 1. 0.']
+        error_inputs = ["16 P 0. 0. 0. 0. 0. 1. 0."]
+        warn_inputs = ["17 p 0. 0. 0. 0. 0. 1. 0. 1. 1. 0. 1. 0."]
         for error_input in error_inputs:
             with self.assertRaises(ValueError):
                 surf = montepy.surfaces.general_plane.GeneralPlane(

--- a/tests/test_surfaces.py
+++ b/tests/test_surfaces.py
@@ -208,6 +208,7 @@ class testSurfaces(TestCase):
             ("13 cz 0", CylinderOnAxis),
             ("14 px 1.e-3", AxisPlane),
             ("15 PY .1", AxisPlane),
+            ("16 p 0. 0. 0. 0. 0. 1. 0. 1. 1. 0. 1. 0.", GeneralPlane),
         ]
         for in_str, surf_plane in testers:
             card = Input([in_str], BlockType.SURFACE)

--- a/tests/test_surfaces.py
+++ b/tests/test_surfaces.py
@@ -267,14 +267,10 @@ class testSurfaces(TestCase):
         warn_inputs = ["17 p 0. 0. 0. 0. 0. 1. 0. 1. 1. 0. 1. 0."]
         for error_input in error_inputs:
             with self.assertRaises(ValueError):
-                surf = montepy.surfaces.general_plane.GeneralPlane(
-                    Input([error_input], BlockType.SURFACE)
-                )
+                surf = montepy.surfaces.general_plane.GeneralPlane(error_input)
         for warn_input in warn_inputs:
             with self.assertRaises(SurfaceConstantsWarning):
-                surf = montepy.surfaces.general_plane.GeneralPlane(
-                    Input([warn_input], BlockType.SURFACE)
-                )
+                surf = montepy.surfaces.general_plane.GeneralPlane(warn_input)
 
     def test_cylinder_axis_radius_setter(self):
         in_str = "1 CZ 5.0"


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

Allows for a general plane to have more than 9 constants. Throw a warning if there is strictly more than 9 constants.

Fixes #761

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25.

---

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [x] I have documented all added classes and methods.

</details>

---

<details open>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [x] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [x] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/developing.html#merge-checklist).
- [x] The PR covers all relevant aspects according to the development guidelines.
- [x] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--763.org.readthedocs.build/en/763/

<!-- readthedocs-preview montepy end -->