### PR TITLE
Consider surface constants and coordinates to be a Sequence, not an Iterable

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -8,6 +8,11 @@ MontePy Changelog
 
 **Features Added**
 
+**Code Quality**
+
+* Check surface constants against ``Sequence`` instead of ``Iterable`` (:issue:`914`).
+
+**Features Added**
 
 * Add _checkvalue.py_ to codebase (:issue:`687`). 
 * Added ``extend_renumber`` to ``NumberedObjectCollection`` with related test cases (:issue:`881`).

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -8,14 +8,7 @@ MontePy Changelog
 
 **Features Added**
 
-**Code Quality**
-
-* Check surface constants against ``Sequence`` instead of ``Iterable`` (:issue:`914`).
-
-**Features Added**
-
 * Add _checkvalue.py_ to codebase (:issue:`687`). 
-* Added ``extend_renumber`` to ``NumberedObjectCollection`` with related test cases (:issue:`881`).
 
 
 1.3 releases

--- a/montepy/surfaces/cylinder_par_axis.py
+++ b/montepy/surfaces/cylinder_par_axis.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, Battelle Energy Alliance, LLC All Rights Reserved.
+# Copyright 2024-2026, Battelle Energy Alliance, LLC All Rights Reserved.
 from __future__ import annotations
 
 import montepy
@@ -74,7 +74,7 @@ class CylinderParAxis(Surface):
 
     @coordinates.setter
     @args_checked
-    def coordinates(self, coordinates: ty.Iterable[ty.Real]):
+    def coordinates(self, coordinates: ty.Sequence[ty.Real]):
         if len(coordinates) != 2:
             raise ValueError("coordinates must have exactly two elements")
         for i, val in enumerate(coordinates):

--- a/montepy/surfaces/general_sphere.py
+++ b/montepy/surfaces/general_sphere.py
@@ -32,7 +32,6 @@ class GeneralSphere(Surface):
         self,
         input: InitInput = None,
         number: ty.PositiveInt = None,
-        surface_type: SurfaceType | str = None,
     ):
         self._coordinates = [
             self._generate_default_node(float, None),
@@ -76,7 +75,7 @@ class GeneralSphere(Surface):
 
     @coordinates.setter
     @args_checked
-    def coordinates(self, coordinates: ty.Iterable[ty.Real]):
+    def coordinates(self, coordinates: ty.Sequence[ty.Real]):
         if len(coordinates) != 3:
             raise ValueError("coordinates must have exactly three elements")
         for i, val in enumerate(coordinates):

--- a/montepy/surfaces/surface.py
+++ b/montepy/surfaces/surface.py
@@ -237,7 +237,7 @@ class Surface(Numbered_MCNP_Object):
 
     @surface_constants.setter
     @args_checked
-    def surface_constants(self, constants: ty.Iterable[ty.Real]):
+    def surface_constants(self, constants: ty.Sequence[ty.Real]):
         if len(constants) != len(self._surface_constants):
             raise ValueError(f"Cannot change the length of the surface constants.")
         for i, value in enumerate(constants):

--- a/montepy/types.py
+++ b/montepy/types.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Callable
+from collections.abc import Iterable, Callable, Sequence
 from numbers import Real, Integral
 from typing import Annotated, Self
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -120,9 +120,7 @@ def test_geometry_comments():
       :(-11536    97  -401 )  $ C 3 Lower water
       :(-11546    97  -401 )  $ C 4 Lower water
       :(-11556    97  -401 )  $ C 5 Lower water
-      :(-11576    97  -401 ) imp:n=1 $ C 7 Lower water""".split(
-        "\n"
-    )
+      :(-11576    97  -401 ) imp:n=1 $ C 7 Lower water""".split("\n")
     input_obj = montepy.input_parser.mcnp_input.Input(
         in_strs, montepy.input_parser.block_type.BlockType.CELL
     )

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -47,8 +47,7 @@ class TestMaterial:
 
     @pytest.fixture
     def parsed_material(_):
-        return Material(
-            """M1   1001.00c   0.05
+        return Material("""M1   1001.00c   0.05
       1001.04c   0.05
       1001.80c   0.05
       1001.04p   0.05
@@ -64,8 +63,7 @@ class TestMaterial:
       95242      0.05
       27560.50c  0.05
       94239      0.05
-      28000.60c  0.05"""
-        )
+      28000.60c  0.05""")
 
     @pytest.fixture
     def materials(_, big_material, parsed_material):

--- a/tests/test_surfaces.py
+++ b/tests/test_surfaces.py
@@ -472,6 +472,10 @@ def test_cylinder_location_setter():
     # test wrong type
     with pytest.raises(TypeError):
         surf.coordinates = "fo"
+    with pytest.raises(TypeError):
+        surf.coordinates = {5, 6, 7}
+    with pytest.raises(TypeError):
+        surf.coordinates = iter((5, 6, 7))
     # test length issues
     with pytest.raises(ValueError):
         surf.coordinates = [3, 4, 5]
@@ -487,6 +491,10 @@ def test_sphere_coordinate_setter():
         surf.coordinates = 6
     with pytest.raises(TypeError):
         surf.coordinates = (6, 7, "eight")
+    with pytest.raises(TypeError):
+        surf.coordinates = {6, 7}
+    with pytest.raises(TypeError):
+        surf.coordinates = iter((6, 7))
     # test length issues
     with pytest.raises(ValueError):
         surf.coordinates = [6, 7]
@@ -497,7 +505,6 @@ def test_sphere_location_setter():
     assert surf.location == 3.0
     surf.location = 4.0
     assert surf.location == 4.0
-    # test length issues
     with pytest.raises(TypeError):
         surf.location = "over there"
 


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

Previously, the type checker verified that surface coordinates and coefficients were instances of `Iterable`. This was overly permissive, as it would allow objects like sets and generators to be used. Now, they only allowed to be instances of `Sequence`, which has a definite order and length.

Fixes #914 

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

### LLM Disclosure

1. Are you?

   - [x] A human user 

1. Were any large language models (LLM or "AI") used in to generate any of this code?

  - [x] No

---

### Additional Notes for Reviewers

Ensure that:

- [x] This PR fully addresses and resolves the referenced issue(s).
- [x] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [x] The PR covers all relevant aspects according to the development guidelines.
- [x] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--926.org.readthedocs.build/en/926/

<!-- readthedocs-preview montepy end -->