### PR TITLE
Drop numpy 1.26 and Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14-dev"]
+        python-version: ["3.12", "3.13", "3.14-dev"]
 
     steps:
       - uses: actions/checkout@v4
@@ -54,11 +54,11 @@ jobs:
       actions: write
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14-dev"]
+        python-version: ["3.12", "3.13", "3.14-dev"]
         numpy-version: ["2.0", "2.3"]
         sly-version: ["0.5"]
         include:
-          - python-version: "3.11"
+          - python-version: "3.13"
             numpy-version: "2.3"
             sly-version: "0.4"
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "A library for reading, editing, and writing MCNP input files"
 
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 maintainers = [
 	{name = "Micah Gale", email = "mgale@montepy.org"}
 ]


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This drops numpy 1.26 from supported versions with the next minor release. This is in [accordance with SPEC 0](https://scientific-python.org/specs/spec-0000/). Probably should make this drop in October, however, I doubt we will ship before then. With Python 3.11 drop we will definitely have to wait until October. 

Fixes #784, 

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).


---

<details open> 

<summary><h3>Documentation Checklist</h3></summary>


</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--807.org.readthedocs.build/en/807/

<!-- readthedocs-preview montepy end -->