### PR TITLE
Add `in` operator support to comments

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Travis J. Labossiere-Hickman <Travis.LabossiereHickman@inl.gov>
 Brenna A. Carbno <brenna.carbno@inl.gov>
 Benjaminas M. <BenjaminasDev@outlook.com>
 Ferney P. <Paul.Ferney@inl.gov>
+Yusra Rasool <ryusra9@gmail.com>

--- a/doc/source/api/modules.rst
+++ b/doc/source/api/modules.rst
@@ -33,6 +33,7 @@ Collections
    :template: myclass.rst
 
    montepy.Cells
+   montepy.CommentCollection
    montepy.Materials
    montepy.Surfaces
    montepy.Transforms

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -12,17 +12,18 @@ Next Release
 **Features Added**
 
 * Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
+* Added support for the ``in`` operator on comments, so a comment's text can be searched with e.g. ``"keyword" in comment`` (:issue:`185`).
+* Added :class:`~montepy.comments.CommentCollection`, now returned by ``comments`` and ``leading_comments``, so an object can be found by its comments with e.g. ``"keyword" in cell.comments``, or searched by regular expression with ``cell.comments.search`` (:issue:`185`).
+
+**Bugs Fixed**
+
+* Fixed ``leading_comments`` crashing when set with more than one comment (:pull:`972`).
 
 1.4 releases
 ============
 
 #Next Version#
 --------------
-
-**Feature Added**
-
-* Added support for the ``in`` operator on comments, so a comment's text can be searched with e.g. ``"keyword" in comment`` (:issue:`185`).
-* Added :class:`~montepy.comments.CommentCollection`, now returned by ``comments`` and ``leading_comments``, so an object can be found by its comments with e.g. ``"keyword" in cell.comments``, or searched by regular expression with ``cell.comments.search`` (:issue:`185`).
 
 **Bugs Fixed**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,6 +15,7 @@ MontePy Changelog
 **Feature Added**
 
 * Added support for the ``in`` operator on comments, so a comment's text can be searched with e.g. ``"keyword" in comment`` (:issue:`185`).
+* Added :class:`~montepy.comments.CommentCollection`, now returned by ``comments`` and ``leading_comments``, so an object can be found by its comments with e.g. ``"keyword" in cell.comments``, or searched by regular expression with ``cell.comments.search`` (:issue:`185`).
 
 **Bugs Fixed**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -12,6 +12,10 @@ MontePy Changelog
 #Next Version#
 --------------
 
+**Feature Added**
+
+* Added support for the ``in`` operator on comments, so a comment's text can be searched with e.g. ``"keyword" in comment`` (:issue:`185`).
+
 **Bugs Fixed**
 
 * Fixed bug where values for user generated objects would be rounded off at five digits no matter what. This will now round off at 15 digits if necessary (:issue:`962`).

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -12,12 +12,6 @@ Next Release
 **Features Added**
 
 * Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
-* Added support for the ``in`` operator on comments, so a comment's text can be searched with e.g. ``"keyword" in comment`` (:issue:`185`).
-* Added :class:`~montepy.comments.CommentCollection`, now returned by ``comments`` and ``leading_comments``, so an object can be found by its comments with e.g. ``"keyword" in cell.comments``, or searched by regular expression with ``cell.comments.search`` (:issue:`185`).
-
-**Bugs Fixed**
-
-* Fixed ``leading_comments`` crashing when set with more than one comment (:pull:`972`).
 
 1.4 releases
 ============
@@ -25,8 +19,14 @@ Next Release
 #Next Version#
 --------------
 
+**Feature Added**
+
+* Added support for the ``in`` operator on comments, so a comment's text can be searched with e.g. ``"keyword" in comment`` (:issue:`185`).
+* Added :class:`~montepy.comments.CommentCollection`, now returned by ``comments`` and ``leading_comments``, so an object can be found by its comments with e.g. ``"keyword" in cell.comments``, or searched by regular expression with ``cell.comments.search`` (:issue:`185`).
+
 **Bugs Fixed**
 
+* Fixed ``leading_comments`` crashing when set with more than one comment (:pull:`972`).
 * Fixed bug where values for user generated objects would be rounded off at five digits no matter what. This will now round off at 15 digits if necessary (:issue:`962`).
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -306,6 +306,10 @@ nitpick_ignore_regex = [
     # sphinx_autodoc_typehints generates "self" and "self._attr" refs for some
     # return-type annotations; these cannot be resolved and are harmless
     (r"py:class", r"^self(\._\w+)?$"),
+    # collections.abc.Sequence's inherited count/index carry C-style docstrings
+    # whose return annotations (e.g. "integer -- return number of occurrences
+    # of value") are not resolvable cross-references
+    (r"py:class", r"^integer -- return .*$"),
 ]
 
 

--- a/montepy/__init__.py
+++ b/montepy/__init__.py
@@ -43,6 +43,7 @@ from montepy.mcnp_problem import MCNP_Problem
 
 # collections
 from montepy.cells import Cells
+from montepy.comments import CommentCollection
 from montepy.materials import Materials
 from montepy.universes import Universes
 from montepy.surface_collection import Surfaces

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -1,17 +1,19 @@
 # Copyright 2026, Battelle Energy Alliance, LLC All Rights Reserved.
+from collections.abc import Sequence
 import re
 
 from montepy.input_parser.syntax_node import CommentNode
 
 
