### PR TITLE
fix: handle None number in append_renumber (fixes #880)

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -8,6 +8,10 @@ MontePy Changelog
 #Next Version#
 ==============
 
+**Bugs Fixed**
+
+* Fixed a bug where ``append_renumber`` raised a ``TypeError`` when called with an object whose ``number`` is ``None`` (e.g. an object created with no arguments) (:issue:`880`).
+
 **Feature Added**
 
 * Added ``extend_renumber`` to ``NumberedObjectCollection`` with related test cases (:issue:`881`).

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -616,15 +616,9 @@ class NumberedObjectCollection(ABC):
             raise TypeError(f"object being appended must be of type: {self._obj_class}")
         if not isinstance(step, Integral):
             raise TypeError("The step number must be an int")
-        # If the object has no number yet (None) or an invalid number (<=0),
-        # start renumbering from 1.  We must assign a concrete number before
-        # calling append() because __internal_append requires obj.number to be
-        # a non-None integer.
         if obj.number is None or obj.number <= 0:
-            number = 1
-            obj.number = number
-        else:
-            number = obj.number
+            obj.number = 1
+        number = obj.number
         if self._problem:
             obj.link_to_problem(self._problem)
         obj._unlink_from_collection()

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -616,7 +616,15 @@ class NumberedObjectCollection(ABC):
             raise TypeError(f"object being appended must be of type: {self._obj_class}")
         if not isinstance(step, Integral):
             raise TypeError("The step number must be an int")
-        number = obj.number if obj.number > 0 else 1
+        # If the object has no number yet (None) or an invalid number (<=0),
+        # start renumbering from 1.  We must assign a concrete number before
+        # calling append() because __internal_append requires obj.number to be
+        # a non-None integer.
+        if obj.number is None or obj.number <= 0:
+            number = 1
+            obj.number = number
+        else:
+            number = obj.number
         if self._problem:
             obj.link_to_problem(self._problem)
         obj._unlink_from_collection()

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -183,6 +183,23 @@ class TestNumberedObjectCollection:
         assert cell.number == 4
         assert len(cells) == size + 2
 
+    def test_append_renumber_none_number(self, cp_simple_problem):
+        """Test that append_renumber assigns the next available number when
+        the object has no number yet (number is None).  Regression test for
+        GitHub issue #880.
+        """
+        cells = copy.deepcopy(cp_simple_problem.cells)
+        size = len(cells)
+        # montepy.Cell() created from scratch has number == None
+        new_cell = montepy.Cell()
+        assert new_cell.number is None, "Sanity: fresh Cell should have number=None"
+        assigned = cells.append_renumber(new_cell)
+        assert new_cell.number is not None, "Cell should have been assigned a number"
+        assert new_cell.number > 0, "Assigned number must be positive"
+        assert assigned == new_cell.number, "Return value must match assigned number"
+        assert assigned in cells.numbers, "Cell must be present in collection"
+        assert len(cells) == size + 1
+
     def test_append_renumber_problems(self, cp_simple_problem):
         print(hex(id(cp_simple_problem.materials._problem)))
         prob1 = copy.deepcopy(cp_simple_problem)

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -203,6 +203,7 @@ class TestNumberedObjectCollection:
         assert new_cell.number > 0, "Assigned number must be positive"
         assert assigned == new_cell.number, "Return value must match assigned number"
         assert assigned in cells.numbers, "Cell must be present in collection"
+        assert new_cell in cells, "Cell object must be iterable-accessible in collection"
         assert len(cells) == size + 1
 
     def test_append_renumber_problems(self, cp_simple_problem):

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -127,6 +127,11 @@ class TestNumberedObjectCollection:
             cells.append(cell)
         with pytest.raises(TypeError):
             cells.append(5)
+        # Directly set a negative internal value to cover the guard in
+        # __internal_append (bypasses the property-level validator).
+        cell._number.value = -1
+        with pytest.raises(ValueError):
+            cells.append(cell)
         cell.number = 20
         cells.append(cell)
         assert len(cells) == size + 1

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -203,7 +203,9 @@ class TestNumberedObjectCollection:
         assert new_cell.number > 0, "Assigned number must be positive"
         assert assigned == new_cell.number, "Return value must match assigned number"
         assert assigned in cells.numbers, "Cell must be present in collection"
-        assert new_cell in cells, "Cell object must be iterable-accessible in collection"
+        assert (
+            new_cell in cells
+        ), "Cell object must be iterable-accessible in collection"
         assert len(cells) == size + 1
 
     def test_append_renumber_problems(self, cp_simple_problem):


### PR DESCRIPTION
## Description

Fixes #880 — `append_renumber()` raises `TypeError` when called with an object whose `number` is `None` (e.g. a cell created with `montepy.Cell()` without any arguments).

**Root cause:** The guard on line 619 was:
```python
number = obj.number if obj.number > 0 else 1
```
When `obj.number is None`, the comparison `obj.number > 0` raises `TypeError: '>' not supported between instances of 'NoneType' and 'int'`. The subsequent `self.append(obj)` call has the same failure point.

**Fix:** Treat `None` the same as an invalid (`<= 0`) number — pre-assign `obj.number = 1` before `append()` so `__internal_append` always receives a concrete integer. Existing `request_number()` conflict resolution handles collisions.

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

### LLM Disclosure

Were any large language models (LLM or "AI") used to generate any of this code?

- [x] Yes
    - Model(s) used: Claude (Anthropic)
- [ ] No

<details open>

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide. (N/A — this is a bug fix)

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [x] This PR fully addresses and resolves the referenced issue(s).
- [x] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [x] 100% coverage of the patch is achieved, or justification for a variance is given.

<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--909.org.readthedocs.build/en/909/

<!-- readthedocs-preview montepy end -->