### PR TITLE
Fixed deprecated test fixtures breaking tests

### DIFF
--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -13,7 +13,8 @@ import os
 
 class TestNumberedObjectCollection:
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture
+    @classmethod
     def read_simple_problem(_):
         return montepy.read_input(os.path.join("tests", "inputs", "test.imcnp"))
 
@@ -825,7 +826,8 @@ class TestNumberedObjectCollection:
 
 class TestMaterials:
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture
+    @classmethod
     def m0_prob(_):
         return montepy.read_input(
             os.path.join("tests", "inputs", "test_importance.imcnp")

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -489,8 +489,8 @@ class TestFill:
             fill1.merge(fill2)
 
     @given(
-        indices=st.lists(st.integers(), min_size=3, max_size=3),
-        width=st.lists(st.integers(1), min_size=3, max_size=3),
+        indices=st.lists(st.integers(-1_000_000, 1_000_000), min_size=3, max_size=3),
+        width=st.lists(st.integers(1, 1_000_000), min_size=3, max_size=3),
     )
     def test_fill_index_setter(self, indices, width):
         fill = self.simple_fill.clone()


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

Class scope pytest fixtures were deprecated when made with `@pytest.fixture(scope="class")`, now they must be marked `@classmethod`. I also fixed a edge case test failure where sometimes hypothesis would try a universe index of `9e18` that would cause a conversion to float instead of an integer overflow, which caused a `TypeError`.

Fixes #969

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

### LLM Disclosure

1. Are you?

   - [x] A human user 
   - [ ] A large language model (LLM), including ones acting on behalf of a human

1. Were any large language models (LLM or "AI") used in to generate any of this code?

  - [x] Yes
      - Model(s) used: Claude (sonnet 4.6) to lazy `grep` for me.
  - [ ] No

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] This PR fully addresses and resolves the referenced issue(s).
- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--970.org.readthedocs.build/en/970/

<!-- readthedocs-preview montepy end -->