-class CommentCollection(list):
-    """A list of the comments in an object that supports searching by text.
+class CommentCollection(Sequence):
+    """A read-only collection of the comments in an object that supports searching by text.
 
-    This is a :class:`list` of :class:`~montepy.input_parser.syntax_node.CommentNode`
-    instances, and behaves like a normal list in every way. In addition,
-    checking a string with the ``in`` operator searches the *text* of all
-    comments, so an object can be found by its comments; anything other than a
-    string keeps the normal list membership behavior.
+    This is a :class:`~collections.abc.Sequence` of
+    :class:`~montepy.input_parser.syntax_node.CommentNode` instances, so it
+    supports indexing, slicing, iteration, and ``len()``. Checking a string
+    with the ``in`` operator searches the *text* of all comments, so an
+    object can be found by its comments; anything other than a string keeps
+    normal membership behavior.
 
     Examples
     --------
@@ -24,13 +26,34 @@ class CommentCollection(list):
         True
         >>> problem.materials[1].comments.search(r"(?i)LIGHT", regex=True)[0].contents
         'light water'
+
+    Parameters
+    ----------
+    comments : iterable of CommentNode
+        the comments in this collection.
     """
 
+    __slots__ = ("_comments",)
+
+    def __init__(self, comments=()):
+        self._comments = list(comments)
+
+    def __getitem__(self, i):
+        if isinstance(i, slice):
+            return CommentCollection(self._comments[i])
+        return self._comments[i]
+
+    def __len__(self):
+        return len(self._comments)
+
     def __contains__(self, item):
-        """For a string: search the text of all comments; otherwise: normal list membership."""
+        """For a string: search the text of all comments; otherwise: normal membership."""
         if isinstance(item, str):
-            return bool(self.search(item))
-        return super().__contains__(item)
+            return any(item in comment for comment in self._comments)
+        return item in self._comments
+
+    def __repr__(self):
+        return f"CommentCollection({self._comments!r})"
 
     def search(self, pattern, regex=False):
         """Searches the text of the comments in this collection.
@@ -71,4 +94,4 @@ class CommentCollection(list):
             raise TypeError(
                 f"pattern must be a str, or a pattern compiled from a str. {pattern} given."
             )
-        return CommentCollection(c for c in self if matcher(c.contents))
+        return CommentCollection(c for c in self._comments if matcher(c.contents))

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -8,70 +8,26 @@ class CommentCollection(list):
     """A list of the comments in an object that supports searching by text.
 
     This is a :class:`list` of :class:`~montepy.input_parser.syntax_node.CommentNode`
-    instances, and behaves like a normal list in every way. In addition, it
-    supports searching the text of its comments.
+    instances, and behaves like a normal list in every way. In addition,
+    checking a string with the ``in`` operator searches the *text* of all
+    comments, so an object can be found by its comments; anything other than a
+    string keeps the normal list membership behavior.
 
     Examples
     --------
 
-    Searching comments with ``in``
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    .. doctest::
 
-    Checking a string with the ``in`` operator searches the *text* of all
-    comments in the collection, so an object can be found by its comments:
-
-    .. testcode::
-
-        import montepy
-
-        problem = montepy.read_input("foo.imcnp")
-
-        for material in problem.materials:
-            if "light water" in material.comments:
-                print("found material:", material.number)
-
-    .. testoutput::
-
-        found material: 1
-
-    Checking anything other than a string keeps the normal :class:`list`
-    behavior, so membership tests for
-    :class:`~montepy.input_parser.syntax_node.CommentNode` instances are
-    unchanged.
-
-    Searching comments by pattern
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-    :func:`search` finds the comments matching a substring, or a regular
-    expression with ``regex=True``:
-
-    .. testcode::
-
-        material = problem.materials[1]
-        for comment in material.comments.search(r"(?i)LIGHT", regex=True):
-            print(comment.contents)
-
-    .. testoutput::
-
-        light water
-
+        >>> import montepy
+        >>> problem = montepy.read_input("foo.imcnp")
+        >>> "light water" in problem.materials[1].comments
+        True
+        >>> problem.materials[1].comments.search(r"(?i)LIGHT", regex=True)[0].contents
+        'light water'
     """
 
     def __contains__(self, item):
-        """Checks if a string is in the text of any comment, or if a comment is in this list.
-
-        Parameters
-        ----------
-        item : str or object
-            a string to search the text of all comments for, or any other
-            object to check list membership for.
-
-        Returns
-        -------
-        bool
-            for a string: True iff the string is contained in any comment's
-            ``contents``; otherwise: normal list membership.
-        """
+        """For a string: search the text of all comments; otherwise: normal list membership."""
         if isinstance(item, str):
             return bool(self.search(item))
         return super().__contains__(item)
