### PR TITLE
Fixed parser bug with SDEF with X and Y

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -2,9 +2,8 @@
 MontePy Changelog
 *****************
 
-1.0 releases
+1.1 releases
 ============
-
 
 #Next Version#
 --------------
@@ -32,6 +31,9 @@ MontePy Changelog
 * Fixed bug where MontePy would overly aggressively round outputs and remove the user's intent (:issue:`756`).
 * Fixed bug where a cell complement in the first five characters causes a spurious vertical mode detection (:issue:`753`).
 
+
+1.0 releases
+============
 
 1.0.0
 --------------

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -13,6 +13,11 @@ MontePy Changelog
 
 * Added demonstration jupyter notebooks for working with Pin Cell and PWR assemblies in MontePy.
 
+**Bugs Fixed**
+
+* Fixed bug that couldn't parse ``SDEF`` by simply not parsing the input for the time being (:pull:`767`).
+* Fixed parsing bug with ``DE LOG`` style inputs by simply not parsing them for now (:pull:`767`).
+
 1.1.0
 --------------
 

--- a/doc/source/developing.rst
+++ b/doc/source/developing.rst
@@ -393,6 +393,7 @@ Using the :func:`~montepy.data_inputs.data_parser.parse_data` function:
 The function :func:`~montepy.data_inputs.data_parser.parse_data` handles converting a ``data_input`` to the correct class automatically.
 It uses the set ``PREFIX_MATCH`` to do this. 
 This lists all classes that the function will look into for a matching class prefix.
+Inputs that should not be parsed can have their prefix added to ``VERBOTEN`` in that file.
 
 The ``parse_data`` function will use the ``fast_parse`` option for parsing the data_input.
 This method will only match the first word/classifier using the :class:`~montepy.input_parser.data_parser.ClassifierParser`.

--- a/montepy/data_inputs/data_input.py
+++ b/montepy/data_inputs/data_input.py
@@ -354,3 +354,67 @@ class DataInput(DataInputAbstract):
         }
         if prefix.lower() in PARSER_PREFIX_MAP:
             self._parser = PARSER_PREFIX_MAP[prefix.lower()]()
+
+
+class ForbiddenDataInput(DataInputAbstract):
+    """Catch-all for all other MCNP data inputs.
+
+    Parameters
+    ----------
+    input : Union[Input, str]
+        the Input object representing this data input
+    fast_parse : bool
+        Whether or not to only parse the first word for the type of
+        data.
+    prefix : str
+        The input prefix found during parsing (internal use only)
+    """
+
+    def __init__(
+        self, input: InitInput = None, fast_parse: bool = False, prefix: str = None
+    ):
+        super().__init__(input, True)
+        self._input = input
+
+    @property
+    def _class_prefix(self):
+        return None
+
+    @property
+    def _has_number(self):  # pragma: no cover
+        return None
+
+    @property
+    def _has_classifier(self):  # pragma: no cover
+        return None
+
+    def _error_out(self):
+        """ """
+        raise UnsupportedFeature(
+            f"Inputs of type: {self.classifier} are not supported yet "
+            "due to their complex syntax."
+            "These will be written out correctly, but cannot be edited",
+            input,
+        )
+
+    @property
+    def _prop_error(self):
+        self._error_out()
+
+    data = _prop_error
+
+    def format_for_mcnp_input(self, mcnp_version: tuple[int]) -> list[str]:
+        """Creates a list of strings representing this MCNP_Object that can be
+        written to file.
+
+        Parameters
+        ----------
+        mcnp_version : tuple[int]
+            The tuple for the MCNP version that must be exported to.
+
+        Returns
+        -------
+        list
+            a list of strings for the lines that this input will occupy.
+        """
+        return self._input.input_lines

--- a/montepy/data_inputs/data_input.py
+++ b/montepy/data_inputs/data_input.py
@@ -374,6 +374,10 @@ class ForbiddenDataInput(DataInputAbstract):
         self, input: InitInput = None, fast_parse: bool = False, prefix: str = None
     ):
         super().__init__(input, True)
+        if isinstance(input, str):
+            input = montepy.input_parser.mcnp_input.Input(
+                input.split("\n"), self._BLOCK_TYPE
+            )
         self._input = input
 
     @property
