### PR TITLE
Fixing warnings issued by setuptools scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ test = [
 ]
 build = [
 	"build",
-	"setuptools>=64.0.0",
-	"setuptools-scm>=8",
+	"setuptools>=80.0.0",
+	"setuptools-scm>=8,<10.0",
 ]
 doc = [
 	"montepy[build]",
@@ -90,7 +90,7 @@ coverage = "https://coveralls.io/github/idaholab/MontePy"
 "change_to_ascii" = "montepy._scripts.change_to_ascii:main"
 
 [build-system]
-requires = ["setuptools>=77.0.0", "setuptools_scm>=8"]
+requires = ["setuptools>=80.0.0", "setuptools_scm>=8,<10.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This is a quick dependency fix. It appears that `setuptools-scm` has introduced an internal bug with `10.0.0`: https://github.com/pypa/setuptools-scm/issues/1348. For now this just pins to avoid this version. Yes it's a bit extreme, since in the end it is just a warning being issued. 

Fixes #953

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).

---

### LLM Disclosure

1. Are you?

   - [x] A human user 
   - [ ] A large language model (LLM), including ones acting on behalf of a human

1. Were any large language models (LLM or "AI") used in to generate any of this code?

  - [ ] Yes
      - Model(s) used:
  - [x] No

<details> 

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] This PR fully addresses and resolves the referenced issue(s).
- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--954.org.readthedocs.build/en/954/

<!-- readthedocs-preview montepy end -->