@@ -102,25 +58,17 @@ class CommentCollection(list):
         TypeError
             if ``pattern`` is not a str, or a pattern compiled from a str.
         """
-        if isinstance(pattern, re.Pattern):
-            # bytes patterns cannot search the comments' str contents
-            if not isinstance(pattern.pattern, str):
-                raise TypeError(
-                    f"pattern must be a str, or a pattern compiled from a str. {pattern} given."
-                )
+        if isinstance(pattern, re.Pattern) and isinstance(pattern.pattern, str):
             matcher = pattern.search
+        elif isinstance(pattern, str) and regex:
+            matcher = re.compile(pattern).search
+        elif isinstance(pattern, str):
+
+            def matcher(contents):
+                return pattern in contents
+
         else:
-            if not isinstance(pattern, str):
-                raise TypeError(
-                    f"pattern must be a str, or a pattern compiled from a str. {pattern} given."
-                )
-            if regex:
-                matcher = re.compile(pattern).search
-            else:
-
-                def matcher(contents):
-                    return pattern in contents
-
-        return CommentCollection(
-            comment for comment in self if matcher(comment.contents)
-        )
+            raise TypeError(
+                f"pattern must be a str, or a pattern compiled from a str. {pattern} given."
+            )
+        return CommentCollection(c for c in self if matcher(c.contents))

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -1,14 +1,14 @@
 # Copyright 2026, Battelle Energy Alliance, LLC All Rights Reserved.
-from collections.abc import Sequence
+from collections.abc import Collection
 import re
 
 
-class CommentCollection(Sequence):
+class CommentCollection(Collection):
     """A read-only collection of the comments in an object that supports searching by text.
 
-    This is a :class:`~collections.abc.Sequence` of
-    :class:`~montepy.input_parser.syntax_node.CommentNode` instances, so it
-    supports indexing, slicing, iteration, and ``len()``. Checking a string
+    This is a :class:`~collections.abc.Collection` of
+    :class:`~montepy.input_parser.syntax_node.CommentNode` instances that
+    also supports indexing, slicing, and ``len()``. Checking a string
     with the ``in`` operator searches the *text* of all comments, so an
     object can be found by its comments; anything other than a string keeps
     normal membership behavior.
@@ -28,8 +28,9 @@ class CommentCollection(Sequence):
 
     Parameters
     ----------
-    comments : iterable of CommentNode
-        the comments in this collection.
+    comments : collections.abc.Iterable
+        the comments in this collection, as an iterable of
+        :class:`~montepy.input_parser.syntax_node.CommentNode`.
     """
 
     __slots__ = ("_comments",)
@@ -41,6 +42,9 @@ class CommentCollection(Sequence):
         if isinstance(i, slice):
             return CommentCollection(self._comments[i])
         return self._comments[i]
+
+    def __iter__(self):
+        return iter(self._comments)
 
     def __len__(self):
         return len(self._comments)

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -13,6 +13,8 @@ class CommentCollection(Collection):
     object can be found by its comments; anything other than a string keeps
     normal membership behavior.
 
+    .. versionadded:: 1.5.0
+
     Examples
     --------
 
@@ -64,6 +66,8 @@ class CommentCollection(Collection):
         The search is run against each comment's
         :attr:`~montepy.input_parser.syntax_node.CommentNode.contents`, that
         is the comment's text without its delimiters (``c``/``$``).
+
+        .. versionadded:: 1.5.0
 
         Parameters
         ----------

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -2,8 +2,6 @@
 from collections.abc import Sequence
 import re
 
-from montepy.input_parser.syntax_node import CommentNode
-
 
 class CommentCollection(Sequence):
     """A read-only collection of the comments in an object that supports searching by text.
@@ -24,7 +22,8 @@ class CommentCollection(Sequence):
         >>> problem = montepy.read_input("foo.imcnp")
         >>> "light water" in problem.materials[1].comments
         True
-        >>> problem.materials[1].comments.search(r"(?i)LIGHT", regex=True)[0].contents
+        >>> import re
+        >>> problem.materials[1].comments.search(re.compile(r"(?i)LIGHT"))[0].contents
         'light water'
 
     Parameters
@@ -36,7 +35,7 @@ class CommentCollection(Sequence):
     __slots__ = ("_comments",)
 
     def __init__(self, comments=()):
-        self._comments = list(comments)
+        self._comments = tuple(comments)
 
     def __getitem__(self, i):
         if isinstance(i, slice):
@@ -55,7 +54,7 @@ class CommentCollection(Sequence):
     def __repr__(self):
         return f"CommentCollection({self._comments!r})"
 
-    def search(self, pattern, regex=False):
+    def search(self, pattern):
         """Searches the text of the comments in this collection.
 
         The search is run against each comment's
@@ -65,11 +64,8 @@ class CommentCollection(Sequence):
         Parameters
         ----------
         pattern : str or re.Pattern
-            the substring to search for, or a regular expression when
-            ``regex`` is True. Compiled patterns are always treated as
-            regular expressions.
-        regex : bool
-            whether to interpret ``pattern`` as a regular expression.
+            a substring to search for, or a compiled regular expression
+            (e.g. ``re.compile(pattern, re.IGNORECASE)``).
 
         Returns
         -------
@@ -81,15 +77,10 @@ class CommentCollection(Sequence):
         TypeError
             if ``pattern`` is not a str, or a pattern compiled from a str.
         """
-        if isinstance(pattern, re.Pattern) and isinstance(pattern.pattern, str):
+        if isinstance(pattern, str):
+            matcher = re.compile(re.escape(pattern)).search
+        elif isinstance(pattern, re.Pattern) and isinstance(pattern.pattern, str):
             matcher = pattern.search
