### PR TITLE
Pinned jupyterlit sphinx due to bad dependency resolution.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,14 +55,14 @@ build = [
 ]
 doc = [
 	"montepy[build]",
-	"sphinx~=8.0", 
+	"sphinx>=8.0.0,<9.0.0", 
 	"sphinxcontrib-apidoc", 
 	"pydata_sphinx_theme",
 	"sphinx-favicon",
 	"sphinx-copybutton",
   	"sphinx_autodoc_typehints",
 	"autodocsumm",
-	"jupyterlite-sphinx",
+	"jupyterlite-sphinx>=0.22",
 	"jupyterlite-pyodide-kernel",
 	"sphinx-sitemap",
 ]


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

This fixes sphinx build failures. For some reason pip was installing `jupyterlite-sphinx=0.9.3` and not `jupyterlite-sphinx>=0.22`. There is no clear reason for why this is occurring. AFAICT there are no dependency clashes. I have just manually specified a minimum version, and this appears to fix the issue. This may be a bug with `pip`, but I doubt it. 

Fixes #978

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).


---

### LLM Disclosure

1. Are you?

   - [x] A human user 
   - [ ] A large language model (LLM), including ones acting on behalf of a human

1. Were any large language models (LLM or "AI") used in to generate any of this code?

  - [ ] Yes
      - Model(s) used:
  - [x] No

<details> 

<summary><h3>Documentation Checklist</h3></summary>

- [ ] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Ensure that:

- [ ] This PR fully addresses and resolves the referenced issue(s).
- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--979.org.readthedocs.build/en/979/

<!-- readthedocs-preview montepy end -->