### PR TITLE
fix(cell): allow nullifying Cell.universe via None or del (#902)

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -11,6 +11,7 @@ MontePy Changelog
 **Bugs Fixed**
 
 * Fixed a bug where ``append_renumber`` raised a ``TypeError`` when called with an object whose ``number`` is ``None`` (e.g. an object created with no arguments) (:issue:`880`).
+* ``Cell.universe`` can now be set to ``None`` (or deleted via ``del cell.universe``) to reset the universe assignment back to the default (:issue:`902`).
 
 **Feature Added**
 

--- a/montepy/cell.py
+++ b/montepy/cell.py
@@ -254,9 +254,16 @@ class Cell(Numbered_MCNP_Object):
 
     @universe.setter
     def universe(self, value):
+        if value is None:
+            self._universe._universe = None
+            return
         if not isinstance(value, Universe):
             raise TypeError("universe must be set to a Universe")
         self._universe.universe = value
+
+    @universe.deleter
+    def universe(self):
+        self._universe._universe = None
 
     @property
     def fill(self):

--- a/tests/test_universe_integration.py
+++ b/tests/test_universe_integration.py
@@ -46,6 +46,24 @@ def test_universe_setter(cells):
         cell_verify(basic_cell)
 
 
+def test_universe_nullify(cells):
+    """Cell.universe can be set to None (or deleted) to reset to the default."""
+    for basic_cell in cells:
+        uni = Universe(5)
+        basic_cell.universe = uni
+        assert basic_cell.universe is not None
+
+        # Setting to None should work
+        basic_cell.universe = None
+        assert basic_cell.universe is None
+
+        # Setting back, then using del
+        basic_cell.universe = uni
+        assert basic_cell.universe is not None
+        del basic_cell.universe
+        assert basic_cell.universe is None
+
+
 def test_fill_setter(cells):
     for basic_cell in cells:
         uni = Universe(5)


### PR DESCRIPTION
Closes #902.

## Problem

Setting `cell.universe = None` raised `TypeError`, and `del cell.universe` raised `AttributeError`. This made it impossible to reset a cell's universe assignment back to the default (universe 0) once it had been set.

```python
>>> c = montepy.Cell()
>>> c.universe is None
True
>>> c.universe = montepy.Universe(5)
>>> c.universe = None   # TypeError (before this fix)
>>> del c.universe      # AttributeError (before this fix)
```

## Fix

- **`universe.setter`**: short-circuits when `value is None`, directly resetting `_universe._universe = None` (the same internal state as a newly-constructed cell)
- **`universe.deleter`**: new — does the same thing as `setter(None)`

The `UniverseInput` type guard is intentionally bypassed for the `None` case only, so all other invalid types still raise `TypeError`.

## Tests

Added `test_universe_nullify` in `tests/test_universe_integration.py` covering both code paths (set to None, delete) on both parsed and programmatically created cells.

All 952 existing tests pass.

---
*Note: I'm an AI assistant (Claude via OpenClaw). Happy to revise based on feedback.*

<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--917.org.readthedocs.build/en/917/

<!-- readthedocs-preview montepy end -->