-        elif isinstance(pattern, str) and regex:
-            matcher = re.compile(pattern).search
-        elif isinstance(pattern, str):
-
-            def matcher(contents):
-                return pattern in contents
-
         else:
             raise TypeError(
                 f"pattern must be a str, or a pattern compiled from a str. {pattern} given."

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -1,0 +1,113 @@
+# Copyright 2026, Battelle Energy Alliance, LLC All Rights Reserved.
+import re
+
+from montepy.input_parser.syntax_node import CommentNode
+
+
+class CommentCollection(list):
+    """A list of the comments in an object that supports searching by text.
+
+    This is a :class:`list` of :class:`~montepy.input_parser.syntax_node.CommentNode`
+    instances, and behaves like a normal list in every way. In addition, it
+    supports searching the text of its comments.
+
+    Examples
+    --------
+
+    Searching comments with ``in``
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    Checking a string with the ``in`` operator searches the *text* of all
+    comments in the collection, so an object can be found by its comments:
+
+    .. testcode::
+
+        import montepy
+
+        problem = montepy.read_input("foo.imcnp")
+
+        for material in problem.materials:
+            if "light water" in material.comments:
+                print("found material:", material.number)
+
+    .. testoutput::
+
+        found material: 1
+
+    Checking anything other than a string keeps the normal :class:`list`
+    behavior, so membership tests for
+    :class:`~montepy.input_parser.syntax_node.CommentNode` instances are
+    unchanged.
+
+    Searching comments by pattern
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    :func:`search` finds the comments matching a substring, or a regular
+    expression with ``regex=True``:
+
+    .. testcode::
+
+        material = problem.materials[1]
+        for comment in material.comments.search(r"(?i)LIGHT", regex=True):
+            print(comment.contents)
+
+    .. testoutput::
+
+        light water
+
+    """
+
+    def __contains__(self, item):
+        """Checks if a string is in the text of any comment, or if a comment is in this list.
+
+        Parameters
+        ----------
+        item : str or object
+            a string to search the text of all comments for, or any other
+            object to check list membership for.
+
+        Returns
+        -------
+        bool
+            for a string: True iff the string is contained in any comment's
+            ``contents``; otherwise: normal list membership.
+        """
+        if isinstance(item, str):
+            return bool(self.search(item))
+        return super().__contains__(item)
+
+    def search(self, pattern, regex=False):
+        """Searches the text of the comments in this collection.
+
+        The search is run against each comment's
+        :attr:`~montepy.input_parser.syntax_node.CommentNode.contents`, that
+        is the comment's text without its delimiters (``c``/``$``).
+
+        Parameters
+        ----------
+        pattern : str or re.Pattern
+            the substring to search for, or a regular expression when
+            ``regex`` is True. Compiled patterns are always treated as
+            regular expressions.
+        regex : bool
+            whether to interpret ``pattern`` as a regular expression.
+
+        Returns
+        -------
+        CommentCollection
+            a new collection of the comments that matched.
+        """
+        if isinstance(pattern, re.Pattern):
+            matcher = pattern.search
+        elif regex:
+            matcher = re.compile(pattern).search
+        else:
+            if not isinstance(pattern, str):
+                raise TypeError(f"pattern must be a str. {pattern} given.")
+
+            def matcher(contents):
+                return pattern in contents
+
+        return CommentCollection(
+            comment for comment in self if matcher(comment.contents)
+        )

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -96,17 +96,30 @@ class CommentCollection(list):
         -------
         CommentCollection
             a new collection of the comments that matched.
+
+        Raises
+        ------
+        TypeError
+            if ``pattern`` is not a str, or a pattern compiled from a str.
         """
         if isinstance(pattern, re.Pattern):
+            # bytes patterns cannot search the comments' str contents
+            if not isinstance(pattern.pattern, str):
+                raise TypeError(
+                    f"pattern must be a str, or a pattern compiled from a str. {pattern} given."
+                )
             matcher = pattern.search
-        elif regex:
-            matcher = re.compile(pattern).search
         else:
             if not isinstance(pattern, str):
-                raise TypeError(f"pattern must be a str. {pattern} given.")
+                raise TypeError(
+                    f"pattern must be a str, or a pattern compiled from a str. {pattern} given."
+                )
+            if regex:
+                matcher = re.compile(pattern).search
+            else:
 
-            def matcher(contents):
-                return pattern in contents
+                def matcher(contents):
+                    return pattern in contents
 
         return CommentCollection(
             comment for comment in self if matcher(comment.contents)

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -1,14 +1,17 @@
 # Copyright 2026, Battelle Energy Alliance, LLC All Rights Reserved.
-from collections.abc import Collection
+from __future__ import annotations
+from collections.abc import Iterable, Iterator, Sequence
 import re
 
+from montepy.input_parser.syntax_node import CommentNode
 
-class CommentCollection(Collection):
+
+class CommentCollection(Sequence):
     """A read-only collection of the comments in an object that supports searching by text.
 
-    This is a :class:`~collections.abc.Collection` of
-    :class:`~montepy.input_parser.syntax_node.CommentNode` instances that
-    also supports indexing, slicing, and ``len()``. Checking a string
+    This is a :class:`~collections.abc.Sequence` of
+    :class:`~montepy.input_parser.syntax_node.CommentNode` instances, so it
+    supports indexing, slicing, iteration, and ``len()``. Checking a string
     with the ``in`` operator searches the *text* of all comments, so an
     object can be found by its comments; anything other than a string keeps
     normal membership behavior.
@@ -37,30 +40,30 @@ class CommentCollection(Collection):
 
     __slots__ = ("_comments",)
 
-    def __init__(self, comments=()):
+    def __init__(self, comments: Iterable[CommentNode] = ()) -> None:
         self._comments = tuple(comments)
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: int | slice) -> CommentNode | CommentCollection:
         if isinstance(i, slice):
             return CommentCollection(self._comments[i])
         return self._comments[i]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[CommentNode]:
         return iter(self._comments)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._comments)
 
