### PR TITLE
Fixed broken test cases with Windows

### DIFF
--- a/montepy/errors.py
+++ b/montepy/errors.py
@@ -71,7 +71,8 @@ class ParsingError(MalformedInputError):
         else:
             self.message = message
 
-        # ValueError.__init__(self, self.message)
+    def __str__(self):
+        return self.message
 
 
 def _print_input(

--- a/montepy/errors.py
+++ b/montepy/errors.py
@@ -173,7 +173,7 @@ class ParticleTypeNotInCell(ParticleTypeWarning):
     pass
 
 
-class UnsupportedFeature(Exception):
+class UnsupportedFeature(ParsingError):
     """Raised when MCNP syntax that is not supported is found"""
 
     def __init__(self, message, input=None, error_queue=None):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -187,7 +187,7 @@ def test_read_card_recursion():
 
 def test_problem_str(simple_problem):
     output = str(simple_problem)
-    assert "MCNP problem for: tests/inputs/test.imcnp" in output
+    assert f"MCNP problem for: {simple_problem.input_file.name}" in output
 
 
 def test_write_to_file(simple_problem):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1186,9 +1186,9 @@ def test_alternate_encoding():
 
 _SKIP_LINES = {
     # skip lines of added implied importances
-    "tests/inputs/test_universe_data.imcnp": {5: 1, 14: 1, 15: 1},
+    Path("tests")/"inputs"/"test_universe_data.imcnp": {5: 1, 14: 1, 15: 1},
     # I don't care about the edge case of shortcuts in a material def.
-    "tests/inputs/test_complement_edge.imcnp": {37: 0, 38: 0, 39: 0},
+    Path("tests")/"inputs"/"test_complement_edge.imcnp": {37: 0, 38: 0, 39: 0},
 }
 
 
@@ -1209,7 +1209,7 @@ def test_read_write_cycle(file):
     if ".swp" in file.suffixes:
         return
     problem = montepy.read_input(file, multi_proc=MULTI_PROC)
-    SKIPPERS = _SKIP_LINES.get(str(file), {})
+    SKIPPERS = _SKIP_LINES.get(file, {})
     fh = io.StringIO()
     # make string unclosable to keep open after reading.
     fh.close = lambda: None
@@ -1234,7 +1234,7 @@ def test_read_write_cycle(file):
                 else:
                     gold_line = next(gold_fh_iter)
             # edge case override for not fixing #527.
-            if str(file) == "tests/inputs/test_interp_edge.imcnp" and i == 1:
+            if file == Path("tests")/"inputs"/"test_interp_edge.imcnp" and i == 1:
                 assert new_line == "10214   0    (1  2I 4 )"
                 continue
             try:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1186,9 +1186,9 @@ def test_alternate_encoding():
 
 _SKIP_LINES = {
     # skip lines of added implied importances
-    Path("tests")/"inputs"/"test_universe_data.imcnp": {5: 1, 14: 1, 15: 1},
+    Path("tests") / "inputs" / "test_universe_data.imcnp": {5: 1, 14: 1, 15: 1},
     # I don't care about the edge case of shortcuts in a material def.
-    Path("tests")/"inputs"/"test_complement_edge.imcnp": {37: 0, 38: 0, 39: 0},
+    Path("tests") / "inputs" / "test_complement_edge.imcnp": {37: 0, 38: 0, 39: 0},
 }
 
 
@@ -1234,7 +1234,7 @@ def test_read_write_cycle(file):
                 else:
                     gold_line = next(gold_fh_iter)
             # edge case override for not fixing #527.
-            if file == Path("tests")/"inputs"/"test_interp_edge.imcnp" and i == 1:
+            if file == Path("tests") / "inputs" / "test_interp_edge.imcnp" and i == 1:
                 assert new_line == "10214   0    (1  2I 4 )"
                 continue
             try:


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This fixes an issue with some tests failing on windows. The errors ultimately came down to file paths being hard coded in strings, and not being platform agnostic. This moves all of that to using `Path()` (for the most part). 

Fixes #745

---

### General Checklist

- [ ] I have performed a self-review of my own code.
- [ ] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [ ] I have formatted my code with `black` version 25.
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--771.org.readthedocs.build/en/771/

<!-- readthedocs-preview montepy end -->