### PR TITLE
docs: fix typo in changelog (occured → occurred)

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -242,7 +242,7 @@ MontePy Changelog
 
 **Bug Fixes**
 
-* Fixed ``AttributeError`` that occured when a data block ``IMP`` was preceded by a comment (:issue:`580`).
+* Fixed ``AttributeError`` that occurred when a data block ``IMP`` was preceded by a comment (:issue:`580`).
 * Fixed bug where tally inputs in a file prevented the file from being pickled or copied (:issue:`463`).
 
 0.5.0


### PR DESCRIPTION
## Summary\n- fixes a typo in the changelog entry in \n- changes `occured` to `occurred`\n\nSmall docs-only change; no behavior changes.

<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--899.org.readthedocs.build/en/899/

<!-- readthedocs-preview montepy end -->