-    def __contains__(self, item):
+    def __contains__(self, item: object) -> bool:
         """For a string: search the text of all comments; otherwise: normal membership."""
         if isinstance(item, str):
             return any(item in comment for comment in self._comments)
         return item in self._comments
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"CommentCollection({self._comments!r})"
 
-    def search(self, pattern):
+    def search(self, pattern: str | re.Pattern) -> CommentCollection:
         """Searches the text of the comments in this collection.
 
         The search is run against each comment's
@@ -85,10 +88,17 @@ class CommentCollection(Collection):
         TypeError
             if ``pattern`` is not a str, or a pattern compiled from a str.
         """
-        if isinstance(pattern, str):
-            matcher = re.compile(re.escape(pattern)).search
-        elif isinstance(pattern, re.Pattern) and isinstance(pattern.pattern, str):
+        if isinstance(pattern, re.Pattern):
+            if not isinstance(pattern.pattern, str):
+                raise TypeError(
+                    f"pattern must be a str, or a pattern compiled from a str. {pattern} given."
+                )
             matcher = pattern.search
+        elif isinstance(pattern, str):
+
+            def matcher(contents):
+                return pattern in contents
+
         else:
             raise TypeError(
                 f"pattern must be a str, or a pattern compiled from a str. {pattern} given."

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -825,6 +825,25 @@ class CommentNode(SyntaxNodeBase):
     ----------
     input : sly.lex.Token
         the token from the lexer
+
+    Examples
+    --------
+
+    Searching within a comment
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    You can check whether a substring appears in a comment's text with the
+    ``in`` operator. This works for both ``c`` style and ``$`` (dollar)
+    comments, and searches the comment's ``contents`` (the text without the
+    comment delimiter).
+
+    .. testcode::
+
+        from montepy.input_parser.syntax_node import CommentNode
+
+        comment = CommentNode("c the important fuel region")
+        assert "important" in comment
+        assert "coolant" not in comment
     """
 
     _MATCHER = re.compile(

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -829,7 +829,7 @@ class CommentNode(SyntaxNodeBase):
     Examples
     --------
 
-    The ``in`` operator searches the comment's text — its ``contents``
+    The ``in`` operator searches the comment's text, its ``contents``,
     without the ``c``/``$`` delimiter:
 
     .. doctest::

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -959,6 +959,8 @@ class CommentNode(SyntaxNodeBase):
         This allows searching a comment by its text, e.g.
         ``"important" in comment``.
 
+        .. versionadded:: 1.5.0
+
         Parameters
         ----------
         value : str

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -829,21 +829,14 @@ class CommentNode(SyntaxNodeBase):
     Examples
     --------
 
-    Searching within a comment
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    The ``in`` operator searches the comment's text — its ``contents``
+    without the ``c``/``$`` delimiter:
 
-    You can check whether a substring appears in a comment's text with the
-    ``in`` operator. This works for both ``c`` style and ``$`` (dollar)
-    comments, and searches the comment's ``contents`` (the text without the
-    comment delimiter).
+    .. doctest::
 
-    .. testcode::
-
-        from montepy.input_parser.syntax_node import CommentNode
-
-        comment = CommentNode("c the important fuel region")
-        assert "important" in comment
-        assert "coolant" not in comment
+        >>> from montepy.input_parser.syntax_node import CommentNode
+        >>> "important" in CommentNode("c the important fuel region")
+        True
     """
 
     _MATCHER = re.compile(

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -821,6 +821,10 @@ class PaddingNode(SyntaxNodeBase):
 class CommentNode(SyntaxNodeBase):
     """Object to represent a comment in an MCNP problem.
 
+    .. versionchanged:: 1.5.0
+
+        A comment's text can now be searched with the ``in`` operator.
+
     Parameters
     ----------
     input : sly.lex.Token

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -937,6 +937,24 @@ class CommentNode(SyntaxNodeBase):
     def __eq__(self, other):
         return str(self) == str(other)
 
+    def __contains__(self, value):
+        """Checks if a string is found in the contents of this comment.
+
+        This allows searching a comment by its text, e.g.
+        ``"important" in comment``.
+
+        Parameters
+        ----------
+        value : str
+            the string to search for.
+
+        Returns
+        -------
+        bool
+            True iff ``value`` is a substring of this comment's ``contents``.
+        """
+        return value in self.contents
+
 
 class ValueNode(SyntaxNodeBase):
     """A syntax node to represent the leaf node.

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import ABC, ABCMeta, abstractmethod
 import copy
 import functools
-import itertools as it
 import textwrap
 from typing import TypeAlias, Union, Type
 import warnings
@@ -335,23 +334,17 @@ The new input was:\n\n"""
     def leading_comments(self, comments):
         if not isinstance(comments, (list, tuple, CommentNode, CommentCollection)):
             raise TypeError(
-                f"Comments must be a CommentNode, or a list of Comments. {comments} given."
+                f"Comments must be a CommentNode, CommentCollection, or list/tuple of CommentNodes. {comments} given."
             )
         if isinstance(comments, CommentNode):
             comments = [comments]
-        if isinstance(comments, (list, tuple, CommentCollection)):
-            for comment in comments:
-                if not isinstance(comment, CommentNode):
-                    raise TypeError(
-                        f"Comments must be a CommentNode, or a list of Comments. {comment} given."
-                    )
 
         for i, comment in enumerate(comments):
             if not isinstance(comment, CommentNode):
                 raise TypeError(
                     f"Comment must be a CommentNode. {comment} given at index {i}."
                 )
-        new_nodes = list(*zip(comments, it.cycle(["\n"])))
+        new_nodes = [node for comment in comments for node in (comment, "\n")]
         if self._tree["start_pad"] is None:
             self._tree["start_pad"] = PaddingNode(" ")
         self._tree["start_pad"]._nodes = new_nodes

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -306,7 +306,7 @@ The new input was:\n\n"""
         Returns
         -------
         CommentCollection
-            a list of the comments associated with this comment, which also
+            a list of the comments associated with this object, which also
             supports searching the comments' text (e.g. ``"foo" in
             obj.comments``).
         """

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -306,9 +306,8 @@ The new input was:\n\n"""
         Returns
         -------
         CommentCollection
