### PR TITLE
Switched over to StrEnum 

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -144,7 +144,10 @@ apidoc_module_dir = "../../montepy"
 apidoc_module_first = True
 apidoc_separate_modules = True
 
-suppress_warnings = ["epub.unknown_project_files"]
+suppress_warnings = [
+    "epub.unknown_project_files",
+    "RemovedInSphinx11Warning",
+]
 
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -144,10 +144,7 @@ apidoc_module_dir = "../../montepy"
 apidoc_module_first = True
 apidoc_separate_modules = True
 
-suppress_warnings = [
-    "epub.unknown_project_files",
-    "RemovedInSphinx11Warning",
-]
+suppress_warnings = ["epub.unknown_project_files"]
 
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/montepy/particle.py
+++ b/montepy/particle.py
@@ -1,9 +1,9 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
-from enum import unique, Enum
+from enum import unique, StrEnum
 
 
 @unique
-class Particle(str, Enum):
+class Particle(StrEnum):
     """Supported MCNP supported particles.
 
     Taken from :manual62:`46`.
@@ -61,7 +61,7 @@ class Particle(str, Enum):
 
 
 @unique
-class LibraryType(str, Enum):
+class LibraryType(StrEnum):
     """Enum to represent the possible types that a nuclear data library can be.
 
     .. versionadded:: 1.0.0

--- a/montepy/surfaces/surface_type.py
+++ b/montepy/surfaces/surface_type.py
@@ -1,9 +1,9 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
-from enum import unique, Enum
+from enum import unique, StrEnum
 
 
 @unique
-class SurfaceType(str, Enum):
+class SurfaceType(StrEnum):
     """An enumeration of the surface types allowed.
 
     Parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,7 @@ build = [
 ]
 doc = [
 	"montepy[build]",
-	# This is needed for a sphinx bug. See #414.
-	"sphinx>=7.4.0", 
+	"sphinx~=8.0", 
 	"sphinxcontrib-apidoc", 
 	"pydata_sphinx_theme",
 	"sphinx-favicon",


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

In reviewing #588, I realized we can now safely use [`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum), which was added in py 3.11. This shouldn't change a whole lot but may give better future proofing. 

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26.
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

### LLM Disclosure

1. Are you?

   - [x] A human user 
   - [ ] A large language model (LLM), including ones acting on behalf of a human

1. Were any large language models (LLM or "AI") used in to generate any of this code?

  - [x] Yes
      - Model(s) used: Claude, Sonnet 4.6
  - [ ] No

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] This PR fully addresses and resolves the referenced issue(s).
- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--938.org.readthedocs.build/en/938/

<!-- readthedocs-preview montepy end -->