### PR TITLE
Drop "montepy." prefix from API nav entries (#901)

### DIFF
--- a/doc/source/_templates/mofunc.rst
+++ b/doc/source/_templates/mofunc.rst
@@ -1,0 +1,6 @@
+{{ objname }}
+{{ "=" * objname|length }}
+
+.. currentmodule:: {{ module }}
+
+.. autofunction:: {{ objname }}

--- a/doc/source/_templates/mofunc.rst
+++ b/doc/source/_templates/mofunc.rst
@@ -1,5 +1,5 @@
 {{ objname }}
-{{ "=" * objname|length }}
+{{ underline }}
 
 .. currentmodule:: {{ module }}
 

--- a/doc/source/_templates/myclass.rst
+++ b/doc/source/_templates/myclass.rst
@@ -1,5 +1,5 @@
 {{ objname }}
-{{ "=" * objname|length }}
+{{ underline }}
 
 .. currentmodule:: {{ module }}
 

--- a/doc/source/_templates/myclass.rst
+++ b/doc/source/_templates/myclass.rst
@@ -1,5 +1,5 @@
-{{ fullname }}
-{{ underline }}
+{{ objname }}
+{{ "=" * objname|length }}
 
 .. currentmodule:: {{ module }}
 
@@ -8,4 +8,4 @@
     :inherited-members:
     :undoc-members:
     :show-inheritance:
-    :private-members: _problem, _clear_data, _is_worth_printing, _tree_value, _collect_new_values, _update_cell_values, _update_values, _class_prefix, _has_number, _has_classifier, _add_children_objs, _update_number, _append_hook, _delete_hook, _delete_trailing_comment, _grab_beginning_comment, _flatten_shortcut, _get_first_comment, _convert_to_node, _print_value, _value_changed, _avoid_rounding_truncation, _particles_sorted, _expand_shortcuts, _can_consume_node, _can_use_last_node, _generate_default_node, _format_tree, _check_redundant_definitions         
+    :private-members: _problem, _clear_data, _is_worth_printing, _tree_value, _collect_new_values, _update_cell_values, _update_values, _class_prefix, _has_number, _has_classifier, _add_children_objs, _update_number, _append_hook, _delete_hook, _delete_trailing_comment, _grab_beginning_comment, _flatten_shortcut, _get_first_comment, _convert_to_node, _print_value, _value_changed, _avoid_rounding_truncation, _particles_sorted, _expand_shortcuts, _can_consume_node, _can_use_last_node, _generate_default_node, _format_tree, _check_redundant_definitions

--- a/doc/source/api/modules.rst
+++ b/doc/source/api/modules.rst
@@ -279,6 +279,7 @@ Object Builders
 .. autosummary::
    :toctree: generated
    :nosignatures:
+   :template: mofunc.rst
 
    montepy.data_inputs.data_parser.parse_data
    montepy.input_parser.input_syntax_reader.read_input_syntax

--- a/doc/source/api/montepy.constants.rst
+++ b/doc/source/api/montepy.constants.rst
@@ -1,5 +1,5 @@
-montepy.constants module
-========================
+constants
+=========
 
 
 .. automodule:: montepy.constants

--- a/doc/source/api/montepy.exceptions.rst
+++ b/doc/source/api/montepy.exceptions.rst
@@ -1,5 +1,5 @@
-montepy.exceptions module
-=========================
+exceptions
+==========
 
 
 .. automodule:: montepy.exceptions

--- a/doc/source/api/montepy.utilities.rst
+++ b/doc/source/api/montepy.utilities.rst
@@ -1,5 +1,5 @@
-montepy.utilities module
-========================
+utilities
+=========
 
 
 .. automodule:: montepy.utilities

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -29,6 +29,7 @@ MontePy Changelog
 **Documentation**
 
 * Enable Sphinx nitpicky mode and fix ~30 broken cross-references in the developer guide, user guide, and migration docs (:issue:`889`).
+* Remove redundant "montepy.*" prefix from navigation in the API docs (:issue:`901`).
 
 1.3 releases
 ============


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

Remove "montepy.*" from navigation in the API docs because it takes up space and the users already know that it's montepy.spam.

Learning to use Claude Code for the first time and this seemed like an easy way to take it for a test drive. Locally built docs look ok on my end.

Fixes #901

---

### General Checklist

N/A documentation only

---

### LLM Disclosure

1. Are you?

   - [x] A human user 
   - [ ] A large language model (LLM), including ones acting on behalf of a human

1. Were any large language models (LLM or "AI") used in to generate any of this code?

  - [x] Yes
      - Model(s) used: Claude Opus 4.7 


---

### Additional Notes for Reviewers

Ensure that:

- [x] This PR fully addresses and resolves the referenced issue(s).
- [x] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [x] The PR covers all relevant aspects according to the development guidelines.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--957.org.readthedocs.build/en/957/

<!-- readthedocs-preview montepy end -->