### PR TITLE
Test that str/repr of user-facing objects never raise

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -241,8 +241,11 @@ def _user_facing_objects(problem: montepy.MCNP_Problem) -> Iterator[object]:
     yield from problem.data_inputs
     # cell-block modifier objects
     for cell in problem.cells:
-        yield cell.importance
-        yield cell.fill
+        yield cell.geometry
+        yield cell.leading_comments
+        yield from (
+            getattr(cell, attr) for attr, _ in cell._INPUTS_TO_PROPERTY.values()
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -218,6 +218,54 @@ def test_problem_str(simple_problem):
     assert "MCNP problem for: tests/inputs/test.imcnp" in output
 
 
+def _user_facing_objects(problem):
+    """Yield a problem's user-facing objects: the problem, its top-level
+    members, every collection and its members, the data-block inputs, and the
+    cell-block modifiers."""
+    yield problem
+    # top-level objects a user can print directly (``message`` may be ``None``)
+    for obj in (problem.input_file, problem.message, problem.title, problem.mode):
+        if obj is not None:
+            yield obj
+    for collection in (
+        problem.cells,
+        problem.surfaces,
+        problem.materials,
+        problem.universes,
+        problem.transforms,
+    ):
+        yield collection
+        yield from collection
+    # data-block inputs, e.g. ``Volume``, ``Mode`` (see the original report)
+    yield from problem.data_inputs
+    # cell-block modifier objects
+    for cell in problem.cells:
+        yield cell.importance
+        yield cell.fill
+
+
+@pytest.mark.parametrize(
+    "problem_fixture",
+    [
+        "simple_problem",
+        "importance_problem",
+        "universe_problem",
+        "data_universe_problem",
+    ],
+)
+def test_str_and_repr_do_not_raise(request, problem_fixture):
+    """``str`` and ``repr`` of user-facing objects must never raise (:issue:`152`).
+
+    Some attributes are not populated in every context (e.g. a ``Volume`` in
+    the data block), which used to make ``__repr__`` raise ``AttributeError``.
+    """
+    problem = request.getfixturevalue(problem_fixture)
+    for obj in _user_facing_objects(problem):
+        for func in (str, repr):
+            # an empty string is a valid result; the requirement is "never raises"
+            assert isinstance(func(obj), str)
+
+
 def test_write_to_file(simple_problem):
     out = "foo.imcnp"
     try:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+from collections.abc import Iterator
 import copy
 import io
 from pathlib import Path
@@ -218,7 +219,7 @@ def test_problem_str(simple_problem):
     assert "MCNP problem for: tests/inputs/test.imcnp" in output
 
 
-def _user_facing_objects(problem):
+def _user_facing_objects(problem: montepy.MCNP_Problem) -> Iterator[object]:
     """Yield a problem's user-facing objects: the problem, its top-level
     members, every collection and its members, the data-block inputs, and the
     cell-block modifiers."""
@@ -254,10 +255,10 @@ def _user_facing_objects(problem):
     ],
 )
 def test_str_and_repr_do_not_raise(request, problem_fixture):
-    """``str`` and ``repr`` of user-facing objects must never raise (:issue:`152`).
+    """str and repr of user-facing objects must never raise (#152).
 
-    Some attributes are not populated in every context (e.g. a ``Volume`` in
-    the data block), which used to make ``__repr__`` raise ``AttributeError``.
+    Some attributes are not populated in every context (e.g. a Volume in
+    the data block), which used to make __repr__ raise AttributeError.
     """
     problem = request.getfixturevalue(problem_fixture)
     for obj in _user_facing_objects(problem):


### PR DESCRIPTION
### Description

#152 asked for unit tests so that broken custom `__str__` / `__repr__` methods get caught before users hit them. The original report was a `Volume.__repr__` crash because `_volume` is not set when a `Volume` is parsed in the data block.

This adds one regression test that calls `str()` and `repr()` on every user-facing object of a parsed problem and asserts neither raises. That covers the problem itself, its top-level objects (input file, message, title, mode), each object collection and its members, the data-block inputs, and the cell-block modifiers. It runs over four fixtures so both the cell-block and data-block forms are exercised.



Fixes #152

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

### LLM Disclosure

1. Are you?

   - [x] A human user
   - [ ] A large language model (LLM), including ones acting on behalf of a human

1. Were any large language models (LLM or "AI") used in to generate any of this code?

  - [x] Yes
      - Model(s) used: Claude (Claude Code): Opus 4.8, Fable 5
  - [ ] No



<details open>

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

(Documentation checklist N/A: test-only change, no new public classes or methods.)

</details>



### Additional Notes for Reviewers

Ensure that:

- [x] This PR fully addresses and resolves the referenced issue(s).
- [x] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [x] The PR covers all relevant aspects according to the development guidelines.
- [x] 100% coverage of the patch is achieved, or justification for a variance is given. _(Patch is test code, which is excluded from coverage measurement.)_

<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--974.org.readthedocs.build/en/974/

<!-- readthedocs-preview montepy end -->
