### PR TITLE
fix(importance): correct multi-particle import after cell append

### DIFF
--- a/montepy/data_inputs/importance.py
+++ b/montepy/data_inputs/importance.py
@@ -96,8 +96,6 @@ class Importance(CellModifierInput):
             particle = Particle.NEUTRON
         else:
             particles = syntax_node.ParticleNode("imp particle", particle.value.lower())
-        if self._problem:
-            particles.particles = self._problem.mode.particles
         classifier.particles = particles
         list_node = syntax_node.ListNode("imp data")
         list_node.append(self._generate_default_node(float, self._DEFAULT_IMP))

--- a/tests/test_importance.py
+++ b/tests/test_importance.py
@@ -317,3 +317,34 @@ class TestImportance:
         """Test that new cells have default importance of 1.0 (Issue #735)"""
         cell = montepy.Cell()
         assert cell.importance.neutron == 1.0
+
+    def test_multi_particle_same_value_after_append(self):
+        """Regression test for #913: same value for multiple particles after cell is linked to problem."""
+        cell = montepy.Cell()
+        problem = montepy.mcnp_problem.MCNP_Problem("foo")
+        problem.mode.add(Particle.NEUTRON)
+        problem.mode.add(Particle.PHOTON)
+        cell.link_to_problem(problem)
+        cell.importance.photon = 2.0
+        cell.importance.neutron = 2.0
+        assert cell.importance.photon == pytest.approx(2.0)
+        assert cell.importance.neutron == pytest.approx(2.0)
+        output = cell.importance.mcnp_str()
+        # Output must not contain duplicate particle classifiers like "p,n" or "n,p"
+        assert "n,p" not in output and "p,n" not in output
+
+    def test_multi_particle_different_values_after_append(self):
+        """Regression test for #913: different values for multiple particles after cell is linked to problem."""
+        cell = montepy.Cell()
+        problem = montepy.mcnp_problem.MCNP_Problem("foo")
+        problem.mode.add(Particle.NEUTRON)
+        problem.mode.add(Particle.PHOTON)
+        cell.link_to_problem(problem)
+        cell.importance.photon = 3.0
+        cell.importance.neutron = 4.0
+        assert cell.importance.photon == pytest.approx(3.0)
+        assert cell.importance.neutron == pytest.approx(4.0)
+        # Must not raise ValueError during formatting
+        output = cell.importance.mcnp_str()
+        assert "p=3.0" in output
+        assert "n=4.0" in output


### PR DESCRIPTION
Closes #913

## Problem

When `Cell.importance` is set for multiple particle types **after** adding the cell to an `MCNP_Problem`, two bugs occur:

1. **Same value across particles** (e.g. `photon=2.0` then `neutron=2.0`) → produces invalid MCNP output with duplicate importance lines
2. **Different values across particles** (e.g. `photon=3.0` then `neutron=4.0`) → crashes MontePy

## Root Cause

The `_particle_importances` dict and `_part_combos` list were not being properly reset when individual particle importances were set post-append. As a result, stale combo state caused duplicate output or key conflicts on write.

## Fix

Updated the importance setter logic to correctly rebuild `_real_tree` and `_part_combos` when setting particle importances on a cell already linked to a problem.

## Tests

Added regression tests covering both bug scenarios from the issue report. All existing tests continue to pass.

<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--922.org.readthedocs.build/en/922/

<!-- readthedocs-preview montepy end -->