### PR TITLE
Updated default float precision to be basically machine precision.

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -9,6 +9,14 @@ MontePy Changelog
 1.4 releases
 ============
 
+#Next Version#
+--------------
+
+**Bugs Fixed**
+
+* Fixed bug where values for user generated objects would be rounded off at five digits no matter what. This will now round off at 15 digits if necessary (:issue:`962`).
+
+
 1.4.0
 --------------
 

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -1305,7 +1305,11 @@ class ValueNode(SyntaxNodeBase):
             precision += 1
         self._formatter["precision"] = precision
         # add in significant digits before the decimal  to be consistent with `g` format.
-        if not self._formatter["is_scientific"] and not self._is_reversed:
+        if (
+            not self._formatter["is_scientific"]
+            and not self._is_reversed
+            and self.value != 0
+        ):
             exp = math.floor(math.log10(abs(self.value)))
             self._formatter["precision"] += exp + 1
 

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -967,7 +967,7 @@ class ValueNode(SyntaxNodeBase):
             "exponent_zero_pad": 0,
             "as_int": False,
             "int_tolerance": 1e-6,
-            "is_scientific": True,
+            "is_scientific": False,
             "rel_eps": 1e-6,
             "abs_eps": 1e-9,
         },

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -959,7 +959,7 @@ class ValueNode(SyntaxNodeBase):
     _FORMATTERS = {
         float: {
             "value_length": 0,
-            "precision": 5,
+            "precision": 15,
             "zero_padding": 0,
             "sign": "-",
             "divider": "e",

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -1304,6 +1304,10 @@ class ValueNode(SyntaxNodeBase):
         ):
             precision += 1
         self._formatter["precision"] = precision
+        # add in significant digits before the decimal  to be consistent with `g` format.
+        if not self._formatter["is_scientific"] and not self._is_reversed:
+            exp = math.floor(math.log10(abs(self.value)))
+            self._formatter["precision"] += exp + 1
 
     def format(self):
         if not self._value_changed:

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -239,8 +239,8 @@ class TestValueNode:
             (None, float, 1.23, "1.23 ", False),
             (None, float, 1.23456789, "1.23456789 ", False),
             # max precision: 15
-            (None, float, 1.012345678912345, "1.0123456789012345 ", False),
-            (None, float, 1.0123456789123456, "1.0123456789012346 ", False),
+            (None, float, 1.012345678954321, "1.012345678954321 ", False),
+            (None, float, 1.0123456789123451, "1.012345678912345 ", False),
         ],
     )
     def test_value_float_format(_, input, val_type, val, answer, expand):

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -234,6 +234,13 @@ class TestValueNode:
             ("0.5", float, 0, "0.0", False),
             ("hi", str, "foo", "foo", True),
             ("hi", str, None, "", False),
+            # default rounding
+            (None, float, 1.0, "1 ", False),
+            (None, float, 1.23, "1.23 ", False),
+            (None, float, 1.23456789, "1.23456789 ", False),
+            # max precision: 15
+            (None, float, 1.012345678912345, "1.0123456789012345 ", False),
+            (None, float, 1.0123456789123456, "1.0123456789012346 ", False),
         ],
     )
     def test_value_float_format(_, input, val_type, val, answer, expand):


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This makes it so that MontePy will default to basically printing all important digits. MontePy will automatically round when appropriate so this formatter specification is really the ceiling of the precision. I set it to 15 instead of 16 because [float-64 has 15.95](https://en.wikipedia.org/wiki/IEEE_754) decimal digits of precision, and I wanted to avoid issues with repeating digits. 

Fixes #962

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

### LLM Disclosure

1. Are you?

   - [x] A human user 
   - [ ] A large language model (LLM), including ones acting on behalf of a human

1. Were any large language models (LLM or "AI") used in to generate any of this code?

  - [ ] Yes
      - Model(s) used:
  - [x] No

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] This PR fully addresses and resolves the referenced issue(s).
- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--966.org.readthedocs.build/en/966/

<!-- readthedocs-preview montepy end -->