### PR TITLE
Remove Guardrail from NumberedObjectCollection

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -8,6 +8,10 @@ MontePy Changelog
 #Next Version#
 ==============
 
+**Performance Improvement**
+
+* Removed Guardrails from :func:`~montepy.numbered_object_collection.NumberedObjectCollection` (:issue:`895`)
+
 **Feature Added**
 
 * Added ``extend_renumber`` to ``NumberedObjectCollection`` with related test cases (:issue:`881`).

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -14,7 +14,7 @@ MontePy Changelog
 
 **Performance Improvement**
 
-* Removed Guardrails from :func:`~montepy.numbered_object_collection.NumberedObjectCollection` (:issue:`895`)
+* Removed Guardrails from :class:`~montepy.numbered_object_collection.NumberedObjectCollection` (:issue:`895`)
 
 **Feature Added**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -8,6 +8,10 @@ MontePy Changelog
 #Next Version#
 ==============
 
+**Bugs Fixed**
+
+* Fixed a bug where ``append_renumber`` raised a ``TypeError`` when called with an object whose ``number`` is ``None`` (e.g. an object created with no arguments) (:issue:`880`).
+
 **Performance Improvement**
 
 * Removed Guardrails from :func:`~montepy.numbered_object_collection.NumberedObjectCollection` (:issue:`895`)

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -613,7 +613,15 @@ class NumberedObjectCollection(ABC):
             raise TypeError(f"object being appended must be of type: {self._obj_class}")
         if not isinstance(step, Integral):
             raise TypeError("The step number must be an int")
-        number = obj.number if obj.number > 0 else 1
+        # If the object has no number yet (None) or an invalid number (<=0),
+        # start renumbering from 1.  We must assign a concrete number before
+        # calling append() because __internal_append requires obj.number to be
+        # a non-None integer.
+        if obj.number is None or obj.number <= 0:
+            number = 1
+            obj.number = number
+        else:
+            number = obj.number
         if self._problem:
             obj.link_to_problem(self._problem)
         obj._unlink_from_collection()

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -613,15 +613,9 @@ class NumberedObjectCollection(ABC):
             raise TypeError(f"object being appended must be of type: {self._obj_class}")
         if not isinstance(step, Integral):
             raise TypeError("The step number must be an int")
-        # If the object has no number yet (None) or an invalid number (<=0),
-        # start renumbering from 1.  We must assign a concrete number before
-        # calling append() because __internal_append requires obj.number to be
-        # a non-None integer.
         if obj.number is None or obj.number <= 0:
-            number = 1
-            obj.number = number
-        else:
-            number = obj.number
+            obj.number = 1
+        number = obj.number
         if self._problem:
             obj.link_to_problem(self._problem)
         obj._unlink_from_collection()

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -254,12 +254,9 @@ class NumberedObjectCollection(ABC):
             raise ValueError(f"The number must be non-negative. {number} given.")
         conflict = False
         # only can trust cache if being updated
