### PR TITLE
Add Cell.is_mass_dens as the complement of is_atom_dens

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,6 +15,7 @@ MontePy Changelog
 **Features Added**
 
 * Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
+* Added :func:`~montepy.cell.Cell.is_mass_dens` as the logical complement of ``is_atom_dens``, returning ``None`` when no density is set (:issue:`964`).
 
 **Feature Added**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,7 +15,7 @@ MontePy Changelog
 **Features Added**
 
 * Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
-* Added :func:`~montepy.cell.Cell.is_mass_dens` as the logical complement of ``is_atom_dens``, returning ``None`` when no density is set (:issue:`964`).
+* Added :func:`~montepy.Cell.is_mass_dens` as the logical complement of :func:`~montepy.Cell.is_atom_dens`, returning ``None`` when no density is set (:issue:`964`).
 
 **Feature Added**
 

--- a/montepy/cell.py
+++ b/montepy/cell.py
@@ -567,6 +567,22 @@ class Cell(Numbered_MCNP_Object):
         """
         return self._is_atom_dens
 
+    @property
+    def is_mass_dens(self):
+        """Whether or not the density is in mass density [g/cc].
+
+        This is the logical complement of :func:`is_atom_dens`. True means
+        it is in mass density, False means atom density [a/b-cm]. If no
+        density is set this will return ``None``.
+
+        Returns
+        -------
+        bool, None
+        """
+        if self._is_atom_dens is None:
+            return None
+        return not self._is_atom_dens
+
     @make_prop_val_node("_old_mat_number")
     def old_mat_number(self):
         """The material number provided in the original input file

--- a/montepy/cell.py
+++ b/montepy/cell.py
@@ -568,20 +568,21 @@ class Cell(Numbered_MCNP_Object):
         return self._is_atom_dens
 
     @property
-    def is_mass_dens(self):
+    def is_mass_dens(self) -> bool | None:
         """Whether or not the density is in mass density [g/cc].
 
         This is the logical complement of :func:`is_atom_dens`. True means
         it is in mass density, False means atom density [a/b-cm]. If no
         density is set this will return ``None``.
 
+        .. versionadded:: 1.5.0
+
         Returns
         -------
         bool, None
         """
-        if self._is_atom_dens is None:
-            return None
-        return not self._is_atom_dens
+        if self._is_atom_dens is not None:
+            return not self._is_atom_dens
 
     @make_prop_val_node("_old_mat_number")
     def old_mat_number(self):

--- a/tests/test_cell_problem.py
+++ b/tests/test_cell_problem.py
@@ -70,7 +70,7 @@ def test_cell_is_mass_dens():
     assert cell.is_mass_dens is True
     assert cell.is_mass_dens == (not cell.is_atom_dens)
     # atom density set
-    cell.atom_density = 1.6
+    cell.atom_density = 0.016
     assert cell.is_mass_dens is False
     assert cell.is_mass_dens == (not cell.is_atom_dens)
 

--- a/tests/test_cell_problem.py
+++ b/tests/test_cell_problem.py
@@ -60,6 +60,21 @@ def test_cell_density_setter():
         cell.mass_density = -5
 
 
+def test_cell_is_mass_dens():
+    # no density set yet
+    cell = Cell()
+    assert cell.is_mass_dens is None
+    assert cell.is_atom_dens is None
+    # mass density set
+    cell.mass_density = 1.5
+    assert cell.is_mass_dens is True
+    assert cell.is_mass_dens == (not cell.is_atom_dens)
+    # atom density set
+    cell.atom_density = 1.6
+    assert cell.is_mass_dens is False
+    assert cell.is_mass_dens == (not cell.is_atom_dens)
+
+
 def test_cell_density_deleter():
     in_str = "1 1 0.5 2"
     cell = Cell(in_str)


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

Adds a read-only `Cell.is_mass_dens` property, the logical complement of the existing `Cell.is_atom_dens`. It lets you check whether a cell's density is expressed in mass density [g/cc] directly, instead of negating `is_atom_dens` yourself.

It is tri-state aware. The internal `_is_atom_dens` is `True` (atom density), `False` (mass density), or `None` (no density set). A naive `return not self.is_atom_dens` would turn the `None` case into `True` and falsely report a density-less cell as mass density, so `is_mass_dens` returns `None` when no density is set, matching how `mass_density`/`atom_density` already treat the unset case:

| `_is_atom_dens` | `is_atom_dens` | `is_mass_dens` |
| --- | --- | --- |
| `True`  | `True`  | `False` |
| `False` | `False` | `True`  |
| `None`  | `None`  | `None`  |

```python
cell.mass_density = 1.5
cell.is_mass_dens   # True
cell.is_atom_dens   # False

cell.atom_density = 1.6
cell.is_mass_dens   # False
```

Fixes #964

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26.
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).

---

### LLM Disclosure

1. Are you?

   - [ ] A human user 
   - [x] A large language model (LLM), including ones acting on behalf of a human

1. Were any large language models (LLM or "AI") used in to generate any of this code?

  - [x] Yes
      - Model(s) used: Claude (Opus 4.8)
  - [ ] No

> Note: Mike German is the human contributor accountable for this PR. The code was drafted by an LLM acting on his behalf and reviewed/verified by him before submission. Disclosed per the repo's "good first prompt 🤖" convention that welcomes disclosed LLM-assisted contributions.

<details open> 

<summary><h3>Documentation Checklist</h3></summary>

- [x] I have documented all added classes and methods.
- [ ] For infrastructure updates, I have updated the developer's guide.
- [ ] For significant new features, I have added a section to the getting started guide.

</details>

---

<details>
<summary><h3>First-Time Contributor Checklist</h3></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.

</details>

---

### Additional Notes for Reviewers

Scope is a single tri-state property plus its test and a changelog entry.

Ensure that:

- [x] This PR fully addresses and resolves the referenced issue(s).
- [x] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [x] The PR covers all relevant aspects according to the development guidelines.
- [x] 100% coverage of the patch is achieved, or justification for a variance is given. `test_cell_is_mass_dens` exercises all three states (mass set → `True`, atom set → `False`, none set → `None`) plus the invariant that `is_mass_dens == (not is_atom_dens)` whenever a density is set.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--984.org.readthedocs.build/en/984/

<!-- readthedocs-preview montepy end -->