-            a list of the comments associated with this object, which also
-            supports searching the comments' text (e.g. ``"foo" in
-            obj.comments``).
+            the comments associated with this object; supports searching
+            the comments' text, e.g. ``"foo" in obj.comments``.
         """
         return CommentCollection(self._tree.comments)
 
@@ -319,8 +318,8 @@ The new input was:\n\n"""
         Returns
         -------
         CommentCollection
-            the leading comments, which also support searching the comments'
-            text (e.g. ``"foo" in obj.leading_comments``).
+            the leading comments; supports searching the comments' text,
+            e.g. ``"foo" in obj.leading_comments``.
         """
         return CommentCollection(self._tree["start_pad"].comments)
 

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -325,13 +325,13 @@ The new input was:\n\n"""
 
     @leading_comments.setter
     def leading_comments(self, comments):
-        if not isinstance(comments, (list, tuple, CommentNode)):
+        if not isinstance(comments, (list, tuple, CommentNode, CommentCollection)):
             raise TypeError(
                 f"Comments must be a CommentNode, or a list of Comments. {comments} given."
             )
         if isinstance(comments, CommentNode):
             comments = [comments]
-        if isinstance(comments, (list, tuple)):
+        if isinstance(comments, (list, tuple, CommentCollection)):
             for comment in comments:
                 if not isinstance(comment, CommentNode):
                     raise TypeError(

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -298,7 +298,7 @@ The new input was:\n\n"""
 
     @property
     def comments(self) -> CommentCollection:
-        """The comments associated with this input if any.
+        """The comments associated with this object if any.
 
         This includes all ``C`` comments before this card that aren't part of another card,
         and any comments that are inside this card.

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -9,6 +9,7 @@ from typing import TypeAlias, Union, Type
 import warnings
 import weakref
 
+from montepy.comments import CommentCollection
 from montepy.exceptions import *
 from montepy.constants import (
     BLANK_SPACE_CONTINUE,
@@ -296,7 +297,7 @@ The new input was:\n\n"""
             warnings.warn(warning, stacklevel=4)
 
     @property
-    def comments(self) -> list[PaddingNode]:
+    def comments(self) -> CommentCollection:
         """The comments associated with this input if any.
 
         This includes all ``C`` comments before this card that aren't part of another card,
@@ -304,21 +305,24 @@ The new input was:\n\n"""
 
         Returns
         -------
-        list
-            a list of the comments associated with this comment.
+        CommentCollection
+            a list of the comments associated with this comment, which also
+            supports searching the comments' text (e.g. ``"foo" in
+            obj.comments``).
         """
-        return list(self._tree.comments)
+        return CommentCollection(self._tree.comments)
 
     @property
-    def leading_comments(self) -> list[PaddingNode]:
+    def leading_comments(self) -> CommentCollection:
         """Any comments that come before the beginning of the input proper.
 
         Returns
         -------
-        list
-            the leading comments.
+        CommentCollection
+            the leading comments, which also support searching the comments'
+            text (e.g. ``"foo" in obj.leading_comments``).
         """
-        return list(self._tree["start_pad"].comments)
+        return CommentCollection(self._tree["start_pad"].comments)
 
     @leading_comments.setter
     def leading_comments(self, comments):

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -303,6 +303,10 @@ The new input was:\n\n"""
         This includes all ``C`` comments before this card that aren't part of another card,
         and any comments that are inside this card.
 
+        .. versionchanged:: 1.5.0
+
+            Returns a :class:`~montepy.comments.CommentCollection` instead of a list.
+
         Returns
         -------
         CommentCollection
@@ -314,6 +318,10 @@ The new input was:\n\n"""
     @property
     def leading_comments(self) -> CommentCollection:
         """Any comments that come before the beginning of the input proper.
+
+        .. versionchanged:: 1.5.0
+
+            Returns a :class:`~montepy.comments.CommentCollection` instead of a list.
 
         Returns
         -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ authors = [
 	{name = "Paul Ferney", email="Paul.Ferney@inl.gov"},
 	{name = "Digvijay Yeware", email="yewaredigvijay@gmail.com"},
 	{name = "Harsh Dayal", email="harshdayal13@gmail.com"},
+	{name = "Yusra Rasool", email = "ryusra9@gmail.com"},
 ]
 keywords = ["MCNP", "neutronics", "imcnp", "input file", "monte carlo", "radiation transport"]
 license = "MIT"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -558,6 +558,17 @@ def test_comments_setter(simple_problem):
         cell.leading_comments = 5
 
 
