### PR TITLE
feat: Extend renumber in numbered_object_collection

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -16,7 +16,6 @@ MontePy Changelog
 **Features Added**
 
 * Added support for ``Surface`` subtypes for spheres (:issue:`876`).
-* Added ``extend_renumber`` method to numbered object collections (:issue:`881`).
 
 **Bugs Fixed**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -16,7 +16,7 @@ MontePy Changelog
 **Features Added**
 
 * Added support for ``Surface`` subtypes for spheres (:issue:`876`).
-
+* Added ``extend_renumber`` method to numbered object collections (:issue:`881`).
 
 **Bugs Fixed**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,6 +5,13 @@ MontePy Changelog
 1.3 releases
 ============
 
+Next Version
+============
+
+**Feature Added**
+
+* Added ``extend_renumber`` to ``NumberedObjectCollection`` with related test cases (:issue:`881`).
+
 1.3.0
 --------------
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,7 +6,7 @@ MontePy Changelog
 ============
 
 #Next Version#
-============
+==============
 
 **Feature Added**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -5,7 +5,7 @@ MontePy Changelog
 1.3 releases
 ============
 
-Next Version
+#Next Version#
 ============
 
 **Feature Added**

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -630,11 +630,11 @@ class NumberedObjectCollection(ABC):
         return number
 
     def extend_renumber(self, other_list, step=1):
-        """Extends the collection with the given list, but will renumber objects if collision occurs.
+        """Extends the collection with the given list, renumbering objects that have conflicts.
 
-        This behaves like extend, except if there is a number collision the object will
-        be renumbered to an available number. The number will be incremented by step
-        until an available number is found.
+        This differs from extend() which fails on conflicts, and append_renumber()
+        which handles single objects. This method processes multiple
+        objects by checking and renumbering before adding.
 
         Parameters
         ----------
@@ -658,7 +658,14 @@ class NumberedObjectCollection(ABC):
                 raise TypeError(
                     f"The object in the list {obj} is not of type: {self._obj_class}"
                 )
-            self.append_renumber(obj, step)
+
+            try:
+                self.check_number(obj.number)
+            except NumberConflictError:
+                new_num = self.request_number(obj.number if obj.number > 0 else 1, step)
+                obj.number = new_num
+
+            self.append(obj)  # After loop all objects are added i.e extended
 
         return self
 

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -640,13 +640,10 @@ class NumberedObjectCollection(ABC):
         ----------
         other_list : list
             the list of objects to add.
-             step : int
+        step : int
             the incrementing step to use to find new numbers (default: 1).
 
-        Returns
-        -------
-        self
-            returns the collection for method chaining."""
+        """
 
         if not isinstance(other_list, (list, type(self))):
             raise TypeError("The extending list must be a list")
@@ -666,8 +663,6 @@ class NumberedObjectCollection(ABC):
                 obj.number = new_num
 
             self.append(obj)  # After loop all objects are added i.e extended
-
-        return self
 
     def request_number(self, start_num=None, step=None):
         """Requests a new available number.

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -629,6 +629,39 @@ class NumberedObjectCollection(ABC):
 
         return number
 
+    def extend_renumber(self, other_list, step=1):
+        """Extends the collection with the given list, but will renumber objects if collision occurs.
+
+        This behaves like extend, except if there is a number collision the object will
+        be renumbered to an available number. The number will be incremented by step
+        until an available number is found.
+
+        Parameters
+        ----------
+        other_list : list
+            the list of objects to add.
+             step : int
+            the incrementing step to use to find new numbers (default: 1).
+
+        Returns
+        -------
+        self
+            returns the collection for method chaining."""
+
+        if not isinstance(other_list, (list, type(self))):
+            raise TypeError("The extending list must be a list")
+        if not isinstance(step, Integral):
+            raise TypeError("The step number must be an int")
+
+        for obj in other_list:
+            if not isinstance(obj, self._obj_class):
+                raise TypeError(
+                    f"The object in the list {obj} is not of type: {self._obj_class}"
+                )
+            self.append_renumber(obj, step)
+
+        return self
+
     def request_number(self, start_num=None, step=None):
         """Requests a new available number.
 

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -632,7 +632,7 @@ class NumberedObjectCollection(ABC):
     def extend_renumber(self, other_list, step=1):
         """Extends the collection with the given list, renumbering objects that have conflicts.
 
-        This differs from extend() which fails on conflicts, and append_renumber()
+        This differs from :func:`extend` which fails on conflicts, and :func:`append_renumber`
         which handles single objects. This method processes multiple
         objects by checking and renumbering before adding.
 

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -230,8 +230,10 @@ class TestNumberedObjectCollection:
         with pytest.raises(TypeError):
             cells.extend_renumber([], step="hi")
         # Test return value
+        size_before = len(cells)
         result = cells.extend_renumber([])
-        assert result is cells
+        assert result is None
+        assert len(cells) == size_before
 
     def test_request_number(self, cp_simple_problem):
         cells = cp_simple_problem.cells


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

Added `extend_renumber` to Numbered_object_collection, that extends a collection with multiple objects, automatically renumbering any that have conflicting numbers.

#### Flow
Check conflict → renumber → append

Time complexity: $O(N)$

Uses `_last_assigned_number` cache optimization from PR #841, making renumbering $O(1)$ .


#### Tests:
Added Test cases `test_extend_number` in `test_numbered_collection`

Fixes #881 

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

### LLM Disclosure

Were any large language models (LLM or "AI") used in to generate any of this code?

- [ ] Yes
    - Model(s) used:
- [x] No

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [x] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [x] This PR fully addresses and resolves the referenced issue(s).
- [x] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [x] The PR covers all relevant aspects according to the development guidelines.
- [x] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--897.org.readthedocs.build/en/897/

<!-- readthedocs-preview montepy end -->