### PR TITLE
fix(write): skip blank-line terminator for empty cell/surface blocks

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -10,6 +10,7 @@ MontePy Changelog
 
 **Bugs Fixed**
 
+* Fixed a bug where ``write_problem`` added two unnecessary trailing blank lines when writing a problem with empty cell and/or surface blocks (e.g. a pure ``READ`` include file) (:issue:`523`).
 * Fixed a bug where ``append_renumber`` raised a ``TypeError`` when called with an object whose ``number`` is ``None`` (e.g. an object created with no arguments) (:issue:`880`).
 
 **Feature Added**

--- a/montepy/mcnp_problem.py
+++ b/montepy/mcnp_problem.py
@@ -619,7 +619,7 @@ class MCNP_Problem:
                         self.data_inputs, self.mcnp_version
                     ):
                         inp.write(line + "\n")
-                elif terminate:
+                elif terminate and objects:
                     inp.write("\n")
 
         self._handle_warnings(warning_catch)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -254,3 +254,20 @@ def test_expanding_new_line():
     fill.universes = np.array([[universes]])
     with io.StringIO() as fh, pytest.warns(LineExpansionWarning):
         problem.write_problem(fh)
+
+
+def test_no_trailing_blank_lines_for_empty_blocks():
+    """Ensure write_problem does not emit blank-line terminators for empty
+    cell/surface blocks (e.g. a pure-READ include file). Regression for
+    GitHub issue #523."""
+    problem = montepy.read_input(Path("tests") / "inputs" / "testReadRec2.imcnp")
+    assert len(problem.cells) == 0
+    assert len(problem.surfaces) == 0
+    with io.StringIO() as fh:
+        problem.write_problem(fh)
+        content = fh.getvalue()
+    # The output must end with exactly one newline (no extra blank lines)
+    assert content == content.rstrip("\n") + "\n", (
+        f"write_problem added unexpected trailing blank lines; "
+        f"got trailing newlines: {len(content) - len(content.rstrip(chr(10)))}"
+    )


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

When writing a problem that has no cells or no surfaces (e.g. a pure `READ` include file), `_write_to_stream` unconditionally emitted a blank-line block terminator even though no content for that block was written. This produced two spurious trailing blank lines at the end of the output.

**Root cause:** the `elif terminate: inp.write("\n")` branch ran regardless of whether any objects were present in the block.

**Fix:** guard the terminator with `elif terminate and objects:` so the blank separator is only written when the block actually has content.

Fixes #523

**One-line change in `mcnp_problem.py`:**
```python
# before
elif terminate:
    inp.write("\n")

# after
elif terminate and objects:
    inp.write("\n")
```

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

### LLM Disclosure

1. Are you?

   - [ ] A human user
   - [x] A large language model (LLM), including ones acting on behalf of a human

1. Were any large language models (LLM or "AI") used in to generate any of this code?

   - [x] Yes
       - Model(s) used: Claude (Anthropic)
   - [ ] No

<details open>

<summary><h3>Documentation Checklist</h3></summary>

- [x] I have documented all added classes and methods.
- [x] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide. *(bug fix only)*

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] This PR fully addresses and resolves the referenced issue(s).
- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.

<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--928.org.readthedocs.build/en/928/

<!-- readthedocs-preview montepy end -->