+def test_comments_setter_multiple_comments(simple_problem):
+    cell = copy.deepcopy(simple_problem.cells[1])
+    comment = simple_problem.surfaces[1000].comments[0]
+    comments = [comment, copy.deepcopy(comment)]
+    cell.leading_comments = comments
+    assert len(cell.leading_comments) == 2
+    assert [comment.contents for comment in cell.leading_comments] == [
+        comment.contents for comment in comments
+    ]
+
+
 def test_problem_linker():
     cell = montepy.Cell()
     with pytest.raises(TypeError):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,6 +2,7 @@
 import copy
 import io
 from pathlib import Path
+import re
 
 import pytest
 import os
@@ -567,6 +568,18 @@ def test_comments_setter_multiple_comments(simple_problem):
     assert [comment.contents for comment in cell.leading_comments] == [
         comment.contents for comment in comments
     ]
+
+
+def test_object_comments_are_collection(simple_problem):
+    cell = simple_problem.cells[1]
+    assert isinstance(cell.comments, montepy.CommentCollection)
+    assert isinstance(cell.leading_comments, montepy.CommentCollection)
+    # an object can be found by its comment text (#185)
+    assert "hidden vertical" in cell.comments
+    assert "not actually in there" not in cell.comments
+    # both search pattern types work against an object's comments
+    assert len(cell.comments.search("hidden")) == 1
+    assert len(cell.comments.search(re.compile(r"(?i)HIDDEN"))) == 1
 
 
 def test_problem_linker():

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -1,7 +1,6 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
 import copy
 from io import StringIO
-import os
 import re
 import pytest
 
@@ -657,16 +656,23 @@ class TestPaddingNode:
         with pytest.raises(TypeError):
             comments.search(re.compile(b"fuel"))
 
-
-def test_object_comments_are_collection():
-    problem = montepy.read_input(os.path.join("tests", "inputs", "test.imcnp"))
-    cell = problem.cells[1]
-    assert isinstance(cell.comments, montepy.CommentCollection)
-    assert isinstance(cell.leading_comments, montepy.CommentCollection)
-    # an object can be found by its comment text (#185)
-    assert "hidden vertical" in cell.comments
-    assert "not actually in there" not in cell.comments
-    assert len(cell.comments.search(re.compile(r"(?i)HIDDEN"))) == 1
+    def test_comment_collection_sequence(self):
+        c1 = syntax_node.CommentNode("c the fuel region")
+        c2 = syntax_node.CommentNode("$ moderator notes")
+        comments = montepy.CommentCollection([c1, c2])
+        # indexing, slicing, iteration, and length
+        assert len(comments) == 2
+        assert comments[0] is c1
+        assert comments[-1] is c2
+        sliced = comments[0:1]
+        assert isinstance(sliced, montepy.CommentCollection)
+        assert list(sliced) == [c1]
+        assert [c.contents for c in comments] == ["the fuel region", "moderator notes"]
+        # Sequence mixins
+        assert list(reversed(comments)) == [c2, c1]
+        assert comments.index(c2) == 1
+        assert comments.count(c1) == 1
+        assert "CommentCollection" in repr(comments)
 
 
 def test_graveyard_comment():

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -651,9 +651,14 @@ class TestPaddingNode:
         assert isinstance(matches, montepy.CommentCollection)
         # compiled patterns are always treated as regular expressions
         assert len(comments.search(re.compile("notes"))) == 1
-        # non-string patterns are rejected
+        # non-string patterns are rejected, with or without regex
         with pytest.raises(TypeError):
             comments.search(5)
+        with pytest.raises(TypeError):
+            comments.search(5, regex=True)
+        # bytes patterns cannot search the str contents
+        with pytest.raises(TypeError):
+            comments.search(re.compile(b"fuel"))
 
 
 def test_object_comments_are_collection():

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -1,6 +1,8 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
 import copy
 from io import StringIO
+import os
+import re
 import pytest
 
 import montepy
@@ -616,6 +618,53 @@ class TestPaddingNode:
         # non-string operands are rejected like normal str containment
         with pytest.raises(TypeError):
             5 in comment