-        if self._problem:
-            if number in self.__num_cache:
-                conflict = True
-        else:
-            if number in self.numbers:
-                conflict = True
+        if number in self.__num_cache:
+            conflict = True
+
         if conflict:
             raise NumberConflictError(
                 f"Number {number} is already in use for the collection: {type(self).__name__} by {self[number]}"
@@ -1123,17 +1120,9 @@ class NumberedObjectCollection(ABC):
         -------
         Numbered_MCNP_Object
         """
-        try:
-            ret = self.__num_cache[i]
-            if ret.number == i:
-                return ret
-        except KeyError:
-            pass
-        for obj in self._objects:
-            self.__num_cache[obj.number] = obj
-            if obj.number == i:
-                self.__num_cache[i] = obj
-                return obj
+        ret = self.__num_cache.get(i)
+        if ret is not None and ret.number == i:
+            return ret
         return default
 
     def keys(self) -> typing.Generator[int, None, None]:

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -253,7 +253,7 @@ class NumberedObjectCollection(ABC):
         if number < 0:
             raise ValueError(f"The number must be non-negative. {number} given.")
         conflict = False
-        # only can trust cache if being updated
+        # __num_cache is treated as authoritative: any present key is considered in use
         if number in self.__num_cache:
             conflict = True
 

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -1122,10 +1122,7 @@ class NumberedObjectCollection(ABC):
         -------
         Numbered_MCNP_Object
         """
-        ret = self.__num_cache.get(i)
-        if ret is not None and ret.number == i:
-            return ret
-        return default
+        return self.__num_cache.get(i, default)
 
     def keys(self) -> typing.Generator[int, None, None]:
         """Get iterator of the collection's numbers.

--- a/tests/test_cell_problem.py
+++ b/tests/test_cell_problem.py
@@ -275,9 +275,6 @@ def verify_internal_links(cell):
 
 def verify_clone_format(cell):
     surf = list(cell.surfaces)[0]
-    old_num = surf.number
-    num = 1000
-    surf.number = num
     output = cell.format_for_mcnp_input((6, 3, 0))
     note(output)
     input = montepy.input_parser.mcnp_input.Input(
@@ -292,8 +289,7 @@ def verify_clone_format(cell):
     for attr in {"number", "mass_density", "old_mat_number"}:
         assert getattr(cell, attr) == getattr(new_cell, attr)
     new_surf = list(new_cell.surfaces)[0]
-    assert new_surf.number == num
-    surf.number = old_num
+    assert new_surf.number == surf.number
 
 
 def test_cell_clone_default():

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -183,6 +183,23 @@ class TestNumberedObjectCollection:
         assert cell.number == 4
         assert len(cells) == size + 2
 
+    def test_append_renumber_none_number(self, cp_simple_problem):
+        """Test that append_renumber assigns the next available number when
+        the object has no number yet (number is None).  Regression test for
+        GitHub issue #880.
+        """
+        cells = copy.deepcopy(cp_simple_problem.cells)
+        size = len(cells)
+        # montepy.Cell() created from scratch has number == None
+        new_cell = montepy.Cell()
+        assert new_cell.number is None, "Sanity: fresh Cell should have number=None"
+        assigned = cells.append_renumber(new_cell)
+        assert new_cell.number is not None, "Cell should have been assigned a number"
+        assert new_cell.number > 0, "Assigned number must be positive"
+        assert assigned == new_cell.number, "Return value must match assigned number"
+        assert assigned in cells.numbers, "Cell must be present in collection"
+        assert len(cells) == size + 1
+
     def test_append_renumber_problems(self, cp_simple_problem):
         print(hex(id(cp_simple_problem.materials._problem)))
         prob1 = copy.deepcopy(cp_simple_problem)

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -97,16 +97,6 @@ class TestNumberedObjectCollection:
         extender[1].number = 60
         surfaces.extend(extender)
         assert len(surfaces) == size + 2
-        # force a num_cache miss
-        extender = copy.deepcopy(extender)
-        for surf in extender:
-            surf._problem = None
-            surf._collection_ref = None
-        surfaces[1000].number = 1
-        extender[0].number = 1000
-        extender[1].number = 70
-        surfaces.extend(extender)
-        assert len(surfaces) == size + 4
         with pytest.raises(TypeError):
             surfaces.extend(5)
         with pytest.raises(TypeError):

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -203,6 +203,7 @@ class TestNumberedObjectCollection:
         assert new_cell.number > 0, "Assigned number must be positive"
         assert assigned == new_cell.number, "Return value must match assigned number"
         assert assigned in cells.numbers, "Cell must be present in collection"
+        assert new_cell in cells, "Cell object must be iterable-accessible in collection"
         assert len(cells) == size + 1
 
     def test_append_renumber_problems(self, cp_simple_problem):

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -127,6 +127,11 @@ class TestNumberedObjectCollection:
             cells.append(cell)
         with pytest.raises(TypeError):
             cells.append(5)
+        # Directly set a negative internal value to cover the guard in
+        # __internal_append (bypasses the property-level validator).
+        cell._number.value = -1
+        with pytest.raises(ValueError):
+            cells.append(cell)
         cell.number = 20
         cells.append(cell)
         assert len(cells) == size + 1

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -203,7 +203,9 @@ class TestNumberedObjectCollection:
         assert new_cell.number > 0, "Assigned number must be positive"
         assert assigned == new_cell.number, "Return value must match assigned number"
         assert assigned in cells.numbers, "Cell must be present in collection"
-        assert new_cell in cells, "Cell object must be iterable-accessible in collection"
+        assert (
+            new_cell in cells
+        ), "Cell object must be iterable-accessible in collection"
         assert len(cells) == size + 1
 
     def test_append_renumber_problems(self, cp_simple_problem):


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

Removed Guardrail from `NumberedObjectCollection` 
 [See this guardrail that is no longer covered because of this](https://coveralls.io/builds/77662955/source?filename=montepy%2Fnumbered_object_collection.py#L1097). 
 
 - Updated `check_number()` in `NumberObjectCollection` to follow changes
 
The problem is that test intent is already covered by the fact that `clone_region=True` clones the surface and assigns it a brand new number anyway. So by the time `verify_clone_format` is called, surf.number is already a freshly assigned number, not 2 anymore. The temporary mutation to 1000 was redundant and just added fragility.

 - Updated `verify_clone_format` test in `test_cell_problem` 


Fixes #895

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26.
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

### LLM Disclosure

1. Are you?

   - [x] A human user 
   - [ ] A large language model (LLM), including ones acting on behalf of a human

1. Were any large language models (LLM or "AI") used in to generate any of this code?

  - [ ] Yes
      - Model(s) used:
  - [x] No

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [x] This PR fully addresses and resolves the referenced issue(s).
- [x] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [x] The PR covers all relevant aspects according to the development guidelines.
- [x] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--915.org.readthedocs.build/en/915/

<!-- readthedocs-preview montepy end -->