### PR TITLE
feat: add MCNP string helpers for geometry halfspaces

### DIFF
--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -545,6 +545,19 @@ class HalfSpace:
     def _generate_default_tree(self):
         pass
 
+    def format_for_mcnp_input(self) -> str:
+        """Return this geometry in MCNP input syntax.
+
+        The geometry tree is updated before formatting so changes to divider
+        numbers, sides, and operators are reflected in the returned value.
+        """
+        self._update_values()
+        return self.node.format()
+
+    def mcnp_str(self) -> str:
+        """Return this geometry as it would appear in an MCNP input file."""
+        return self.format_for_mcnp_input()
+
     def __str__(self):
         if self.operator == Operator.COMPLEMENT:
             return f"{self.operator.value}{self.left}"

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -85,6 +85,18 @@ def test_half_str():
     repr(half_space)
 
 
+def test_halfspace_mcnp_string():
+    surf1 = montepy.CylinderOnAxis(number=1)
+    surf2 = montepy.CylinderOnAxis(number=2)
+    geometry = -surf1 & (+surf2 | -surf1)
+
+    assert geometry.format_for_mcnp_input() == "-1 (2 : -1)"
+    assert geometry.mcnp_str() == "-1 (2 : -1)"
+
+    surf1.number = 3
+    assert geometry.mcnp_str() == "-3 (2 : -3)"
+
+
 def test_unit_half_init():
     node = montepy.input_parser.syntax_node.ValueNode("123", float)
     half_space = UnitHalfSpace(123, True, False, node)


### PR DESCRIPTION
## Summary
Adds public `HalfSpace.format_for_mcnp_input()` and `HalfSpace.mcnp_str()` helpers so callers can obtain MCNP geometry syntax directly.

## Changes
- Update geometry syntax nodes before formatting, including changed divider numbers.
- Add focused coverage for nested union/intersection geometry and mutated surface numbers.

## Related issue
Closes #942

## Validation
- `uv run pytest tests/test_geometry.py -q` → 42 passed
- `uv run pytest -q` → 1239 passed
- `uv run black --check montepy/surfaces/half_space.py tests/test_geometry.py` → 2 files unchanged
- `git diff --check` and a staged added-lines security scan → no findings

## Notes
This contribution was prepared by an automated contributor workflow; the validation results above are from this branch.

<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--987.org.readthedocs.build/en/987/

<!-- readthedocs-preview montepy end -->