+
+    def test_comment_collection_contains(self):
+        comments = montepy.CommentCollection(
+            [
+                syntax_node.CommentNode("c the fuel region"),
+                syntax_node.CommentNode("$ moderator notes"),
+            ]
+        )
+        # strings search the text of all comments
+        assert "fuel" in comments
+        assert "notes" in comments
+        assert "graphite" not in comments
+        # anything else keeps normal list membership behavior
+        assert comments[0] in comments
+        assert syntax_node.CommentNode("c not in there") not in comments
+        assert 5 not in comments
+
+    def test_comment_collection_search(self):
+        comments = montepy.CommentCollection(
+            [
+                syntax_node.CommentNode("c the fuel region"),
+                syntax_node.CommentNode("$ moderator notes"),
+            ]
+        )
+        # substring search
+        assert [c.contents for c in comments.search("fuel")] == ["the fuel region"]
+        assert len(comments.search("graphite")) == 0
+        # regex search
+        matches = comments.search(r"(?i)FUEL|MODERATOR", regex=True)
+        assert len(matches) == 2
+        assert isinstance(matches, montepy.CommentCollection)
+        # compiled patterns are always treated as regular expressions
+        assert len(comments.search(re.compile("notes"))) == 1
+        # non-string patterns are rejected
+        with pytest.raises(TypeError):
+            comments.search(5)
+
+
+def test_object_comments_are_collection():
+    problem = montepy.read_input(os.path.join("tests", "inputs", "test.imcnp"))
+    cell = problem.cells[1]
+    assert isinstance(cell.comments, montepy.CommentCollection)
+    assert isinstance(cell.leading_comments, montepy.CommentCollection)
+    # an object can be found by its comment text (#185)
+    assert "hidden vertical" in cell.comments
+    assert "not actually in there" not in cell.comments
+    assert len(cell.comments.search(r"(?i)HIDDEN", regex=True)) == 1
 
 
 def test_graveyard_comment():

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -642,20 +642,17 @@ class TestPaddingNode:
                 syntax_node.CommentNode("$ moderator notes"),
             ]
         )
-        # substring search
+        # substring search, incl. regex metacharacters taken literally
         assert [c.contents for c in comments.search("fuel")] == ["the fuel region"]
         assert len(comments.search("graphite")) == 0
-        # regex search
-        matches = comments.search(r"(?i)FUEL|MODERATOR", regex=True)
+        assert len(comments.search("fuel|moderator")) == 0
+        # compiled patterns are treated as regular expressions
+        matches = comments.search(re.compile(r"(?i)FUEL|MODERATOR"))
         assert len(matches) == 2
         assert isinstance(matches, montepy.CommentCollection)
-        # compiled patterns are always treated as regular expressions
-        assert len(comments.search(re.compile("notes"))) == 1
-        # non-string patterns are rejected, with or without regex
+        # non-string patterns are rejected
         with pytest.raises(TypeError):
             comments.search(5)
-        with pytest.raises(TypeError):
-            comments.search(5, regex=True)
         # bytes patterns cannot search the str contents
         with pytest.raises(TypeError):
             comments.search(re.compile(b"fuel"))
@@ -669,7 +666,7 @@ def test_object_comments_are_collection():
     # an object can be found by its comment text (#185)
     assert "hidden vertical" in cell.comments
     assert "not actually in there" not in cell.comments
-    assert len(cell.comments.search(r"(?i)HIDDEN", regex=True)) == 1
+    assert len(cell.comments.search(re.compile(r"(?i)HIDDEN"))) == 1
 
 
 def test_graveyard_comment():

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -603,6 +603,20 @@ class TestPaddingNode:
         assert len(list(comment.comments)) == 1
         assert len(comment.contents) == 0
 
+    def test_comment_contains(self):
+        comment = syntax_node.CommentNode("c hello world")
+        assert "hello" in comment
+        assert "goodbye" not in comment
+        # the delimiter itself is not part of the contents
+        assert "c " not in comment
+        # works for dollar comments and across appended lines
+        comment.append("c second line")
+        assert "second" in comment
+        assert "note" in syntax_node.CommentNode("$ note here")
+        # non-string operands are rejected like normal str containment
+        with pytest.raises(TypeError):
+            5 in comment
+
 
 def test_graveyard_comment():
     padding = syntax_node.PaddingNode(" ")


### PR DESCRIPTION
### Description

Lets objects be found by their comments, in two layers:

1. `CommentNode.__contains__`: a comment's text can be searched with the `in` operator. It delegates to the existing `contents` property, so it works for both `c` and `$` comments and across appended comment lines. Non-string operands raise `TypeError`, matching normal `str` containment.

2. `CommentCollection`: a new read-only collection type returned by `MCNP_Object.comments` and `leading_comments`. It is its own `collections.abc.Collection` (not a `list` or `tuple` subclass, per review) and stores its comments in a tuple, so it is immutable and supports no operands. It keeps indexing, slicing, iteration, and `len()`. A string checked with `in` searches the text of all comments. Anything else keeps normal membership behavior. `search(pattern)` takes a substring or a compiled `re.Pattern`:

```python
if "shielding" in cell.comments:
    ...
cell.comments.search(re.compile(r"fuel", re.IGNORECASE))
```

`NumberedObjectCollection.get_by_comment` is left to #982, and `trailing_comment` handling to the design discussion in #185.

Fixes #185

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

### LLM Disclosure

1. Are you?

   - [x] A human user
   - [ ] A large language model (LLM), including ones acting on behalf of a human

1. Were any large language models (LLM or "AI") used in to generate any of this code?

  - [x] Yes
      - Model(s) used: Claude (Claude Code): Opus 4.8, Fable 5
  - [ ] No

<details open>

<summary><h3>Documentation Checklist</h3></summary>

- [x] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details open>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [x] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>



### Additional Notes for Reviewers

Ensure that:

- [x] This PR fully addresses and resolves the referenced issue(s).
- [x] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [x] The PR covers all relevant aspects according to the development guidelines.
- [x] 100% coverage of the patch is achieved, or justification for a variance is given.

<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--972.org.readthedocs.build/en/972/

<!-- readthedocs-preview montepy end -->


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--972.org.readthedocs.build/en/972/

<!-- readthedocs-preview montepy end -->