### PR TITLE
Release 1.4.0 take 2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,7 @@ jobs:
           name: build
           path: dist/
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -108,7 +108,7 @@ jobs:
           name: build
           path: dist/
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
 
        

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
         run: .github/scripts/check_version.py
       - run: python -m build .
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc
         with:
           inputs: >-
             ./dist/*.tar.gz


### PR DESCRIPTION
# correction

There was an error in the deploy GHA that needed to be corrected with git sha pinning.

## Features Added

- Added surface classes to support almost all surface types such as `montepy.XPlane` and `montepy.YTorus` (#502).
- `Cell.universe` can now be set to `None` (or deleted via `del cell.universe`) to reset the universe assignment back to the default (#902).
- Added `extend_renumber` to `NumberedObjectCollection` with related test cases (#881).
- Made `montepy.data_inputs.importance.Importance` more `dict`-like with `keys`, `values`, and `items` functions (#921).

## Bugs Fixed

- Fixed a bug where surface type mnemonics (e.g. `SO`, `PZ`) were always written in uppercase, discarding the original case supplied by the user (e.g. `sO`, `Pz`) (#522).
- Fixed a bug where `append_renumber` raised a `TypeError` when called with an object whose `number` is `None` (e.g. an object created with no arguments) (#880).
- Fixed a bug where the importance of cells made from scratch are usually not printed to the output file (#921).

## Performance Improvements

- Removed Guardrails from `montepy.numbered_object_collection.NumberedObjectCollection` (#895).

## Documentation

- Enable Sphinx nitpicky mode and fix ~30 broken cross-references in the developer guide, user guide, and migration docs (#889).
- Added example notebook based on a fusion radial build model (#944).

<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--948.org.readthedocs.build/en/948/

<!-- readthedocs-preview montepy end -->