### PR TITLE
docs: fix typos tracked in #875

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -327,7 +327,7 @@ MontePy Changelog
 * Fixed bug with appending and renumbering numbered objects from other MCNP problems (:issue:`466`).
 * Fixed bug with dynamic typing and the parsers that only appear in edge cases (:issue:`461`).
 * Fixed parser bug with having spaces in the start of the transform input for the fill of a cell (:pull:`479`).
-* Fixed bug with trying to get trailing comments from non-existant parts of the syntax tree (:pull:`480`).
+* Fixed bug with trying to get trailing comments from non-existent parts of the syntax tree (:pull:`480`).
 
 **Code Quality**
 

--- a/doc/source/starting.rst
+++ b/doc/source/starting.rst
@@ -356,7 +356,7 @@ This can be done quickly with a for loop:
    for cell in problem.cells:
        cell.number += 1000
 
-Number Collisions (should) be Impossible
+Number Collisions Should Be Impossible
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``NumberedObjectCollection`` has various mechanisms internally to avoid number collisions 
@@ -838,7 +838,7 @@ Order of precedence and grouping is automatically handled by Python so you can e
 .. note::
 
   MontePy does not check if the geometry definition is "rational".
-  It doesn't check for being finite, existant (having any volume at all), or being infinite.
+  It doesn't check for being finite, existent (having any volume at all), or being infinite.
   Nor does it check for overlapping geometry.
 
 Setting and Modifying Geometry
@@ -1338,7 +1338,7 @@ Now you can add cells to this universe as you normally would.
 
 .. note::
 
-   A universe with no cells assigned will not be written out to the MCNP input file, and will "dissapear".
+   A universe with no cells assigned will not be written out to the MCNP input file, and will "disappear".
 
 .. note::
 
@@ -1412,7 +1412,7 @@ MontePy will then show which file it is reading, and show a warning for every po
 If you want to try to troubleshoot errors in python you can do this with the following steps.
 
 .. warning::
-   This following guide may return an incomplete problem object that may break in very wierd ways.
+   This following guide may return an incomplete problem object that may break in very weird ways.
    Never use this for actual file editing; only use it for troubleshooting.
 
 #. Setup a new Problem object:

--- a/doc/source/starting.rst
+++ b/doc/source/starting.rst
@@ -603,7 +603,7 @@ For Example:
    cyl.is_white_boundary = True
 
 
-Setting a periodic boundary is slightly more difficult. 
+Setting a Periodic boundary is slightly more difficult. 
 In this case the boundary condition must be set to the other periodic surface with :func:`~montepy.surfaces.surface.Surface.periodic_surface`.
 So to continue with the previous example:
 

--- a/montepy/input_parser/parser_base.py
+++ b/montepy/input_parser/parser_base.py
@@ -50,7 +50,7 @@ class MetaBuilder(sly.yacc.ParserMeta):
 
 
 class SLY_Supressor:
-    """This is a fake logger meant to mostly make warnings dissapear."""
+    """This is a fake logger meant to mostly make warnings disappear."""
 
     def __init__(self):
         self._parse_fail_queue = []


### PR DESCRIPTION
### Description

Fixes spelling errors tracked in #875.

Fixes #875

Changes:
- `starting.rst`: `(should) be` → `Should Be` (section heading grammar), `existant` → `existent`, `dissapear` → `disappear`, `wierd` → `weird`
- `changelog.rst`: `non-existant` → `non-existent`
- `parser_base.py`: docstring typo `dissapear` → `disappear`

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26. *(N/A — documentation and docstring only)*
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable). *(N/A — typo fixes only)*

---

### LLM Disclosure

Were any large language models (LLM or "AI") used in to generate any of this code?

- [x] Yes
    - Model(s) used: Claude (Anthropic)
- [ ] No

<details open>

<summary><h3>Documentation Checklist</h3></summary>

- [x] I have documented all added classes and methods. *(N/A)*
- [ ] For infrastructure updates, I have updated the developer's guide. *(N/A)*
- [ ] For significant new features, I have added a section to the getting started guide. *(N/A)*

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [x] This PR fully addresses and resolves the referenced issue(s).
- [x] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [x] The PR covers all relevant aspects according to the development guidelines.
- [x] 100% coverage of the patch is achieved, or justification for a variance is given.

<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--911.org.readthedocs.build/en/911/

<!-- readthedocs-preview montepy end -->