### PR TITLE
Fix bug with over-agressive LineOverRunWarning

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,13 @@ MontePy Changelog
 1.1 releases
 ============
 
+#Next Release#
+--------------
+
+**Bugs Fixed**
+
+* Fixed bug where lines that were the allowed length was raising a ``LineOverRunWarning`` when read by MontePy (:issue:`517`). 
+
 1.1.2
 --------------
 

--- a/montepy/input_parser/input_syntax_reader.py
+++ b/montepy/input_parser/input_syntax_reader.py
@@ -215,11 +215,13 @@ def read_data(fh, mcnp_version, block_type=None, recursion=False):
         old_line = line
         line = line[:line_length]
         if len(old_line) != len(line):
-            if len(line.split("$")[0]) >= line_length and not COMMENT_FINDER.match(
+            comment_free = old_line.split("$")[0]
+            if len(comment_free.rstrip()) > line_length and not COMMENT_FINDER.match(
                 line
             ):
                 warnings.warn(
-                    f"The line: {old_line} exceeded the allowed line length of: {line_length} for MCNP {mcnp_version}",
+                    f"The line number {fh.lineno} exceeded the allowed line length of: {line_length} for MCNP{mcnp_version} "
+                    f'and "{comment_free[line_length -1:].rstrip()}" was removed.',
                     LineOverRunWarning,
                 )
             # if extra length is a comment keep it long

--- a/tests/inputs/test.imcnp
+++ b/tests/inputs/test.imcnp
@@ -44,8 +44,8 @@ m2        26054.80c        5.85
           26057        2.12 $ very very very very very very very very very very very very very very long line that exceeds line limit
           26058.80c        0.28 $ trailing comment shouldn't move #458.
 C water
-C foo
-m3        1001.80c           2
+C foo               valid input up to the line length limit
+m3        1001.80c 2.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
            8016.80c           1
            plib=84p
 MT3 lwtr.23t h-zr.20t h/zr.28t


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This fixes a bug where a file that was line-wrapped by MontePy would trigger a `LineOverrunWarning` when read by MontePy. The line-wrapping was manually confirmed to be producing lines that were valid MCNP lengths. This bug was caused by two issues:

1. `\n` was being considered part of the line. This was fixed with `rstrip`
2. `>=` was being used instead of `>`. This was not allowing lines that were exactly at the limit.

This also made the Warning message more helpful. The one question  I struggled with is: should the information past the line length limit be truncated or not? Current behavior is that it is. 

Fixes #517

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--799.org.readthedocs.build/en/799/

<!-- readthedocs-preview montepy end -->