@@ -391,7 +395,7 @@ class ForbiddenDataInput(DataInputAbstract):
     def _error_out(self):
         """ """
         raise UnsupportedFeature(
-            f"Inputs of type: {self.classifier} are not supported yet "
+            f"Inputs of type: {self.classifier.prefix} are not supported yet "
             "due to their complex syntax."
             "These will be written out correctly, but cannot be edited",
             input,

--- a/montepy/data_inputs/data_input.py
+++ b/montepy/data_inputs/data_input.py
@@ -357,7 +357,12 @@ class DataInput(DataInputAbstract):
 
 
 class ForbiddenDataInput(DataInputAbstract):
-    """Catch-all for all other MCNP data inputs.
+    """MCNP data input that is not actually parsed and only parroted out.
+
+    Current inputs that are in "parser jail":
+
+    * ``DE``
+    * ``SDEF``
 
     Parameters
     ----------
@@ -406,6 +411,18 @@ class ForbiddenDataInput(DataInputAbstract):
         self._error_out()
 
     data = _prop_error
+    """
+    Not supported.
+
+    .. warning::
+
+        Because this input was not parsed these data are not available.
+
+    raises
+    ------
+    UnsupportedFeature 
+        when called.
+    """
 
     def format_for_mcnp_input(self, mcnp_version: tuple[int]) -> list[str]:
         """Creates a list of strings representing this MCNP_Object that can be

--- a/montepy/data_inputs/data_parser.py
+++ b/montepy/data_inputs/data_parser.py
@@ -27,6 +27,8 @@ PREFIX_MATCHES = {
     universe_input.UniverseInput,
 }
 
+VERBOTEN = {"de", "sdef"}
+
 
 def parse_data(input: montepy.mcnp_object.InitInput):
     """Parses the data input as the appropriate object if it is supported.
@@ -44,6 +46,8 @@ def parse_data(input: montepy.mcnp_object.InitInput):
 
     base_input = data_input.DataInput(input, fast_parse=True)
     prefix = base_input.prefix
+    if base_input.prefix in VERBOTEN:
+        return data_input.ForbiddenDataInput(input)
     for data_class in PREFIX_MATCHES:
         if prefix == data_class._class_prefix():
             return data_class(input)

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -123,7 +123,10 @@ class MCNP_Object(ABC, metaclass=_ExceptionContextAdder):
                 # raised if restarted without ever parsing
                 except AttributeError as e:
                     pass
-                self._tree = parser.parse(input.tokenize(), input)
+                tokenizer = input.tokenize()
+                self._tree = parser.parse(tokenizer, input)
+                # consume token stream
+                tokenizer.close()
                 self._input = input
             except ValueError as e:
                 if isinstance(e, UnsupportedFeature):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -12,5 +12,6 @@ import pytest
 def test_source_parse_and_parrot(line):
     input = Input([line], BlockType.DATA)
     data = parse_data(input)
-    print(repr(data._tree))
-    assert data._tree.format() == line
+    assert data.mcnp_str() == line
+    with pytest.raises(montepy.errors.UnsupportedFeature):
+        data.data

--- a/tests/test_source_def.py
+++ b/tests/test_source_def.py
@@ -1,15 +1,18 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
-from unittest import TestCase
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
+import pytest
 
 import montepy
 from montepy.data_inputs.data_parser import parse_data
 from montepy.input_parser.block_type import BlockType
 
 
-class TestSourceDefinition(TestCase):
-    def test_complex_sdef_parser(self):
-        lines = ["si1  l   60001 838i 60840", " sp1  d 0.0100 0.01000 0.0100"]
-        for test_line in lines:
-            print(test_line)
-            input = montepy.input_parser.mcnp_input.Input([test_line], BlockType.DATA)
-            parse_data(input)
+@pytest.mark.parametrize(
+    "test_line",
+    [
+        "si1  l   60001 838i 60840",
+        " sp1  d 0.0100 0.01000 0.0100",
+        "sdef x=d1 Y=d2 Z=d3 erg=d4",
+    ],
+)
+def test_complex_sdef_parser(test_line):
+    parse_data(test_line)

--- a/tests/test_tally.py
+++ b/tests/test_tally.py
@@ -1,17 +1,16 @@
-# Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
+import pytest
+
 import montepy
 from montepy.data_inputs.data_parser import parse_data
 from montepy.input_parser.block_type import BlockType
 from montepy.input_parser.mcnp_input import Input
 
 
-from unittest import TestCase
-import pytest
-
-
-class TestTallyParser(TestCase):
-    def test_parsing_tally_groups(self):
-        for line in [
+class TestTallyParser:
+    @pytest.mark.parametrize(
+        "line",
+        [
             "F4:n (1 3i 5) T",
             "F4:n (1 2 3 4 5) T",
             "F4:n 1 2 3",
@@ -19,18 +18,25 @@ class TestTallyParser(TestCase):
             "f4:n (1 3i 5) (7 8 9)",
             "F7 (1 3i 5) (7 8 9)",
             "F7 (1 3i 5) (7 8 9) ",
-        ]:
-            print(line)
-            input = Input([line], BlockType.DATA)
-            data = parse_data(input)
-            self.assertEqual(data.prefix, "f")
+        ],
+    )
+    def test_parsing_tally_groups(_, line):
+        data = parse_data(line)
+        assert data.prefix == "f"
 
-    def test_parsing_tally_print(self):
+    def test_parsing_tally_print(_):
         input = Input(["Fq4 f p e"], BlockType.DATA)
         data = parse_data(input)
-        self.assertEqual(data.prefix, "fq")
+        assert data.prefix == "fq"
 
-    def test_parsing_tally_multiplier(self):
+    @pytest.mark.parametrize(
+        "test",
+        [
+            "fm904   (1.0) (1.0 961 103)",
+            "fm3064 (1.0 361001 444) $ 1.0=mult",
+        ],
+    )
+    def test_parsing_tally_multiplier(_, test):
         test_lines = {
             "fm904   (1.0) (1.0 961 103)",
             "fm3064 (1.0 361001 444) $ 1.0=mult",
@@ -40,17 +46,20 @@ class TestTallyParser(TestCase):
             input = Input([test], BlockType.DATA)
             data = parse_data(input)
 
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "fs14 -123",
+            "fs12 -456 t",
+            "fs11 -1 -2",
+            "fs16 +1 +2 c",
+            "fs17 -1 -2 t c",
+        ],
+    )
+    def test_tally_segment_init(_, line):
+        input = Input([line], BlockType.DATA)
+        data = parse_data(input)
 
