### PR TITLE
Fix metaclass/__setattr__ overhead in MCNP_Object hot paths

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -27,6 +27,10 @@ MontePy Changelog
 * Fixed ``leading_comments`` crashing when set with more than one comment (:pull:`972`).
 * Fixed bug where values for user generated objects would be rounded off at five digits no matter what. This will now round off at 15 digits if necessary (:issue:`962`).
 
+**Performance Improvement**
+
+* Fixed ``_ExceptionContextAdder`` wrapping every method and property, including private and dunder ones, in a try/except due to a missing ``continue``, and reduced ``MCNP_Object.__setattr__`` from two class lookups to one (:issue:`990`).
+
 1.4 releases
 ============
 

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -144,11 +144,10 @@ class MCNP_Object(ABC, metaclass=_ExceptionContextAdder):
 
     def __setattr__(self, key, value):
         # handle properties first
-        if hasattr(type(self), key):
-            descriptor = getattr(type(self), key)
-            if isinstance(descriptor, property):
-                descriptor.__set__(self, value)
-                return
+        descriptor = getattr(type(self), key, None)
+        if isinstance(descriptor, property):
+            descriptor.__set__(self, value)
+            return
         # handle _private second
         if key.startswith("_"):
             super().__setattr__(key, value)

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -64,8 +64,9 @@ class _ExceptionContextAdder(ABCMeta):
         """
         new_attrs = {}
         for key, value in attributes.items():
-            if key.startswith("_"):
+            if key.startswith("_") and key != "__init__":
                 new_attrs[key] = value
+                continue
             if callable(value):
                 new_attrs[key] = _ExceptionContextAdder._wrap_attr_call(value)
             elif isinstance(value, property):


### PR DESCRIPTION
# Pull Request Checklist for MontePy

### Description

Fixes two general-purpose sources of avoidable per-call overhead in `MCNP_Object`'s metaclass and `__setattr__` (found while profiling `montepy.read_input()` to investigate slowness on an unrelated branch; see the linked issue for the full profiling writeup):

1. `_ExceptionContextAdder.__new__` was supposed to skip wrapping underscore-prefixed attributes, but the branch never `continue`d, so the unconditional `callable(value)` check right after it overwrote the decision anyway. Every method/property, including private helpers and dunders, was being wrapped in a try/except purely to attach file/line context to exceptions -- 1,896,491 wrapped calls parsing `benchmark/big_model.imcnp`. Added the missing `continue`, keeping `__init__` as the one wrapped exception since it's the primary construction entry point and `MCNP_Problem.parse_input` isn't wrapped by this metaclass. Cuts wrapped calls to 1,241,391 (-34.5%) on the same benchmark.
2. `MCNP_Object.__setattr__` did `hasattr()` followed by `getattr()` (two MRO walks) to check for a property descriptor on every attribute write. Collapsed to one `getattr(type(self), key, None)` call. Verified this doesn't change behavior for underscore-named properties with real setters (e.g. `Importance._explicitly_set`).

Fixes #990

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26.
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
  - No new tests added: this is a behavior-preserving refactor of internal hot paths, not new functionality. The existing 1239-test suite passes unchanged and already exercises both code paths, including `Importance._explicitly_set`.

---

### LLM Disclosure

1. Are you?

   - [ ] A human user 
   - [x] A large language model (LLM), including ones acting on behalf of a human

1. Were any large language models (LLM or "AI") used in to generate any of this code?

  - [x] Yes
      - Model(s) used: Claude Sonnet 5 (`claude-sonnet-5`)
  - [ ] No

<details open> 

<summary><h2>Documentation Checklist</h2></summary>

- [x] I have documented all added classes and methods.
- [x] I have added [type hints](https://peps.python.org/pep-0484/) to all functions as needed.
- [x] I have marked all changes with the `.. versionchanged::` or `.. versionadded::` directives.
  - No public API changed, so no `versionchanged`/`versionadded` directive applies; added a **Performance Improvement** entry to the changelog instead.

<h3>Infrastructure Changes </h3>

- [ ] For infrastructure updates, I have updated the developer's guide.
  - N/A, no infrastructure changes.

<h3>Significant features or Behavior changes </h3>

- [ ] For significant new features, I have added a section to the getting started guide.
  - N/A, no user-visible behavior changed.

</details>

---

<details>
<summary><h2>First-Time Contributor Checklist</h2></summary>

- [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.
  - N/A.

</details>

---

## Additional Notes for Reviewers

Ensure that:

- [ ] This PR fully addresses and resolves the referenced issue(s).
- [ ] The submitted code is consistent with the merge checklist outlined [here](https://www.montepy.org/en/stable/dev_checklist.html#merge-checklist).
- [ ] The PR covers all relevant aspects according to the development guidelines.
- [ ] 100% coverage of the patch is achieved, or justification for a variance is given.
  - For the reviewer: verified via `coverage report --include="*mcnp_object.py" -m` that the 4 lines missing coverage in this file (58, 349, 392, 468) are all outside the changed hunks; both patched blocks are fully covered by the existing suite.

Benchmark and profiling numbers, and the rejected-alternative fast paths that were considered (and why), are documented in #990.


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--991.org.readthedocs.build/en/991/

<!-- readthedocs-preview montepy end -->


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--991.org.readthedocs.build/en/991/

<!-- readthedocs-preview montepy end -->