### PR TITLE
Harden Github actions using zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
+      semver-major-days: 28
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown: 
+      default-days: 8

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -23,6 +23,8 @@ jobs:
       
   build-packages:
     name: Build, sign, and release packages on github
+    environment:
+      name: build-pypi
     runs-on: ubuntu-latest
     needs: [last-minute-test]
     permissions:

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest    
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          persist-credentials: false
       - name: set up python  3.14
         uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
@@ -33,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
       - name: set up python  3.14
         uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -56,7 +56,8 @@ jobs:
             ./dist/*.tar.gz
             ./dist/*.whl
       - name: Create a GitHub release
-        run:| gh release create "v${ steps.get_version.outputs.version }" \
+        run: | 
+            gh release create "v${ steps.get_version.outputs.version }" \
             --title="Release ${ steps.get_version.outputs.version }" \
             --generate-notes -d
       - run: >-

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -11,11 +11,11 @@ jobs:
       contents: read
     runs-on: ubuntu-latest    
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       - name: set up python  3.14
-        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with: 
           python-version: 3.14
       - run: pip install . montepy[develop]
@@ -33,13 +33,13 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
       - name: set up python  3.14
-        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with: 
           python-version: 3.14
       - run: pip install . montepy[build]
@@ -50,7 +50,7 @@ jobs:
         run: .github/scripts/check_version.py --alpha 
       - run: python -m build .
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@cd06a1783504a0c8e550f0d0cd47d3bbae8d71bd
+        uses: sigstore/gh-action-sigstore-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -9,9 +9,9 @@ jobs:
   last-minute-test:
     runs-on: ubuntu-latest    
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
       - name: set up python  3.14
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
           python-version: 3.14
       - run: pip install . montepy[develop]
@@ -27,12 +27,12 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: set up python  3.14
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
           python-version: 3.14
       - run: pip install . montepy[build]
@@ -58,7 +58,7 @@ jobs:
           gh release upload
           'v${{ steps.get_version.outputs.version }}' dist/**
           --repo '${{ github.repository }}'
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with: 
            name: build
            path: |
@@ -76,7 +76,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
         with:
           name: build
           path: dist/
@@ -95,7 +95,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
         with:
           name: build
           path: dist/

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   last-minute-test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest    
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -56,11 +56,9 @@ jobs:
             ./dist/*.tar.gz
             ./dist/*.whl
       - name: Create a GitHub release
-        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b
-        with:
-          tag: v${{ steps.get_version.outputs.version }}
-          name: Release ${{ steps.get_version.outputs.version }}
-          draft: true
+        run:| gh release create "v${ steps.get_version.outputs.version }" \
+            --title="Release ${ steps.get_version.outputs.version }" \
+            --generate-notes -d
       - run: >-
           gh release upload
           'v${{ steps.get_version.outputs.version }}' dist/**

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,11 +57,9 @@ jobs:
             ./dist/*.tar.gz
             ./dist/*.whl
       - name: Create a GitHub release
-        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b
-        with:
-          tag: v${{ steps.get_version.outputs.version }}
-          name: Release ${{ steps.get_version.outputs.version }}
-          draft: true
+        run:| gh release create "v${ steps.get_version.outputs.version }" \
+            --title="Release ${ steps.get_version.outputs.version }" \
+            --generate-notes -d
       - run: >-
           gh release upload
           'v${{ steps.get_version.outputs.version }}' dist/**

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ jobs:
   
   build-packages:
     name: Build, sign, and release packages on github
+    environment:
+      name: build-pypi
     runs-on: ubuntu-latest
     needs: [last-minute-test]
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   last-minute-test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest    
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest    
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          persist-credentials: false
       - name: set up python  3.14
         uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
@@ -34,6 +36,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
       - name: set up python  3.14
         uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,9 @@ jobs:
   last-minute-test:
     runs-on: ubuntu-latest    
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
       - name: set up python  3.14
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
           python-version: 3.14
       - run: pip install . montepy[develop]
@@ -28,12 +28,12 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: set up python  3.14
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
           python-version: 3.14
       - run: pip install . montepy[build]
@@ -59,7 +59,7 @@ jobs:
           gh release upload
           'v${{ steps.get_version.outputs.version }}' dist/**
           --repo '${{ github.repository }}'
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with: 
            name: build
            path: |
@@ -78,7 +78,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
         with:
           name: build
           path: dist/
@@ -97,7 +97,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
         with:
           name: build
           path: dist/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,11 +11,11 @@ jobs:
       contents: read
     runs-on: ubuntu-latest    
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       - name: set up python  3.14
-        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with: 
           python-version: 3.14
       - run: pip install . montepy[develop]
@@ -34,13 +34,13 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
       - name: set up python  3.14
-        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with: 
           python-version: 3.14
       - run: pip install . montepy[build]
@@ -51,7 +51,7 @@ jobs:
         run: .github/scripts/check_version.py
       - run: python -m build .
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@cd06a1783504a0c8e550f0d0cd47d3bbae8d71bd
+        uses: sigstore/gh-action-sigstore-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,9 +57,10 @@ jobs:
             ./dist/*.tar.gz
             ./dist/*.whl
       - name: Create a GitHub release
-        run:| gh release create "v${ steps.get_version.outputs.version }" \
-            --title="Release ${ steps.get_version.outputs.version }" \
-            --generate-notes -d
+        run: | 
+             gh release create "v${ steps.get_version.outputs.version }" \
+             --title="Release ${ steps.get_version.outputs.version }" \
+             --generate-notes -d
       - run: >-
           gh release upload
           'v${{ steps.get_version.outputs.version }}' dist/**

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,12 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
           fetch-depth: 0
           fetch-tags: true
       - name: set up python  ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
           python-version: ${{ matrix.python-version }}
       - run: pip install --upgrade pip
@@ -42,7 +42,7 @@ jobs:
       - run: pip install --user . montepy[develop]
       - run: pip freeze
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         if: ${{ matrix.python-version == '3.13'}}
         with: 
            name: build
@@ -63,9 +63,9 @@ jobs:
             sly-version: "0.4"
     
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
       - name: set up python  ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
           python-version: ${{ matrix.python-version }}
       - run: pip install numpy~=${{ matrix.numpy-version }}
@@ -84,13 +84,13 @@ jobs:
         if:  ${{ success() || failure() }}
       - name: Upload test report
         if: ${{ matrix.python-version == '3.14' && matrix.numpy-version == '2.3' && (success() || failure() )}}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: test
           path: test_report.xml
       - name: Upload coverage report
         if: ${{ matrix.python-version == '3.14' && matrix.numpy-version == '2.3' && (success() || failure() )}}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: coverage
           path: coverage.xml
@@ -109,18 +109,18 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: set up python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
           python-version: 3.14
       - run: pip install . montepy[doc,build]
       - run: cd doc && make html SPHINXOPTS="-W --keep-going -E"
         name: Build site strictly
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: website
           path: doc/build
@@ -133,12 +133,12 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: set up python 3.14
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
           python-version: 3.14
       - run: pip install . montepy[doc,build,demo-test,test]
@@ -158,9 +158,9 @@ jobs:
     
     steps:
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
       - name: set up python 3.14
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
           python-version: 3.14
       - run: pip install . montepy[format]
@@ -170,9 +170,9 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
       - name: set up python 3.14
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
           python-version: 3.14
       - run: pip install . montepy[test]
@@ -187,9 +187,9 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
       - name: set up python 3.14
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
           python-version: 3.14
       - run: pip install . montepy[test]
@@ -202,9 +202,9 @@ jobs:
     if: github.ref != 'refs/heads/main'
     
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
       - name: Check for changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c
         id: changes
         with:
           filters: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
@@ -107,6 +109,8 @@ jobs:
 
   doc-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
@@ -131,6 +135,8 @@ jobs:
   
   doc-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
@@ -155,6 +161,8 @@ jobs:
 
   format-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
 
@@ -168,6 +176,8 @@ jobs:
   
   profile:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
@@ -185,6 +195,8 @@ jobs:
   
   benchmark:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
@@ -199,6 +211,8 @@ jobs:
         
   changelog-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.ref != 'refs/heads/main'
     
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,13 +16,13 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with: 
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
       - name: set up python  ${{ matrix.python-version }}
-        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with: 
           python-version: ${{ matrix.python-version }}
       - run: pip install --upgrade pip
@@ -66,11 +66,11 @@ jobs:
             sly-version: "0.4"
     
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       - name: set up python  ${{ matrix.python-version }}
-        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with: 
           python-version: ${{ matrix.python-version }}
       - run: pip install numpy~=${{ matrix.numpy-version }}
@@ -116,13 +116,13 @@ jobs:
       contents: read
     
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
       - name: set up python 3.12
-        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with: 
           python-version: 3.14
       - run: pip install . montepy[doc,build]
@@ -143,13 +143,13 @@ jobs:
       contents: read
     
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
       - name: set up python 3.14
-        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with: 
           python-version: 3.14
       - run: pip install . montepy[doc,build,demo-test,test]
@@ -171,11 +171,11 @@ jobs:
     
     steps:
 
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       - name: set up python 3.14
-        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with: 
           python-version: 3.14
       - run: pip install . montepy[format]
@@ -187,11 +187,11 @@ jobs:
       contents: read
     
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       - name: set up python 3.14
-        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with: 
           python-version: 3.14
       - run: pip install . montepy[test]
@@ -208,11 +208,11 @@ jobs:
       contents: read
     
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       - name: set up python 3.14
-        uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with: 
           python-version: 3.14
       - run: pip install . montepy[test]
@@ -227,7 +227,7 @@ jobs:
     if: github.ref != 'refs/heads/main'
     
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
       - name: Check for changes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
         with: 
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
       - name: set up python  ${{ matrix.python-version }}
         uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
@@ -66,6 +67,8 @@ jobs:
     
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          persist-credentials: false
       - name: set up python  ${{ matrix.python-version }}
         uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
@@ -117,6 +120,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
       - name: set up python 3.12
         uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
@@ -143,6 +147,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
       - name: set up python 3.14
         uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
@@ -167,6 +172,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          persist-credentials: false
       - name: set up python 3.14
         uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
@@ -181,6 +188,8 @@ jobs:
     
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          persist-credentials: false
       - name: set up python 3.14
         uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
@@ -200,6 +209,8 @@ jobs:
     
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          persist-credentials: false
       - name: set up python 3.14
         uses: actions/setup-python@0c366fd6a839edf440554fa01a7085ccba70ac98
         with: 
@@ -217,6 +228,8 @@ jobs:
     
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          persist-credentials: false
       - name: Check for changes
         uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c
         id: changes

--- a/.github/workflows/rtd_link.yml
+++ b/.github/workflows/rtd_link.yml
@@ -8,6 +8,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: readthedocs/actions/preview@v1
+      - uses: readthedocs/actions/preview@31a30360a2d7530806bff6855aa209167f06a89c
         with:
           project-slug: "montepy"


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This was inspired by a recent [incident of an OpenClaw bot exploiting GHA](https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation#attack-6-aquasecuritytrivy---evidence-cleared). From this I was introduced to [`zizmor`](https://docs.zizmor.sh/), which performs a security audit on your github actions configuration.  

Things changed:

1. Pinned all actions to a commit sha, irrespective of source, to mitigate supplier-side attacks.
2. Explicitly set permissions for all jobs 
3. Set a cooldown for dependabot to avoid using brand new release
4. set `persist-credentials: false` for all `checkout` runs. This avoid malicious code accessing the runner's secrets and being able to exploit them outside this one job.
5. Removed a third-party GHA that's always sketched me out in favor for using the `gh` cli to create a release.

The current audit issues are:

```
🌈 zizmor v1.23.1
 INFO audit: zizmor: 🌈 completed ./.github/dependabot.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/deploy-alpha.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/deploy.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/main.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/rtd_link.yml
info[template-injection]: code injection via template expansion
  --> ./.github/workflows/deploy-alpha.yml:65:17
   |
63 |       - run: >-
   |         --- this run block
64 |           gh release upload
65 |           'v${{ steps.get_version.outputs.version }}' dist/**
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

info[template-injection]: code injection via template expansion
  --> ./.github/workflows/deploy.yml:66:17
   |
64 |       - run: >-
   |         --- this run block
65 |           gh release upload
66 |           'v${{ steps.get_version.outputs.version }}' dist/**
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

error[dangerous-triggers]: use of fundamentally insecure workflow trigger
 --> ./.github/workflows/rtd_link.yml:2:1
  |
2 | / on:
3 | |   pull_request_target:
4 | |     types: [opened, reopened, edited]
  | |_____________________________________^ pull_request_target is almost always used insecurely
  |
  = note: audit confidence → Medium
```

So for use of `steps.get_version.outputs.version`. This is inside of the release process which only can run on protected branches, so we should catch malicious code prior to this exploit being used. For security I added a new environment that requires manual workflow approval prior to running this job (via `environment`). This should provide a last line of defense.

On the `pull_request_target` issue. [This issue seems to be](https://github.com/zizmorcore/zizmor/issues/82) that the job is ran using the PR's code, but in the context of the parent repo. So this could give an unknown user instant access to secrets. However this is the job in question:

``` yaml
name: add RTD links
on:
  pull_request_target:
    types: [opened, reopened, edited]
jobs:
  add_rtd_link:
    permissions:
      pull-requests: write
    runs-on: ubuntu-latest
    steps:
      - uses: readthedocs/actions/preview@31a30360a2d7530806bff6855aa209167f06a89c
        with:
          project-slug: "montepy"

```

I don't this is an issue for a few reasons:

1. the permissions are limited
2. No secrets are given to this job
3. No user code is checked out. 
4. Rather RTD code is ran to update the pull request message. 

Therefore I think this usage doesn't create a significant risk currently. 


Note: this may break the deploy CI. I figure if it is broken it will stop the deployment, and we can deal with that issue when it comes up.

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26.
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

### LLM Disclosure

1. Are you?

   - [x] A human user 
   - [ ] A large language model (LLM), including ones acting on behalf of a human

1. Were any large language models (LLM or "AI") used in to generate any of this code?

  - [ ] Yes
      - Model(s) used:
  - [x] No

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] This PR fully addresses and resolves the referenced issue(s).
- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--925.org.readthedocs.build/en/925/

<!-- readthedocs-preview montepy end -->