-@pytest.mark.parametrize(
-    "line",
-    [
-        "fs14 -123",
-        "fs12 -456 t",
-        "fs11 -1 -2",
-        "fs16 +1 +2 c",
-        "fs17 -1 -2 t c",
-    ],
-)
-def test_tally_segment_init(line):
-    input = Input([line], BlockType.DATA)
-    data = parse_data(input)
+    @pytest.mark.parametrize("line", ["de4 log 1 2 3 4"])
+    def test_de_parsing_jail(_, line):
+        parse_data(line)

--- a/tests/test_tally.py
+++ b/tests/test_tally.py
@@ -62,4 +62,7 @@ class TestTallyParser:
 
     @pytest.mark.parametrize("line", ["de4 log 1 2 3 4"])
     def test_de_parsing_jail(_, line):
-        parse_data(line)
+        data = parse_data(line)
+        assert data.mcnp_str() == line
+        with pytest.raises(montepy.errors.UnsupportedFeature):
+            data.data


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This was meant to fix the parsing error with `SDEF X=d1`. However, I realized actually supporting and parsing all of `SDEF` syntax is really complicated because you do things like: `SDEF PAR=FCEL=D3`. So I decided to punt full support to #22, and instead put `SDEF` in parsing jail.

However, I realized we never actually implemented parsing jail. So I went back and implemented the parsing jail and added `SDEF` and `DE` to it.

This should really add a lot of ICSBEP input files that we can parse now.

Fixes #755, Fixes #364

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [x] I have documented all added classes and methods.
- [x] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--767.org.readthedocs.build/en/767/

<!-- readthedocs-preview montepy end -->