### PR TITLE
Release 1.5.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,10 +32,19 @@ Fixes # (issue number)
 
 <details open> 
 
-<summary><h3>Documentation Checklist</h3></summary>
+<summary><h2>Documentation Checklist</h2></summary>
 
 - [ ] I have documented all added classes and methods.
+- [ ] I have added [type hints](https://peps.python.org/pep-0484/) to all functions as needed.
+- [ ] I have marked all changes with the `.. versionchanged::` or `.. versionadded::` directives.
+
+
+<h3>Infrastructure Changes </h3>
+
 - [ ] For infrastructure updates, I have updated the developer's guide.
+
+<h3>Significant features or Behavior changes </h3>
+
 - [ ] For significant new features, I have added a section to the getting started guide.
 
 </details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,7 +52,7 @@ Fixes # (issue number)
 ---
 
 <details>
-<summary><h3>First-Time Contributor Checklist</h3></summary>
+<summary><h2>First-Time Contributor Checklist</h2></summary>
 
 - [ ] If this is your first contribution, add yourself to `pyproject.toml` if you wish to do so.
 
@@ -60,7 +60,7 @@ Fixes # (issue number)
 
 ---
 
-### Additional Notes for Reviewers
+## Additional Notes for Reviewers
 
 Ensure that:
 

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -87,7 +87,7 @@ jobs:
           name: build
           path: dist/
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -106,5 +106,5 @@ jobs:
           name: build
           path: dist/
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -64,7 +64,7 @@ jobs:
           gh release upload
           'v${{ steps.get_version.outputs.version }}' dist/**
           --repo '${{ github.repository }}'
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with: 
            name: build
            path: |

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest    
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: set up python  3.14
@@ -33,7 +33,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -50,7 +50,7 @@ jobs:
         run: .github/scripts/check_version.py --alpha 
       - run: python -m build .
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc
+        uses: sigstore/gh-action-sigstore-python@5b79a39c381910c090341a2c9b0bf022c8b387e1
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -50,15 +50,15 @@ jobs:
         run: .github/scripts/check_version.py --alpha 
       - run: python -m build .
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc
         with:
           inputs: >-
             ./dist/*.tar.gz
             ./dist/*.whl
       - name: Create a GitHub release
-        run: | 
-            gh release create "v${ steps.get_version.outputs.version }" \
-            --title="Release ${ steps.get_version.outputs.version }" \
+        run: |
+            gh release create "v${{ steps.get_version.outputs.version }}" \
+            --title="Release ${{ steps.get_version.outputs.version }}" \
             --generate-notes -d
       - run: >-
           gh release upload

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest    
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
       - name: set up python  3.14
@@ -33,7 +33,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           persist-credentials: false
       - name: set up python  3.14
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with: 
           python-version: 3.14
       - run: pip install . montepy[develop]
@@ -39,7 +39,7 @@ jobs:
           fetch-tags: true
           persist-credentials: false
       - name: set up python  3.14
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with: 
           python-version: 3.14
       - run: pip install . montepy[build]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
           gh release upload
           'v${{ steps.get_version.outputs.version }}' dist/**
           --repo '${{ github.repository }}'
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with: 
            name: build
            path: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           persist-credentials: false
       - name: set up python  3.14
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with: 
           python-version: 3.14
       - run: pip install . montepy[develop]
@@ -40,7 +40,7 @@ jobs:
           fetch-tags: true
           persist-credentials: false
       - name: set up python  3.14
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with: 
           python-version: 3.14
       - run: pip install . montepy[build]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
         run: .github/scripts/check_version.py
       - run: python -m build .
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc
+        uses: sigstore/gh-action-sigstore-python@5b79a39c381910c090341a2c9b0bf022c8b387e1
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest    
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: set up python  3.14
@@ -34,7 +34,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest    
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
       - name: set up python  3.14
@@ -34,7 +34,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       - run: pip install --user . montepy[develop]
       - run: pip freeze
       - name: Upload build artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: ${{ matrix.python-version == '3.13'}}
         with: 
            name: build
@@ -89,13 +89,13 @@ jobs:
         if:  ${{ success() || failure() }}
       - name: Upload test report
         if: ${{ matrix.python-version == '3.14' && matrix.numpy-version == '2.3' && (success() || failure() )}}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: test
           path: test_report.xml
       - name: Upload coverage report
         if: ${{ matrix.python-version == '3.14' && matrix.numpy-version == '2.3' && (success() || failure() )}}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: coverage
           path: coverage.xml
@@ -128,7 +128,7 @@ jobs:
       - run: pip install . montepy[doc,build]
       - run: cd doc && make html SPHINXOPTS="-W --keep-going -E"
         name: Build site strictly
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: website
           path: doc/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     permissions:
-      actions: write
+      contents: read
     strategy:
       matrix:
         python-version: ["3.12", "3.13", "3.14", "3.15-dev"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     continue-on-error: ${{ matrix.python-version == '3.15-dev' }}
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with: 
           fetch-depth: 0
           fetch-tags: true
@@ -70,7 +70,7 @@ jobs:
     continue-on-error: ${{ matrix.python-version == '3.15-dev' }}
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: set up python  ${{ matrix.python-version }}
@@ -120,7 +120,7 @@ jobs:
       contents: read
     
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -147,7 +147,7 @@ jobs:
       contents: read
     
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -175,7 +175,7 @@ jobs:
     
     steps:
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: set up python 3.14
@@ -191,7 +191,7 @@ jobs:
       contents: read
     
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: set up python 3.14
@@ -212,7 +212,7 @@ jobs:
       contents: read
     
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: set up python 3.14
@@ -231,7 +231,7 @@ jobs:
     if: github.ref != 'refs/heads/main'
     
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: Check for changes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,9 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.12", "3.13", "3.14", "3.15-dev"]
-        numpy-version: ["2.0", "2.4"]
+        # 2.0.0 is pinned to a minor version, whereas 2.4 is pinned to a major version.
+        # Though it may be confusing this will install 2.5, etc.
+        numpy-version: ["2.0.0", "2.4"]
         sly-version: ["0.5"]
         include:
           - python-version: "3.13"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-tags: true
           persist-credentials: false
       - name: set up python  ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with: 
           python-version: ${{ matrix.python-version }}
       - run: pip install --upgrade pip
@@ -74,7 +74,7 @@ jobs:
         with:
           persist-credentials: false
       - name: set up python  ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with: 
           python-version: ${{ matrix.python-version }}
       - run: pip install numpy~=${{ matrix.numpy-version }}
@@ -126,7 +126,7 @@ jobs:
           fetch-tags: true
           persist-credentials: false
       - name: set up python 3.12
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with: 
           python-version: 3.14
       - run: pip install . montepy[doc,build]
@@ -153,7 +153,7 @@ jobs:
           fetch-tags: true
           persist-credentials: false
       - name: set up python 3.14
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with: 
           python-version: 3.14
       - run: pip install . montepy[doc,build,demo-test,test]
@@ -179,7 +179,7 @@ jobs:
         with:
           persist-credentials: false
       - name: set up python 3.14
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with: 
           python-version: 3.14
       - run: pip install . montepy[format]
@@ -195,7 +195,7 @@ jobs:
         with:
           persist-credentials: false
       - name: set up python 3.14
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with: 
           python-version: 3.14
       - run: pip install . montepy[test]
@@ -216,7 +216,7 @@ jobs:
         with:
           persist-credentials: false
       - name: set up python 3.14
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with: 
           python-version: 3.14
       - run: pip install . montepy[test]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14", "3.15-dev"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -57,7 +57,7 @@ jobs:
       actions: write
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14", "3.15-dev"]
         numpy-version: ["2.0", "2.4"]
         sly-version: ["0.5"]
         include:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,7 +235,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Check for changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706
         id: changes
         with:
           filters: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with: 
           fetch-depth: 0
           fetch-tags: true
@@ -66,7 +66,7 @@ jobs:
             sly-version: "0.4"
     
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
       - name: set up python  ${{ matrix.python-version }}
@@ -116,7 +116,7 @@ jobs:
       contents: read
     
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -143,7 +143,7 @@ jobs:
       contents: read
     
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -171,7 +171,7 @@ jobs:
     
     steps:
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
       - name: set up python 3.14
@@ -187,7 +187,7 @@ jobs:
       contents: read
     
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
       - name: set up python 3.14
@@ -208,7 +208,7 @@ jobs:
       contents: read
     
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
       - name: set up python 3.14
@@ -227,7 +227,7 @@ jobs:
     if: github.ref != 'refs/heads/main'
     
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
       - name: Check for changes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.12", "3.13", "3.14", "3.15-dev"]
+    continue-on-error: ${{ matrix.python-version == '3.15-dev' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -53,7 +54,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    permissions: 
+    permissions:
       actions: write
     strategy:
       matrix:
@@ -66,7 +67,8 @@ jobs:
           - python-version: "3.13"
             numpy-version: "2.4"
             sly-version: "0.4"
-    
+    continue-on-error: ${{ matrix.python-version == '3.15-dev' }}
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,19 +88,19 @@ jobs:
       - run: coverage xml
         if:  ${{ success() || failure() }}
       - name: Upload test report
-        if: ${{ matrix.python-version == '3.14' && matrix.numpy-version == '2.3' && (success() || failure() )}}
+        if: ${{ matrix.python-version == '3.14' && matrix.numpy-version == '2.4' && (success() || failure() )}}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: test
           path: test_report.xml
       - name: Upload coverage report
-        if: ${{ matrix.python-version == '3.14' && matrix.numpy-version == '2.3' && (success() || failure() )}}
+        if: ${{ matrix.python-version == '3.14' && matrix.numpy-version == '2.4' && (success() || failure() )}}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: coverage
           path: coverage.xml
       - name: Coveralls GitHub Action
-        if: ${{ matrix.python-version == '3.14' && matrix.numpy-version == '2.3' && (success() || failure() )}}
+        if: ${{ matrix.python-version == '3.14' && matrix.numpy-version == '2.4' && (success() || failure() )}}
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e
         with:
           file: coverage.xml

--- a/.github/workflows/rtd_link.yml
+++ b/.github/workflows/rtd_link.yml
@@ -8,6 +8,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: readthedocs/actions/preview@31a30360a2d7530806bff6855aa209167f06a89c
+      - uses: readthedocs/actions/preview@fa6846867b4616e65886b37ae564cb695e8dc570
         with:
           project-slug: "montepy"

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Travis J. Labossiere-Hickman <Travis.LabossiereHickman@inl.gov>
 Brenna A. Carbno <brenna.carbno@inl.gov>
 Benjaminas M. <BenjaminasDev@outlook.com>
 Ferney P. <Paul.Ferney@inl.gov>
+Yusra Rasool <ryusra9@gmail.com>

--- a/demo/0_IntroToMontePy_ANS_studen_26.ipynb
+++ b/demo/0_IntroToMontePy_ANS_studen_26.ipynb
@@ -20,7 +20,9 @@
     "\n",
     "<sup>1</sup> Idaho National Laboratory; University of Wisconsin—Madison; Contact: [Micah.Gale@INL.gov](mailto:micah.gale@inl.gov)\n",
     "\n",
-    "<sup>2</sup> Idaho National Laboratory; University of Illinois, Urbana-Champaign; Contact: [Travis.LabossiereHickman@INL.gov](mailto:Travis.LabossiereHickman@INL.gov)"
+    "<sup>2</sup> Idaho National Laboratory; University of Illinois, Urbana-Champaign; Contact: [Travis.LabossiereHickman@INL.gov](mailto:Travis.LabossiereHickman@INL.gov)\n",
+    "\n",
+    "INL/CON-26-91533"
    ]
   },
   {

--- a/demo/1_PinCellCorrection_inter.ipynb
+++ b/demo/1_PinCellCorrection_inter.ipynb
@@ -11,6 +11,8 @@
     "tags": []
    },
    "source": [
+    "INL/CON-24-82568\n",
+    "\n",
     "# Fixing a Pin Cell problem\n",
     "\n",
     "## Scenario\n",

--- a/demo/1_fusion_radial_build.ipynb
+++ b/demo/1_fusion_radial_build.ipynb
@@ -11,6 +11,8 @@
     "tags": []
    },
    "source": [
+    "INL/CON-26-91533\n",
+    "\n",
     "# Fixing a Radial Build Model for Fusion Applications\n",
     "\n",
     "## Scenario\n",

--- a/demo/1_fusion_radial_build.ipynb
+++ b/demo/1_fusion_radial_build.ipynb
@@ -18,7 +18,8 @@
     "## Scenario\n",
     "* Trying to model a Tokamak fusion power plant\n",
     "* You have simple, but \"buggy\", radial build model\n",
-    "* You are trying to perform a parametric sweep"
+    "* You are trying to perform a parametric sweep\n",
+    "\n"
    ]
   },
   {

--- a/demo/2_BuildAssembly_inter.ipynb
+++ b/demo/2_BuildAssembly_inter.ipynb
@@ -11,6 +11,8 @@
     "tags": []
    },
    "source": [
+    "INL/CON-24-82568\n",
+    "\n",
     "# Building an Assembly $K_\\infty$ Model"
    ]
   },

--- a/demo/3_AddingGuideTubes_inter.ipynb
+++ b/demo/3_AddingGuideTubes_inter.ipynb
@@ -11,6 +11,8 @@
     "tags": []
    },
    "source": [
+    "INL/CON-24-82568\n",
+    "\n",
     "# Making A Realistic Fuel Assembly \n",
     "\n",
     "Previously made an \"all fuel\" W17$\\times$17 fuel assembly\n",

--- a/demo/4_AxialDiscretize_inter.ipynb
+++ b/demo/4_AxialDiscretize_inter.ipynb
@@ -11,6 +11,8 @@
     "tags": []
    },
    "source": [
+    "INL/CON-24-82568\n",
+    "\n",
     "# Adding Axial Realism\n",
     "* Up to this point all models were 1.26 cm tall with reflective boundaries\n",
     "* Great for rough $k_\\infty$, but not a useful $k_\\infty$\n",

--- a/demo/5_AdapterSegue.ipynb
+++ b/demo/5_AdapterSegue.ipynb
@@ -5,6 +5,8 @@
    "id": "f4f5561d-b05a-44c8-bf80-3a51300a1cc6",
    "metadata": {},
    "source": [
+    "INL/CON-24-82568\n",
+    "\n",
     "# Plotting\n",
     "\n",
     "Start by loading our last model:\n",

--- a/demo/_config.py
+++ b/demo/_config.py
@@ -12,4 +12,5 @@ def IFrame(src, width=X_RES, height=Y_RES, extras=None, **kwargs):
 async def install_montepy():
     if "pyodide" in sys.modules:
         import piplite
+
         await piplite.install("montepy")

--- a/demo/answers/1_fusion_radial_build.ipynb
+++ b/demo/answers/1_fusion_radial_build.ipynb
@@ -343,7 +343,7 @@
     "#\n",
     "# Iterate over the cells and their numbers, thanks to items()\n",
     "for num, cell in problem.cells.items():\n",
-    "    #print the cell comments\n",
+    "    # print the cell comments\n",
     "    print(num, cell.comments)"
    ]
   },
@@ -486,12 +486,7 @@
    },
    "outputs": [],
    "source": [
-    "w_natural = {\n",
-    "    182: 0.265,\n",
-    "    183: 0.143,\n",
-    "    184: 0.306,\n",
-    "    186: 0.284\n",
-    "}\n",
+    "w_natural = {182: 0.265, 183: 0.143, 184: 0.306, 186: 0.284}\n",
     "tungsten.clear()\n",
     "for mass, abundance in w_natural.items():\n",
     "    tungsten.add_nuclide(f\"W-{mass}.82c\", abundance)\n",
@@ -765,9 +760,10 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "MIN_RADIUS = 115.01 # [cm]\n",
-    "MAX_RADIUS = 198.99 # [cm]\n",
-    "CAN_THICKNESS = 1 #[cm]\n",
+    "\n",
+    "MIN_RADIUS = 115.01  # [cm]\n",
+    "MAX_RADIUS = 198.99  # [cm]\n",
+    "CAN_THICKNESS = 1  # [cm]\n",
     "\n",
     "radii = np.arange(MIN_RADIUS, MAX_RADIUS, 5)\n",
     "for radius in radii:\n",

--- a/demo/answers/1_fusion_radial_build.ipynb
+++ b/demo/answers/1_fusion_radial_build.ipynb
@@ -343,7 +343,7 @@
     "#\n",
     "# Iterate over the cells and their numbers, thanks to items()\n",
     "for num, cell in problem.cells.items():\n",
-    "    # print the cell comments\n",
+    "    #print the cell comments\n",
     "    print(num, cell.comments)"
    ]
   },
@@ -486,7 +486,12 @@
    },
    "outputs": [],
    "source": [
-    "w_natural = {182: 0.265, 183: 0.143, 184: 0.306, 186: 0.284}\n",
+    "w_natural = {\n",
+    "    182: 0.265,\n",
+    "    183: 0.143,\n",
+    "    184: 0.306,\n",
+    "    186: 0.284\n",
+    "}\n",
     "tungsten.clear()\n",
     "for mass, abundance in w_natural.items():\n",
     "    tungsten.add_nuclide(f\"W-{mass}.82c\", abundance)\n",
@@ -760,10 +765,9 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "\n",
-    "MIN_RADIUS = 115.01  # [cm]\n",
-    "MAX_RADIUS = 198.99  # [cm]\n",
-    "CAN_THICKNESS = 1  # [cm]\n",
+    "MIN_RADIUS = 115.01 # [cm]\n",
+    "MAX_RADIUS = 198.99 # [cm]\n",
+    "CAN_THICKNESS = 1 #[cm]\n",
     "\n",
     "radii = np.arange(MIN_RADIUS, MAX_RADIUS, 5)\n",
     "for radius in radii:\n",

--- a/demo/workshops/MC_2025_intro.ipynb
+++ b/demo/workshops/MC_2025_intro.ipynb
@@ -26,8 +26,7 @@
     "\n",
     "<sup>2</sup> Idaho National Laboratory; University of Wisconsin—Madison; Contact: [Micah.Gale@INL.gov](mailto:micah.gale@inl.gov)\n",
     "\n",
-    "\n",
-    "\n"
+    "INL/CON-24-82568"
    ]
   },
   {

--- a/doc/source/_extension/schema_org.py
+++ b/doc/source/_extension/schema_org.py
@@ -15,7 +15,6 @@ Add to conf.py:
 import json
 from typing import Any, Dict
 
-from docutils import nodes
 from sphinx.application import Sphinx
 
 

--- a/doc/source/_extension/schema_org.py
+++ b/doc/source/_extension/schema_org.py
@@ -18,7 +18,9 @@ from typing import Any, Dict
 from sphinx.application import Sphinx
 
 
-def add_schema_org_data(app: Sphinx, pagename: str, templatename: str, context: Dict, doctree: Any) -> None:
+def add_schema_org_data(
+    app: Sphinx, pagename: str, templatename: str, context: Dict, doctree: Any
+) -> None:
     """Add schema.org JSON-LD to page if configured."""
     configs = app.config.schema_org_configs
     if not configs or pagename not in configs:
@@ -26,7 +28,7 @@ def add_schema_org_data(app: Sphinx, pagename: str, templatename: str, context: 
 
     schema_data = configs[pagename]
     schema_json = json.dumps(schema_data, indent=2)
-    context['schema_org_data'] = schema_json
+    context["schema_org_data"] = schema_json
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:

--- a/doc/source/_extension/schema_org.py
+++ b/doc/source/_extension/schema_org.py
@@ -1,0 +1,42 @@
+"""Sphinx extension to inject schema.org JSON-LD structured data.
+
+Add to conf.py:
+    extensions = [..., "schema_org"]
+
+    schema_org_configs = {
+        "index": {
+            "@type": "SoftwareApplication",
+            "name": "MontePy",
+            ...
+        }
+    }
+"""
+
+import json
+from typing import Any, Dict
+
+from docutils import nodes
+from sphinx.application import Sphinx
+
+
+def add_schema_org_data(app: Sphinx, pagename: str, templatename: str, context: Dict, doctree: Any) -> None:
+    """Add schema.org JSON-LD to page if configured."""
+    configs = app.config.schema_org_configs
+    if not configs or pagename not in configs:
+        return
+
+    schema_data = configs[pagename]
+    schema_json = json.dumps(schema_data, indent=2)
+    context['schema_org_data'] = schema_json
+
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    """Register the extension."""
+    app.add_config_value("schema_org_configs", {}, "html")
+    app.connect("html-page-context", add_schema_org_data)
+
+    return {
+        "version": "0.1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/source/_templates/mofunc.rst
+++ b/doc/source/_templates/mofunc.rst
@@ -1,0 +1,6 @@
+{{ objname }}
+{{ underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autofunction:: {{ objname }}

--- a/doc/source/_templates/myclass.rst
+++ b/doc/source/_templates/myclass.rst
@@ -1,4 +1,4 @@
-{{ fullname }}
+{{ objname }}
 {{ underline }}
 
 .. currentmodule:: {{ module }}
@@ -8,4 +8,4 @@
     :inherited-members:
     :undoc-members:
     :show-inheritance:
-    :private-members: _problem, _clear_data, _is_worth_printing, _tree_value, _collect_new_values, _update_cell_values, _update_values, _class_prefix, _has_number, _has_classifier, _add_children_objs, _update_number, _append_hook, _delete_hook, _delete_trailing_comment, _grab_beginning_comment, _flatten_shortcut, _get_first_comment, _convert_to_node, _print_value, _value_changed, _avoid_rounding_truncation, _particles_sorted, _expand_shortcuts, _can_consume_node, _can_use_last_node, _generate_default_node, _format_tree, _check_redundant_definitions         
+    :private-members: _problem, _clear_data, _is_worth_printing, _tree_value, _collect_new_values, _update_cell_values, _update_values, _class_prefix, _has_number, _has_classifier, _add_children_objs, _update_number, _append_hook, _delete_hook, _delete_trailing_comment, _grab_beginning_comment, _flatten_shortcut, _get_first_comment, _convert_to_node, _print_value, _value_changed, _avoid_rounding_truncation, _particles_sorted, _expand_shortcuts, _can_consume_node, _can_use_last_node, _generate_default_node, _format_tree, _check_redundant_definitions

--- a/doc/source/_templates/page.html
+++ b/doc/source/_templates/page.html
@@ -1,8 +1,8 @@
 {% extends "!page.html" %}
 
-{% block body %}
+{% block extrahead %}
   {{ super() }}
-  {% if pagename == 'index' and schema_org_data %}
+  {% if schema_org_data %}
   <script type="application/ld+json">
   {{ schema_org_data | safe }}
   </script>

--- a/doc/source/_templates/page.html
+++ b/doc/source/_templates/page.html
@@ -1,0 +1,10 @@
+{% extends "!page.html" %}
+
+{% block body %}
+  {{ super() }}
+  {% if pagename == 'index' and schema_org_data %}
+  <script type="application/ld+json">
+  {{ schema_org_data | safe }}
+  </script>
+  {% endif %}
+{% endblock %}

--- a/doc/source/api/modules.rst
+++ b/doc/source/api/modules.rst
@@ -279,6 +279,7 @@ Object Builders
 .. autosummary::
    :toctree: generated
    :nosignatures:
+   :template: mofunc.rst
 
    montepy.data_inputs.data_parser.parse_data
    montepy.input_parser.input_syntax_reader.read_input_syntax

--- a/doc/source/api/modules.rst
+++ b/doc/source/api/modules.rst
@@ -33,6 +33,7 @@ Collections
    :template: myclass.rst
 
    montepy.Cells
+   montepy.CommentCollection
    montepy.Materials
    montepy.Surfaces
    montepy.Transforms

--- a/doc/source/api/montepy.constants.rst
+++ b/doc/source/api/montepy.constants.rst
@@ -1,5 +1,5 @@
-montepy.constants module
-========================
+constants
+=========
 
 
 .. automodule:: montepy.constants

--- a/doc/source/api/montepy.exceptions.rst
+++ b/doc/source/api/montepy.exceptions.rst
@@ -1,5 +1,5 @@
-montepy.exceptions module
-=========================
+exceptions
+==========
 
 
 .. automodule:: montepy.exceptions

--- a/doc/source/api/montepy.utilities.rst
+++ b/doc/source/api/montepy.utilities.rst
@@ -1,5 +1,5 @@
-montepy.utilities module
-========================
+utilities
+=========
 
 
 .. automodule:: montepy.utilities

--- a/doc/source/bugs.rst
+++ b/doc/source/bugs.rst
@@ -1,3 +1,7 @@
+.. meta::
+   :description lang=en:
+        Known bugs and limitations in MontePy, including less obvious unsupported MCNP features and suggested workarounds.
+
 **************************
 Known Bugs and limitations
 **************************

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,7 +6,7 @@ Next Release
 ============
 
 **Features Added**
-* Added :func:`~montepy.surfaces.half_space.HalfSpace.replace` to swap dividers in a cell geometry tree, and ``__iter__`` to traverse geometry leaves (:issue:`737`).
+* Added ``replace`` :class:`~montepy.surfaces.half_space.HalfSpace` to swap dividers in a cell geometry tree, and ``__iter__`` to traverse geometry leaves (:issue:`737`).
 
 
 1.4 releases

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,9 +6,8 @@ Next Release
 ============
 
 **Features Added**
-* Added ``replace`` :class:`~montepy.surfaces.half_space.HalfSpace` to swap dividers in a cell geometry tree, and ``__iter__`` to traverse geometry leaves (:issue:`737`).
 
-
+* Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
 1.4 releases
 ============
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -2,6 +2,13 @@
 MontePy Changelog
 *****************
 
+Next Release
+============
+
+**Features Added**
+* Added :func:`~montepy.surfaces.half_space.HalfSpace.replace` to swap dividers in a cell geometry tree, and ``__iter__`` to traverse geometry leaves (:issue:`737`).
+
+
 1.4 releases
 ============
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -27,6 +27,10 @@ MontePy Changelog
 * Fixed ``leading_comments`` crashing when set with more than one comment (:pull:`972`).
 * Fixed bug where values for user generated objects would be rounded off at five digits no matter what. This will now round off at 15 digits if necessary (:issue:`962`).
 
+**Performance Improvement**
+
+* Fixed ``_ExceptionContextAdder`` wrapping every method and property, including private and dunder ones, in a try/except due to a missing ``continue``, and reduced ``MCNP_Object.__setattr__`` from two class lookups to one (:issue:`990`).
+
 1.4 releases
 ============
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,3 +1,7 @@
+.. meta::
+   :description lang=en:
+        MontePy release notes and changelog: new features, bug fixes, and improvements across all versions of the Python MCNP input file library.
+
 *****************
 MontePy Changelog
 *****************

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,6 +15,7 @@ MontePy Changelog
 **Features Added**
 
 * Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
+* Added :func:`~montepy.cell.Cell.is_mass_dens` as the logical complement of ``is_atom_dens``, returning ``None`` when no density is set (:issue:`964`).
 
 **Feature Added**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -16,9 +16,6 @@ MontePy Changelog
 
 * Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
 * Added :func:`~montepy.Cell.is_mass_dens` as the logical complement of :func:`~montepy.Cell.is_atom_dens`, returning ``None`` when no density is set (:issue:`964`).
-
-**Feature Added**
-
 * Added support for the ``in`` operator on comments, so a comment's text can be searched with e.g. ``"keyword" in comment`` (:issue:`185`).
 * Added :class:`~montepy.comments.CommentCollection`, now returned by ``comments`` and ``leading_comments``, so an object can be found by its comments with e.g. ``"keyword" in cell.comments``, or searched by regular expression with ``cell.comments.search`` (:issue:`185`).
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -12,17 +12,18 @@ Next Release
 **Features Added**
 
 * Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
+* Added support for the ``in`` operator on comments, so a comment's text can be searched with e.g. ``"keyword" in comment`` (:issue:`185`).
+* Added :class:`~montepy.comments.CommentCollection`, now returned by ``comments`` and ``leading_comments``, so an object can be found by its comments with e.g. ``"keyword" in cell.comments``, or searched by regular expression with ``cell.comments.search`` (:issue:`185`).
+
+**Bugs Fixed**
+
+* Fixed ``leading_comments`` crashing when set with more than one comment (:pull:`972`).
 
 1.4 releases
 ============
 
 #Next Version#
 --------------
-
-**Feature Added**
-
-* Added support for the ``in`` operator on comments, so a comment's text can be searched with e.g. ``"keyword" in comment`` (:issue:`185`).
-* Added :class:`~montepy.comments.CommentCollection`, now returned by ``comments`` and ``leading_comments``, so an object can be found by its comments with e.g. ``"keyword" in cell.comments``, or searched by regular expression with ``cell.comments.search`` (:issue:`185`).
 
 **Bugs Fixed**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -32,7 +32,6 @@ MontePy Changelog
 * Enable Sphinx nitpicky mode and fix ~30 broken cross-references in the developer guide, user guide, and migration docs (:issue:`889`).
 * Remove redundant "montepy.*" prefix from navigation in the API docs (:issue:`901`).
 
-
 1.3.0
 --------------
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -14,6 +14,7 @@ MontePy Changelog
 * ``Cell.universe`` can now be set to ``None`` (or deleted via ``del cell.universe``) to reset the universe assignment back to the default (:issue:`902`).
 * Added ``extend_renumber`` to ``NumberedObjectCollection`` with related test cases (:issue:`881`).
 * Made :class:`montepy.data_inputs.importance.Importance` more ``dict``-like with ``keys``, ``values``, and ``items`` functions (:pull:`921`).
+* API to Allow editing cell geometry definition (:issue:`945`).
 
 **Bugs Fixed**
 
@@ -31,8 +32,6 @@ MontePy Changelog
 * Enable Sphinx nitpicky mode and fix ~30 broken cross-references in the developer guide, user guide, and migration docs (:issue:`889`).
 * Remove redundant "montepy.*" prefix from navigation in the API docs (:issue:`901`).
 
-1.3 releases
-============
 
 1.3.0
 --------------

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,6 +15,7 @@ MontePy Changelog
 **Feature Added**
 
 * Added support for the ``in`` operator on comments, so a comment's text can be searched with e.g. ``"keyword" in comment`` (:issue:`185`).
+* Added :class:`~montepy.comments.CommentCollection`, now returned by ``comments`` and ``leading_comments``, so an object can be found by its comments with e.g. ``"keyword" in cell.comments``, or searched by regular expression with ``cell.comments.search`` (:issue:`185`).
 
 **Bugs Fixed**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -10,17 +10,6 @@ MontePy Changelog
 1.5 Releases
 ============
 
-**Features Added**
-
-* Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
-
-**Bugs Fixed**
-
-* Fixed parsing of multiply shortcuts in universe data cards such as ``1 8M`` (:pull:`975`).
-
-1.4 releases
-============
-
 #Next Version#
 --------------
 **Features Added**
@@ -35,6 +24,7 @@ MontePy Changelog
 
 **Bugs Fixed**
 
+* Fixed parsing of multiply shortcuts in universe data cards such as ``1 8M`` (:pull:`975`).
 * Fixed ``leading_comments`` crashing when set with more than one comment (:pull:`972`).
 * Fixed bug where values for user generated objects would be rounded off at five digits no matter what. This will now round off at 15 digits if necessary (:issue:`962`).
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -9,6 +9,14 @@ MontePy Changelog
 1.4 releases
 ============
 
+#Next Version#
+--------------
+
+**Bugs Fixed**
+
+* Fixed bug where values for user generated objects would be rounded off at five digits no matter what. This will now round off at 15 digits if necessary (:issue:`962`).
+
+
 1.4.0
 --------------
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -29,6 +29,7 @@ MontePy Changelog
 **Documentation**
 
 * Enable Sphinx nitpicky mode and fix ~30 broken cross-references in the developer guide, user guide, and migration docs (:issue:`889`).
+* Remove redundant "montepy.*" prefix from navigation in the API docs (:issue:`901`).
 
 1.3 releases
 ============

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -10,6 +10,17 @@ MontePy Changelog
 1.5 Releases
 ============
 
+**Features Added**
+
+* Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
+
+**Bugs Fixed**
+
+* Fixed parsing of multiply shortcuts in universe data cards such as ``1 8M`` (:pull:`975`).
+
+1.4 releases
+============
+
 #Next Version#
 --------------
 **Features Added**

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -12,6 +12,10 @@ MontePy Changelog
 #Next Version#
 --------------
 
+**Feature Added**
+
+* Added support for the ``in`` operator on comments, so a comment's text can be searched with e.g. ``"keyword" in comment`` (:issue:`185`).
+
 **Bugs Fixed**
 
 * Fixed bug where values for user generated objects would be rounded off at five digits no matter what. This will now round off at 15 digits if necessary (:issue:`962`).

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -6,23 +6,22 @@
 MontePy Changelog
 *****************
 
-Next Release
-============
 
-**Features Added**
-
-* Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
-
-1.4 releases
+1.5 Releases
 ============
 
 #Next Version#
 --------------
+**Features Added**
+
+* Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
 
 **Bugs Fixed**
 
 * Fixed bug where values for user generated objects would be rounded off at five digits no matter what. This will now round off at 15 digits if necessary (:issue:`962`).
 
+1.4 releases
+============
 
 1.4.0
 --------------

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -15,7 +15,7 @@ MontePy Changelog
 **Features Added**
 
 * Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
-* Added :func:`~montepy.cell.Cell.is_mass_dens` as the logical complement of ``is_atom_dens``, returning ``None`` when no density is set (:issue:`964`).
+* Added :func:`~montepy.Cell.is_mass_dens` as the logical complement of :func:`~montepy.Cell.is_atom_dens`, returning ``None`` when no density is set (:issue:`964`).
 
 **Feature Added**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -10,7 +10,7 @@ MontePy Changelog
 1.5 Releases
 ============
 
-#Next Version#
+1.5.0
 --------------
 **Features Added**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -8,6 +8,7 @@ Next Release
 **Features Added**
 
 * Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
+
 1.4 releases
 ============
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -12,12 +12,6 @@ Next Release
 **Features Added**
 
 * Added ``HalfSpace.replace`` to swap dividers in a cell geometry tree, and ``HalfSpace.__iter__`` to traverse geometry leaves (:issue:`737`).
-* Added support for the ``in`` operator on comments, so a comment's text can be searched with e.g. ``"keyword" in comment`` (:issue:`185`).
-* Added :class:`~montepy.comments.CommentCollection`, now returned by ``comments`` and ``leading_comments``, so an object can be found by its comments with e.g. ``"keyword" in cell.comments``, or searched by regular expression with ``cell.comments.search`` (:issue:`185`).
-
-**Bugs Fixed**
-
-* Fixed ``leading_comments`` crashing when set with more than one comment (:pull:`972`).
 
 1.4 releases
 ============
@@ -25,8 +19,14 @@ Next Release
 #Next Version#
 --------------
 
+**Feature Added**
+
+* Added support for the ``in`` operator on comments, so a comment's text can be searched with e.g. ``"keyword" in comment`` (:issue:`185`).
+* Added :class:`~montepy.comments.CommentCollection`, now returned by ``comments`` and ``leading_comments``, so an object can be found by its comments with e.g. ``"keyword" in cell.comments``, or searched by regular expression with ``cell.comments.search`` (:issue:`185`).
+
 **Bugs Fixed**
 
+* Fixed ``leading_comments`` crashing when set with more than one comment (:pull:`972`).
 * Fixed bug where values for user generated objects would be rounded off at five digits no matter what. This will now round off at 15 digits if necessary (:issue:`962`).
 
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -33,7 +33,6 @@ Next Release
 * ``Cell.universe`` can now be set to ``None`` (or deleted via ``del cell.universe``) to reset the universe assignment back to the default (:issue:`902`).
 * Added ``extend_renumber`` to ``NumberedObjectCollection`` with related test cases (:issue:`881`).
 * Made :class:`montepy.data_inputs.importance.Importance` more ``dict``-like with ``keys``, ``values``, and ``items`` functions (:pull:`921`).
-* API to Allow editing cell geometry definition (:issue:`945`).
 
 **Bugs Fixed**
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -50,6 +50,9 @@ Next Release
 * Enable Sphinx nitpicky mode and fix ~30 broken cross-references in the developer guide, user guide, and migration docs (:issue:`889`).
 * Remove redundant "montepy.*" prefix from navigation in the API docs (:issue:`901`).
 
+1.3 releases
+============
+
 1.3.0
 --------------
 

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -28,6 +28,10 @@ MontePy Changelog
 * Fixed ``leading_comments`` crashing when set with more than one comment (:pull:`972`).
 * Fixed bug where values for user generated objects would be rounded off at five digits no matter what. This will now round off at 15 digits if necessary (:issue:`962`).
 
+**Performance Improvement**
+
+* Fixed ``_ExceptionContextAdder`` wrapping every method and property, including private and dunder ones, in a try/except due to a missing ``continue``, and reduced ``MCNP_Object.__setattr__`` from two class lookups to one (:issue:`990`).
+
 1.4 releases
 ============
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -181,7 +181,6 @@ nitpick_ignore = [
     ("py:class", "sly.yacc.ParserMeta"),
     ("py:class", "sly.yacc.YaccProduction"),
     ("py:class", "InitInput"),
-    
     # Subpackages referenced with :mod: in docs; autodoc indexes individual classes
     # but not the package-level modules themselves
     # typing.Union is not in the Python intersphinx inventory as a py:data target

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -306,6 +306,10 @@ nitpick_ignore_regex = [
     # sphinx_autodoc_typehints generates "self" and "self._attr" refs for some
     # return-type annotations; these cannot be resolved and are harmless
     (r"py:class", r"^self(\._\w+)?$"),
+    # collections.abc.Sequence's inherited count/index carry C-style docstrings
+    # whose return annotations (e.g. "integer -- return number of occurrences
+    # of value") are not resolvable cross-references
+    (r"py:class", r"^integer -- return .*$"),
 ]
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -131,7 +131,7 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "navbar_start": ["navbar-logo", "project", "version"],
     "logo": {
-        "alt_text": "MontePy - Documentation Home. The image is the MontePy logo: a red over white ball with a python inside of it.",
+        "alt_text": "MontePy documentation home.",
     },
     "icon_links": [
         {

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -130,6 +130,9 @@ github_url = "https://github.com/idaholab/MontePy"
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "navbar_start": ["navbar-logo", "project", "version"],
+    "logo": {
+        "alt_text": "MontePy - Documentation Home. The image is the MontePy logo: a red over white ball with a python inside of it.",
+    },
     "icon_links": [
         {
             "name": "GitHub",

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -44,6 +44,7 @@ extensions = [
     "autodocsumm",
     "jupyterlite_sphinx",
     "schema_org",
+    "sphinx_sitemap",
 ]
 
 # -- Schema.org structured data ----------------------------------------------
@@ -110,7 +111,8 @@ favicons = [
 ]
 html_logo = "monty.svg"
 
-html_baseurl = "https://www.montepy.org/en/stable/"
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "https://www.montepy.org/en/stable/")
+sitemap_url_scheme = "{link}"
 html_extra_path = ["robots.txt", "foo.imcnp"]
 
 # jupyter lite

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -181,7 +181,6 @@ nitpick_ignore = [
     ("py:class", "sly.yacc.ParserMeta"),
     ("py:class", "sly.yacc.YaccProduction"),
     ("py:class", "InitInput"),
-    
     # Subpackages referenced with :mod: in docs; autodoc indexes individual classes
     # but not the package-level modules themselves
     # typing.Union is not in the Python intersphinx inventory as a py:data target
@@ -200,3 +199,41 @@ nitpick_ignore_regex = [
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+
+def _extract_docstring_summary(obj):
+    """Extract first sentence of docstring for SEO meta description."""
+    if not obj.__doc__:
+        return None
+    doc = obj.__doc__.strip()
+    lines = doc.split("\n")
+    first_line = lines[0].strip()
+    if not first_line:
+        first_line = next((l.strip() for l in lines if l.strip()), None)
+    if first_line and len(first_line) > 5:
+        return first_line[:150]
+    return None
+
+
+def _add_meta_descriptions(app, docname, source):
+    """Inject meta directives for API docs from Python docstrings."""
+    if not docname.startswith("api/generated/"):
+        return
+
+    obj_name = docname.replace("api/generated/", "")
+    try:
+        parts = obj_name.split(".")
+        obj = montepy
+        for part in parts:
+            obj = getattr(obj, part)
+
+        summary = _extract_docstring_summary(obj)
+        if summary:
+            meta_directive = f".. meta::\n   :description lang=en: {summary}\n\n"
+            source[0] = meta_directive + source[0]
+    except (AttributeError, ImportError):
+        pass
+
+
+def setup(app):
+    app.connect("source-read", _add_meta_descriptions)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -199,3 +199,41 @@ nitpick_ignore_regex = [
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+
+def _extract_docstring_summary(obj):
+    """Extract first sentence of docstring for SEO meta description."""
+    if not obj.__doc__:
+        return None
+    doc = obj.__doc__.strip()
+    lines = doc.split("\n")
+    first_line = lines[0].strip()
+    if not first_line:
+        first_line = next((l.strip() for l in lines if l.strip()), None)
+    if first_line and len(first_line) > 5:
+        return first_line[:150]
+    return None
+
+
+def _add_meta_descriptions(app, docname, source):
+    """Inject meta directives for API docs from Python docstrings."""
+    if not docname.startswith("api/generated/"):
+        return
+
+    obj_name = docname.replace("api/generated/", "")
+    try:
+        parts = obj_name.split(".")
+        obj = montepy
+        for part in parts:
+            obj = getattr(obj, part)
+
+        summary = _extract_docstring_summary(obj)
+        if summary:
+            meta_directive = f".. meta::\n   :description lang=en: {summary}\n\n"
+            source[0] = meta_directive + source[0]
+    except (AttributeError, ImportError):
+        pass
+
+
+def setup(app):
+    app.connect("source-read", _add_meta_descriptions)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,3 +1,61 @@
+"""Sphinx extension to inject schema.org JSON-LD structured data.
+
+Add to conf.py:
+    extensions = [..., "schema_org"]
+
+    schema_org_configs = {
+        "index": {
+            "@type": "SoftwareApplication",
+            "name": "MontePy",
+            ...
+        }
+    }
+"""
+
+import json
+from typing import Any, Dict
+
+from docutils import nodes
+from sphinx.application import Sphinx
+
+
+def add_schema_org_data(app: Sphinx, pagename: str, templatename: str, context: Dict, doctree: Any) -> None:
+    """Add schema.org JSON-LD to page if configured."""
+    configs = app.config.schema_org_configs
+    if not configs or pagename not in configs:
+        return
+
+    schema_data = configs[pagename]
+    schema_json = json.dumps(schema_data, indent=2)
+    context['schema_org_data'] = schema_json
+
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    """Register the extension."""
+    app.add_config_value("schema_org_configs", {}, "html")
+    app.connect("html-page-context", add_schema_org_data)
+
+    return {
+        "version": "0.1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
+(base)
+(mgale@INL436227)-(~/dev/montepy) (seo_opt)
+ ^_^->cat doc/source/_templates/page.html
+{% extends "!page.html" %}
+
+{% block body %}
+  {{ super() }}
+  {% if pagename == 'index' and schema_org_data %}
+  <script type="application/ld+json">
+  {{ schema_org_data | safe }}
+  </script>
+  {% endif %}
+{% endblock %}
+(base)
+(mgale@INL436227)-(~/dev/montepy) (seo_opt)
+ ^_^->cat doc/source/conf.py
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -18,13 +18,63 @@ sys.path.insert(0, os.path.abspath("../.."))
 sys.path.insert(0, os.path.abspath("_extension"))
 import montepy
 
+
+def _get_project_metadata():
+    """Extract project metadata from package distribution."""
+    try:
+        dist = importlib.metadata.distribution("montepy")
+    except importlib.metadata.PackageNotFoundError:
+        return {}
+
+    metadata = {
+        "name": dist.metadata.get("Name", "MontePy"),
+        "version": dist.metadata.get("Version", "unknown"),
+        "description": dist.metadata.get("Summary", ""),
+        "license": dist.metadata.get("License", "MIT"),
+        "homepage": None,
+        "authors": [],
+        "keywords": [],
+    }
+
+    # Extract keywords
+    if "Keywords" in dist.metadata:
+        keywords_str = dist.metadata.get("Keywords", "")
+        if keywords_str:
+            metadata["keywords"] = [kw.strip() for kw in keywords_str.split(",")]
+
+    # Extract homepage from project URLs
+    if hasattr(dist, "metadata") and "Project-URL" in dist.metadata:
+        urls = dist.metadata.get_all("Project-URL") or []
+        for url_entry in urls:
+            if url_entry.startswith("Homepage"):
+                metadata["homepage"] = (
+                    url_entry.split(", ", 1)[1] if ", " in url_entry else None
+                )
+                break
+
+    # Extract authors from Author-Email field
+    if "Author-Email" in dist.metadata:
+        author_email = dist.metadata.get("Author-Email")
+        if author_email:
+            authors = []
+            for entry in author_email.split(", "):
+                entry = entry.strip()
+                if entry:
+                    authors.append(entry)
+            metadata["authors"] = authors
+
+    return metadata
+
+
+_metadata = _get_project_metadata()
+
 # -- Project information -----------------------------------------------------
 
 project = "MontePy"
 copyright = "2021 – 2026, Battelle Energy Alliance LLC."
-author = "Micah D. Gale (@micahgale), Travis J. Labossiere-Hickman (@tjlaboss)"
+author = ", ".join(_metadata.get("authors", []))
 
-version = importlib.metadata.version("montepy")
+version = _metadata.get("version", "unknown")
 release = version  # Will be true at website deployment.
 # -- General configuration ---------------------------------------------------
 
@@ -55,20 +105,21 @@ schema_org_configs = {
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "MontePy",
-        "description": (
-            "The most user-friendly Python library for reading, editing, "
-            "and writing MCNP input files."
-        ),
-        "url": "https://www.montepy.org/",
+        "description": _metadata.get("description", ""),
+        "url": _metadata.get("homepage", "https://www.montepy.org/"),
         "applicationCategory": "Scientific/Engineering",
         "operatingSystem": "Linux, macOS, Windows",
         "license": "https://github.com/idaholab/MontePy/blob/main/LICENSE",
-        "author": {
-            "@type": "Organization",
-            "name": "Battelle Energy Alliance LLC",
-        },
+        "author": [
+            {
+                "@type": "Person",
+                "name": author.split("<")[0].strip(),
+            }
+            for author in _metadata.get("authors", [])
+        ],
         "softwareVersion": version,
         "downloadUrl": "https://pypi.org/project/montepy/",
+        "keywords": ", ".join(_metadata.get("keywords", [])),
     },
     "faq": {
         "@context": "https://schema.org",
@@ -111,7 +162,9 @@ favicons = [
 ]
 html_logo = "monty.svg"
 
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "https://www.montepy.org/en/stable/")
+html_baseurl = os.environ.get(
+    "READTHEDOCS_CANONICAL_URL", "https://www.montepy.org/en/stable/"
+)
 sitemap_url_scheme = "{link}"
 html_extra_path = ["robots.txt", "foo.imcnp"]
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,61 +1,3 @@
-"""Sphinx extension to inject schema.org JSON-LD structured data.
-
-Add to conf.py:
-    extensions = [..., "schema_org"]
-
-    schema_org_configs = {
-        "index": {
-            "@type": "SoftwareApplication",
-            "name": "MontePy",
-            ...
-        }
-    }
-"""
-
-import json
-from typing import Any, Dict
-
-from docutils import nodes
-from sphinx.application import Sphinx
-
-
-def add_schema_org_data(app: Sphinx, pagename: str, templatename: str, context: Dict, doctree: Any) -> None:
-    """Add schema.org JSON-LD to page if configured."""
-    configs = app.config.schema_org_configs
-    if not configs or pagename not in configs:
-        return
-
-    schema_data = configs[pagename]
-    schema_json = json.dumps(schema_data, indent=2)
-    context['schema_org_data'] = schema_json
-
-
-def setup(app: Sphinx) -> Dict[str, Any]:
-    """Register the extension."""
-    app.add_config_value("schema_org_configs", {}, "html")
-    app.connect("html-page-context", add_schema_org_data)
-
-    return {
-        "version": "0.1.0",
-        "parallel_read_safe": True,
-        "parallel_write_safe": True,
-    }
-(base)
-(mgale@INL436227)-(~/dev/montepy) (seo_opt)
- ^_^->cat doc/source/_templates/page.html
-{% extends "!page.html" %}
-
-{% block body %}
-  {{ super() }}
-  {% if pagename == 'index' and schema_org_data %}
-  <script type="application/ld+json">
-  {{ schema_org_data | safe }}
-  </script>
-  {% endif %}
-{% endblock %}
-(base)
-(mgale@INL436227)-(~/dev/montepy) (seo_opt)
- ^_^->cat doc/source/conf.py
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full
@@ -73,6 +15,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../.."))
+sys.path.insert(0, os.path.abspath("_extension"))
 import montepy
 
 # -- Project information -----------------------------------------------------
@@ -100,7 +43,62 @@ extensions = [
     "sphinx_copybutton",
     "autodocsumm",
     "jupyterlite_sphinx",
+    "schema_org",
 ]
+
+# -- Schema.org structured data ----------------------------------------------
+# Drives JSON-LD injection via the schema_org extension.
+# Only pages listed here get a <script type="application/ld+json"> block.
+schema_org_configs = {
+    "index": {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "MontePy",
+        "description": (
+            "The most user-friendly Python library for reading, editing, "
+            "and writing MCNP input files."
+        ),
+        "url": "https://www.montepy.org/",
+        "applicationCategory": "Scientific/Engineering",
+        "operatingSystem": "Linux, macOS, Windows",
+        "license": "https://github.com/idaholab/MontePy/blob/main/LICENSE",
+        "author": {
+            "@type": "Organization",
+            "name": "Battelle Energy Alliance LLC",
+        },
+        "softwareVersion": version,
+        "downloadUrl": "https://pypi.org/project/montepy/",
+    },
+    "faq": {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": "How do I fix a UnicodeDecodeError when opening an MCNP file in MontePy?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": (
+                        "Try passing a different encoding to read_input(), such as "
+                        "'utf8' or 'cp1252'. Alternatively, use the change_to_ascii "
+                        "utility to remove all non-ASCII characters from the file."
+                    ),
+                },
+            },
+            {
+                "@type": "Question",
+                "name": "Will MontePy ever support MCNP output files?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": (
+                        "No. MontePy is scoped to reading and writing MCNP input "
+                        "files only. Output file parsing is outside the project scope."
+                    ),
+                },
+            },
+        ],
+    },
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -1,3 +1,7 @@
+.. meta::
+   :description lang=en:
+        Common errors and debugging tips for MontePy, including how to fix UnicodeDecodeError when reading MCNP input files.
+
 Frequently Asked Questions
 ==========================
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -21,6 +21,12 @@ MontePy can be installed with pip:
 
    pip install montepy
 
+or with conda:
+
+.. code-block:: shell
+
+   conda install conda-forge::montepy
+
 
 Use cases
 ---------

--- a/doc/source/publications.rst
+++ b/doc/source/publications.rst
@@ -1,4 +1,8 @@
-Publications 
+.. meta::
+   :description lang=en:
+        How to cite MontePy in your research: peer-reviewed journal article, conference papers, and permanent software DOIs for Zenodo and OSTI.
+
+Publications
 ============
 
 Permanent Link to Software

--- a/doc/source/robots.txt
+++ b/doc/source/robots.txt
@@ -1,6 +1,9 @@
 User-agent: *
 
-Disallow: /en/latest/ # Hidden version
+# Block non-stable versions to avoid duplicate content
+Disallow: /en/latest/
+Disallow: /en/v
 Disallow: /_/downloads
 
 Sitemap: https://www.montepy.org/sitemap.xml
+Sitemap: https://www.montepy.org/en/stable/sitemap.xml

--- a/doc/source/scope.rst
+++ b/doc/source/scope.rst
@@ -1,3 +1,7 @@
+.. meta::
+   :description lang=en:
+        Defines the scope of MontePy: what features the project supports, what falls outside it, and how to decide where new functionality belongs.
+
 .. _scope:
 
 MontePy Scope

--- a/doc/source/starting.rst
+++ b/doc/source/starting.rst
@@ -1,8 +1,6 @@
 .. meta::
    :description lang=en:
-        Montepy is the most user-friendly Python library for reading, editing, and writing MCNP input files.
-        It can be easily installed using pip.
-        This tutorial covers the basics of getting started with MontePy.
+        MontePy is the most user-friendly Python library for reading, editing, and writing MCNP input files. Install with pip and get started quickly.
 
 Getting Started with MontePy
 ============================

--- a/doc/source/tricks.rst
+++ b/doc/source/tricks.rst
@@ -1,3 +1,7 @@
+.. meta::
+   :description lang=en:
+        Tips and tricks for working efficiently with MontePy, the Python library for reading, editing, and writing MCNP input files.
+
 Tips and Tricks
 ===============
 

--- a/doc/source/users.rst
+++ b/doc/source/users.rst
@@ -1,3 +1,7 @@
+.. meta::
+   :description lang=en:
+        User guide for MontePy: installation, tutorials, tips, utilities, and reference documentation for the Python MCNP input file library.
+
 User Guide
 ==========
 

--- a/doc/source/utilities.rst
+++ b/doc/source/utilities.rst
@@ -1,3 +1,7 @@
+.. meta::
+   :description lang=en:
+        MontePy command-line utilities for checking MCNP input files for errors, plus other tools for working with MCNP problems from the terminal.
+
 Utility Scripts
 ===============
 

--- a/montepy/__init__.py
+++ b/montepy/__init__.py
@@ -43,6 +43,7 @@ from montepy.mcnp_problem import MCNP_Problem
 
 # collections
 from montepy.cells import Cells
+from montepy.comments import CommentCollection
 from montepy.materials import Materials
 from montepy.universes import Universes
 from montepy.surface_collection import Surfaces

--- a/montepy/cell.py
+++ b/montepy/cell.py
@@ -567,6 +567,22 @@ class Cell(Numbered_MCNP_Object):
         """
         return self._is_atom_dens
 
+    @property
+    def is_mass_dens(self):
+        """Whether or not the density is in mass density [g/cc].
+
+        This is the logical complement of :func:`is_atom_dens`. True means
+        it is in mass density, False means atom density [a/b-cm]. If no
+        density is set this will return ``None``.
+
+        Returns
+        -------
+        bool, None
+        """
+        if self._is_atom_dens is None:
+            return None
+        return not self._is_atom_dens
+
     @make_prop_val_node("_old_mat_number")
     def old_mat_number(self):
         """The material number provided in the original input file

--- a/montepy/cell.py
+++ b/montepy/cell.py
@@ -568,20 +568,21 @@ class Cell(Numbered_MCNP_Object):
         return self._is_atom_dens
 
     @property
-    def is_mass_dens(self):
+    def is_mass_dens(self) -> bool | None:
         """Whether or not the density is in mass density [g/cc].
 
         This is the logical complement of :func:`is_atom_dens`. True means
         it is in mass density, False means atom density [a/b-cm]. If no
         density is set this will return ``None``.
 
+        .. versionadded:: 1.5.0
+
         Returns
         -------
         bool, None
         """
-        if self._is_atom_dens is None:
-            return None
-        return not self._is_atom_dens
+        if self._is_atom_dens is not None:
+            return not self._is_atom_dens
 
     @make_prop_val_node("_old_mat_number")
     def old_mat_number(self):

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -1,17 +1,19 @@
 # Copyright 2026, Battelle Energy Alliance, LLC All Rights Reserved.
+from collections.abc import Sequence
 import re
 
 from montepy.input_parser.syntax_node import CommentNode
 
 
-class CommentCollection(list):
-    """A list of the comments in an object that supports searching by text.
+class CommentCollection(Sequence):
+    """A read-only collection of the comments in an object that supports searching by text.
 
-    This is a :class:`list` of :class:`~montepy.input_parser.syntax_node.CommentNode`
-    instances, and behaves like a normal list in every way. In addition,
-    checking a string with the ``in`` operator searches the *text* of all
-    comments, so an object can be found by its comments; anything other than a
-    string keeps the normal list membership behavior.
+    This is a :class:`~collections.abc.Sequence` of
+    :class:`~montepy.input_parser.syntax_node.CommentNode` instances, so it
+    supports indexing, slicing, iteration, and ``len()``. Checking a string
+    with the ``in`` operator searches the *text* of all comments, so an
+    object can be found by its comments; anything other than a string keeps
+    normal membership behavior.
 
     Examples
     --------
@@ -24,13 +26,34 @@ class CommentCollection(list):
         True
         >>> problem.materials[1].comments.search(r"(?i)LIGHT", regex=True)[0].contents
         'light water'
+
+    Parameters
+    ----------
+    comments : iterable of CommentNode
+        the comments in this collection.
     """
 
+    __slots__ = ("_comments",)
+
+    def __init__(self, comments=()):
+        self._comments = list(comments)
+
+    def __getitem__(self, i):
+        if isinstance(i, slice):
+            return CommentCollection(self._comments[i])
+        return self._comments[i]
+
+    def __len__(self):
+        return len(self._comments)
+
     def __contains__(self, item):
-        """For a string: search the text of all comments; otherwise: normal list membership."""
+        """For a string: search the text of all comments; otherwise: normal membership."""
         if isinstance(item, str):
-            return bool(self.search(item))
-        return super().__contains__(item)
+            return any(item in comment for comment in self._comments)
+        return item in self._comments
+
+    def __repr__(self):
+        return f"CommentCollection({self._comments!r})"
 
     def search(self, pattern, regex=False):
         """Searches the text of the comments in this collection.
@@ -71,4 +94,4 @@ class CommentCollection(list):
             raise TypeError(
                 f"pattern must be a str, or a pattern compiled from a str. {pattern} given."
             )
-        return CommentCollection(c for c in self if matcher(c.contents))
+        return CommentCollection(c for c in self._comments if matcher(c.contents))

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -8,70 +8,26 @@ class CommentCollection(list):
     """A list of the comments in an object that supports searching by text.
 
     This is a :class:`list` of :class:`~montepy.input_parser.syntax_node.CommentNode`
-    instances, and behaves like a normal list in every way. In addition, it
-    supports searching the text of its comments.
+    instances, and behaves like a normal list in every way. In addition,
+    checking a string with the ``in`` operator searches the *text* of all
+    comments, so an object can be found by its comments; anything other than a
+    string keeps the normal list membership behavior.
 
     Examples
     --------
 
-    Searching comments with ``in``
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    .. doctest::
 
-    Checking a string with the ``in`` operator searches the *text* of all
-    comments in the collection, so an object can be found by its comments:
-
-    .. testcode::
-
-        import montepy
-
-        problem = montepy.read_input("foo.imcnp")
-
-        for material in problem.materials:
-            if "light water" in material.comments:
-                print("found material:", material.number)
-
-    .. testoutput::
-
-        found material: 1
-
-    Checking anything other than a string keeps the normal :class:`list`
-    behavior, so membership tests for
-    :class:`~montepy.input_parser.syntax_node.CommentNode` instances are
-    unchanged.
-
-    Searching comments by pattern
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-    :func:`search` finds the comments matching a substring, or a regular
-    expression with ``regex=True``:
-
-    .. testcode::
-
-        material = problem.materials[1]
-        for comment in material.comments.search(r"(?i)LIGHT", regex=True):
-            print(comment.contents)
-
-    .. testoutput::
-
-        light water
-
+        >>> import montepy
+        >>> problem = montepy.read_input("foo.imcnp")
+        >>> "light water" in problem.materials[1].comments
+        True
+        >>> problem.materials[1].comments.search(r"(?i)LIGHT", regex=True)[0].contents
+        'light water'
     """
 
     def __contains__(self, item):
-        """Checks if a string is in the text of any comment, or if a comment is in this list.
-
-        Parameters
-        ----------
-        item : str or object
-            a string to search the text of all comments for, or any other
-            object to check list membership for.
-
-        Returns
-        -------
-        bool
-            for a string: True iff the string is contained in any comment's
-            ``contents``; otherwise: normal list membership.
-        """
+        """For a string: search the text of all comments; otherwise: normal list membership."""
         if isinstance(item, str):
             return bool(self.search(item))
         return super().__contains__(item)
@@ -102,25 +58,17 @@ class CommentCollection(list):
         TypeError
             if ``pattern`` is not a str, or a pattern compiled from a str.
         """
-        if isinstance(pattern, re.Pattern):
-            # bytes patterns cannot search the comments' str contents
-            if not isinstance(pattern.pattern, str):
-                raise TypeError(
-                    f"pattern must be a str, or a pattern compiled from a str. {pattern} given."
-                )
+        if isinstance(pattern, re.Pattern) and isinstance(pattern.pattern, str):
             matcher = pattern.search
+        elif isinstance(pattern, str) and regex:
+            matcher = re.compile(pattern).search
+        elif isinstance(pattern, str):
+
+            def matcher(contents):
+                return pattern in contents
+
         else:
-            if not isinstance(pattern, str):
-                raise TypeError(
-                    f"pattern must be a str, or a pattern compiled from a str. {pattern} given."
-                )
-            if regex:
-                matcher = re.compile(pattern).search
-            else:
-
-                def matcher(contents):
-                    return pattern in contents
-
-        return CommentCollection(
-            comment for comment in self if matcher(comment.contents)
-        )
+            raise TypeError(
+                f"pattern must be a str, or a pattern compiled from a str. {pattern} given."
+            )
+        return CommentCollection(c for c in self if matcher(c.contents))

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -1,14 +1,14 @@
 # Copyright 2026, Battelle Energy Alliance, LLC All Rights Reserved.
-from collections.abc import Sequence
+from collections.abc import Collection
 import re
 
 
-class CommentCollection(Sequence):
+class CommentCollection(Collection):
     """A read-only collection of the comments in an object that supports searching by text.
 
-    This is a :class:`~collections.abc.Sequence` of
-    :class:`~montepy.input_parser.syntax_node.CommentNode` instances, so it
-    supports indexing, slicing, iteration, and ``len()``. Checking a string
+    This is a :class:`~collections.abc.Collection` of
+    :class:`~montepy.input_parser.syntax_node.CommentNode` instances that
+    also supports indexing, slicing, and ``len()``. Checking a string
     with the ``in`` operator searches the *text* of all comments, so an
     object can be found by its comments; anything other than a string keeps
     normal membership behavior.
@@ -28,8 +28,9 @@ class CommentCollection(Sequence):
 
     Parameters
     ----------
-    comments : iterable of CommentNode
-        the comments in this collection.
+    comments : collections.abc.Iterable
+        the comments in this collection, as an iterable of
+        :class:`~montepy.input_parser.syntax_node.CommentNode`.
     """
 
     __slots__ = ("_comments",)
@@ -41,6 +42,9 @@ class CommentCollection(Sequence):
         if isinstance(i, slice):
             return CommentCollection(self._comments[i])
         return self._comments[i]
+
+    def __iter__(self):
+        return iter(self._comments)
 
     def __len__(self):
         return len(self._comments)

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -13,6 +13,8 @@ class CommentCollection(Collection):
     object can be found by its comments; anything other than a string keeps
     normal membership behavior.
 
+    .. versionadded:: 1.5.0
+
     Examples
     --------
 
@@ -64,6 +66,8 @@ class CommentCollection(Collection):
         The search is run against each comment's
         :attr:`~montepy.input_parser.syntax_node.CommentNode.contents`, that
         is the comment's text without its delimiters (``c``/``$``).
+
+        .. versionadded:: 1.5.0
 
         Parameters
         ----------

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -2,8 +2,6 @@
 from collections.abc import Sequence
 import re
 
-from montepy.input_parser.syntax_node import CommentNode
-
 
 class CommentCollection(Sequence):
     """A read-only collection of the comments in an object that supports searching by text.
@@ -24,7 +22,8 @@ class CommentCollection(Sequence):
         >>> problem = montepy.read_input("foo.imcnp")
         >>> "light water" in problem.materials[1].comments
         True
-        >>> problem.materials[1].comments.search(r"(?i)LIGHT", regex=True)[0].contents
+        >>> import re
+        >>> problem.materials[1].comments.search(re.compile(r"(?i)LIGHT"))[0].contents
         'light water'
 
     Parameters
@@ -36,7 +35,7 @@ class CommentCollection(Sequence):
     __slots__ = ("_comments",)
 
     def __init__(self, comments=()):
-        self._comments = list(comments)
+        self._comments = tuple(comments)
 
     def __getitem__(self, i):
         if isinstance(i, slice):
@@ -55,7 +54,7 @@ class CommentCollection(Sequence):
     def __repr__(self):
         return f"CommentCollection({self._comments!r})"
 
-    def search(self, pattern, regex=False):
+    def search(self, pattern):
         """Searches the text of the comments in this collection.
 
         The search is run against each comment's
@@ -65,11 +64,8 @@ class CommentCollection(Sequence):
         Parameters
         ----------
         pattern : str or re.Pattern
-            the substring to search for, or a regular expression when
-            ``regex`` is True. Compiled patterns are always treated as
-            regular expressions.
-        regex : bool
-            whether to interpret ``pattern`` as a regular expression.
+            a substring to search for, or a compiled regular expression
+            (e.g. ``re.compile(pattern, re.IGNORECASE)``).
 
         Returns
         -------
@@ -81,15 +77,10 @@ class CommentCollection(Sequence):
         TypeError
             if ``pattern`` is not a str, or a pattern compiled from a str.
         """
-        if isinstance(pattern, re.Pattern) and isinstance(pattern.pattern, str):
+        if isinstance(pattern, str):
+            matcher = re.compile(re.escape(pattern)).search
+        elif isinstance(pattern, re.Pattern) and isinstance(pattern.pattern, str):
             matcher = pattern.search
-        elif isinstance(pattern, str) and regex:
-            matcher = re.compile(pattern).search
-        elif isinstance(pattern, str):
-
-            def matcher(contents):
-                return pattern in contents
-
         else:
             raise TypeError(
                 f"pattern must be a str, or a pattern compiled from a str. {pattern} given."

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -1,0 +1,113 @@
+# Copyright 2026, Battelle Energy Alliance, LLC All Rights Reserved.
+import re
+
+from montepy.input_parser.syntax_node import CommentNode
+
+
+class CommentCollection(list):
+    """A list of the comments in an object that supports searching by text.
+
+    This is a :class:`list` of :class:`~montepy.input_parser.syntax_node.CommentNode`
+    instances, and behaves like a normal list in every way. In addition, it
+    supports searching the text of its comments.
+
+    Examples
+    --------
+
+    Searching comments with ``in``
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    Checking a string with the ``in`` operator searches the *text* of all
+    comments in the collection, so an object can be found by its comments:
+
+    .. testcode::
+
+        import montepy
+
+        problem = montepy.read_input("foo.imcnp")
+
+        for material in problem.materials:
+            if "light water" in material.comments:
+                print("found material:", material.number)
+
+    .. testoutput::
+
+        found material: 1
+
+    Checking anything other than a string keeps the normal :class:`list`
+    behavior, so membership tests for
+    :class:`~montepy.input_parser.syntax_node.CommentNode` instances are
+    unchanged.
+
+    Searching comments by pattern
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    :func:`search` finds the comments matching a substring, or a regular
+    expression with ``regex=True``:
+
+    .. testcode::
+
+        material = problem.materials[1]
+        for comment in material.comments.search(r"(?i)LIGHT", regex=True):
+            print(comment.contents)
+
+    .. testoutput::
+
+        light water
+
+    """
+
+    def __contains__(self, item):
+        """Checks if a string is in the text of any comment, or if a comment is in this list.
+
+        Parameters
+        ----------
+        item : str or object
+            a string to search the text of all comments for, or any other
+            object to check list membership for.
+
+        Returns
+        -------
+        bool
+            for a string: True iff the string is contained in any comment's
+            ``contents``; otherwise: normal list membership.
+        """
+        if isinstance(item, str):
+            return bool(self.search(item))
+        return super().__contains__(item)
+
+    def search(self, pattern, regex=False):
+        """Searches the text of the comments in this collection.
+
+        The search is run against each comment's
+        :attr:`~montepy.input_parser.syntax_node.CommentNode.contents`, that
+        is the comment's text without its delimiters (``c``/``$``).
+
+        Parameters
+        ----------
+        pattern : str or re.Pattern
+            the substring to search for, or a regular expression when
+            ``regex`` is True. Compiled patterns are always treated as
+            regular expressions.
+        regex : bool
+            whether to interpret ``pattern`` as a regular expression.
+
+        Returns
+        -------
+        CommentCollection
+            a new collection of the comments that matched.
+        """
+        if isinstance(pattern, re.Pattern):
+            matcher = pattern.search
+        elif regex:
+            matcher = re.compile(pattern).search
+        else:
+            if not isinstance(pattern, str):
+                raise TypeError(f"pattern must be a str. {pattern} given.")
+
+            def matcher(contents):
+                return pattern in contents
+
+        return CommentCollection(
+            comment for comment in self if matcher(comment.contents)
+        )

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -96,17 +96,30 @@ class CommentCollection(list):
         -------
         CommentCollection
             a new collection of the comments that matched.
+
+        Raises
+        ------
+        TypeError
+            if ``pattern`` is not a str, or a pattern compiled from a str.
         """
         if isinstance(pattern, re.Pattern):
+            # bytes patterns cannot search the comments' str contents
+            if not isinstance(pattern.pattern, str):
+                raise TypeError(
+                    f"pattern must be a str, or a pattern compiled from a str. {pattern} given."
+                )
             matcher = pattern.search
-        elif regex:
-            matcher = re.compile(pattern).search
         else:
             if not isinstance(pattern, str):
-                raise TypeError(f"pattern must be a str. {pattern} given.")
+                raise TypeError(
+                    f"pattern must be a str, or a pattern compiled from a str. {pattern} given."
+                )
+            if regex:
+                matcher = re.compile(pattern).search
+            else:
 
-            def matcher(contents):
-                return pattern in contents
+                def matcher(contents):
+                    return pattern in contents
 
         return CommentCollection(
             comment for comment in self if matcher(comment.contents)

--- a/montepy/comments.py
+++ b/montepy/comments.py
@@ -1,14 +1,17 @@
 # Copyright 2026, Battelle Energy Alliance, LLC All Rights Reserved.
-from collections.abc import Collection
+from __future__ import annotations
+from collections.abc import Iterable, Iterator, Sequence
 import re
 
+from montepy.input_parser.syntax_node import CommentNode
 
-class CommentCollection(Collection):
+
+class CommentCollection(Sequence):
     """A read-only collection of the comments in an object that supports searching by text.
 
-    This is a :class:`~collections.abc.Collection` of
-    :class:`~montepy.input_parser.syntax_node.CommentNode` instances that
-    also supports indexing, slicing, and ``len()``. Checking a string
+    This is a :class:`~collections.abc.Sequence` of
+    :class:`~montepy.input_parser.syntax_node.CommentNode` instances, so it
+    supports indexing, slicing, iteration, and ``len()``. Checking a string
     with the ``in`` operator searches the *text* of all comments, so an
     object can be found by its comments; anything other than a string keeps
     normal membership behavior.
@@ -37,30 +40,30 @@ class CommentCollection(Collection):
 
     __slots__ = ("_comments",)
 
-    def __init__(self, comments=()):
+    def __init__(self, comments: Iterable[CommentNode] = ()) -> None:
         self._comments = tuple(comments)
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: int | slice) -> CommentNode | CommentCollection:
         if isinstance(i, slice):
             return CommentCollection(self._comments[i])
         return self._comments[i]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[CommentNode]:
         return iter(self._comments)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._comments)
 
-    def __contains__(self, item):
+    def __contains__(self, item: object) -> bool:
         """For a string: search the text of all comments; otherwise: normal membership."""
         if isinstance(item, str):
             return any(item in comment for comment in self._comments)
         return item in self._comments
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"CommentCollection({self._comments!r})"
 
-    def search(self, pattern):
+    def search(self, pattern: str | re.Pattern) -> CommentCollection:
         """Searches the text of the comments in this collection.
 
         The search is run against each comment's
@@ -85,10 +88,17 @@ class CommentCollection(Collection):
         TypeError
             if ``pattern`` is not a str, or a pattern compiled from a str.
         """
-        if isinstance(pattern, str):
-            matcher = re.compile(re.escape(pattern)).search
-        elif isinstance(pattern, re.Pattern) and isinstance(pattern.pattern, str):
+        if isinstance(pattern, re.Pattern):
+            if not isinstance(pattern.pattern, str):
+                raise TypeError(
+                    f"pattern must be a str, or a pattern compiled from a str. {pattern} given."
+                )
             matcher = pattern.search
+        elif isinstance(pattern, str):
+
+            def matcher(contents):
+                return pattern in contents
+
         else:
             raise TypeError(
                 f"pattern must be a str, or a pattern compiled from a str. {pattern} given."

--- a/montepy/input_parser/data_parser.py
+++ b/montepy/input_parser/data_parser.py
@@ -101,12 +101,10 @@ class DataParser(MCNP_Parser):
     # Manually specifying because more levels break SLY. Might be hitting some hard coded limit.
     @_(
         "NUMBER_WORD",
-        "NUM_MULTIPLY",
         "NUMBER_WORD padding ",
-        "NUM_MULTIPLY padding",
     )
     def text_phrase(self, p):
-        self._flush_phrase(p, str)
+        return self._flush_phrase(p, str)
 
     @_("text_phrase", "text_sequence text_phrase")
     def text_sequence(self, p):

--- a/montepy/input_parser/parser_base.py
+++ b/montepy/input_parser/parser_base.py
@@ -283,6 +283,9 @@ class MCNP_Parser(Parser, metaclass=MetaBuilder):
             list_node.append(p[0])
             list_node.append(short_cut)
             return list_node
+        if isinstance(p[0], syntax_node.ListNode):
+            p[0].append(short_cut)
+            return p[0]
         return short_cut
 
     @_("shortcut_sequence", "shortcut_sequence padding")

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -1055,41 +1055,33 @@ class ValueNode(SyntaxNodeBase):
             raise ValueError(f"ValueNode must be a float to convert to int")
         self._type = int
 
-        def convert_token_to_int():
-            try:
-                return int(self._token)
-            except ValueError as e:
-                parts = self._token.split(".")
-                if len(parts) > 1 and int(parts[1]) == 0:
-                    return int(parts[0])
-                raise e
-
         if self._token is not None and not isinstance(
             self._token, input_parser.mcnp_input.Jump
         ):
-            try:
-                token_value = fortran_float(self._token)
-            except ValueError:
-                token_value = None
-            if self._value is not None and token_value is not None:
-                current_value = float(self._value)
+            token_value = fortran_float(self._token)
+            current_value = float(self._value)
+            if not math.isclose(
+                current_value, token_value, rel_tol=rel_tol, abs_tol=abs_tol
+            ):
                 if not math.isclose(
-                    current_value, token_value, rel_tol=rel_tol, abs_tol=abs_tol
+                    current_value,
+                    int(current_value),
+                    rel_tol=rel_tol,
+                    abs_tol=abs_tol,
                 ):
-                    if not math.isclose(
-                        current_value,
-                        int(current_value),
-                        rel_tol=rel_tol,
-                        abs_tol=abs_tol,
-                    ):
-                        raise ValueError(
-                            "ValueNode must hold an integer value to convert to int"
-                        )
-                    self._value = int(current_value)
-                else:
-                    self._value = convert_token_to_int()
+                    raise ValueError(
+                        "ValueNode must hold an integer value to convert to int"
+                    )
+                self._value = int(current_value)
             else:
-                self._value = convert_token_to_int()
+                try:
+                    self._value = int(self._token)
+                except ValueError as e:
+                    parts = self._token.split(".")
+                    if len(parts) > 1 and int(parts[1]) == 0:
+                        self._value = int(parts[0])
+                    else:
+                        raise e
         self._formatter = self._FORMATTERS[int].copy()
 
     def convert_to_enum(
@@ -2239,6 +2231,8 @@ class ShortcutNode(ListNode):
                 last_val = p[0].nodes["left"]
         else:
             last_val = p[0].nodes[-1]
+            if isinstance(last_val, ShortcutNode):
+                last_val = last_val.nodes[-1]
         if last_val.value is None:
             raise ValueError(f"Multiply cannot follow a jump. Given: {list(p)}")
         self._nodes.append(copy.deepcopy(last_val))

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -825,6 +825,25 @@ class CommentNode(SyntaxNodeBase):
     ----------
     input : sly.lex.Token
         the token from the lexer
+
+    Examples
+    --------
+
+    Searching within a comment
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    You can check whether a substring appears in a comment's text with the
+    ``in`` operator. This works for both ``c`` style and ``$`` (dollar)
+    comments, and searches the comment's ``contents`` (the text without the
+    comment delimiter).
+
+    .. testcode::
+
+        from montepy.input_parser.syntax_node import CommentNode
+
+        comment = CommentNode("c the important fuel region")
+        assert "important" in comment
+        assert "coolant" not in comment
     """
 
     _MATCHER = re.compile(

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -829,7 +829,7 @@ class CommentNode(SyntaxNodeBase):
     Examples
     --------
 
-    The ``in`` operator searches the comment's text — its ``contents``
+    The ``in`` operator searches the comment's text, its ``contents``,
     without the ``c``/``$`` delimiter:
 
     .. doctest::

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -1305,7 +1305,11 @@ class ValueNode(SyntaxNodeBase):
             precision += 1
         self._formatter["precision"] = precision
         # add in significant digits before the decimal  to be consistent with `g` format.
-        if not self._formatter["is_scientific"] and not self._is_reversed:
+        if (
+            not self._formatter["is_scientific"]
+            and not self._is_reversed
+            and self.value != 0
+        ):
             exp = math.floor(math.log10(abs(self.value)))
             self._formatter["precision"] += exp + 1
 

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -1059,7 +1059,7 @@ class ValueNode(SyntaxNodeBase):
             self._token, input_parser.mcnp_input.Jump
         ):
             token_value = fortran_float(self._token)
-            current_value = float(self._value)
+            current_value = token_value if self._value is None else float(self._value)
             if not math.isclose(
                 current_value, token_value, rel_tol=rel_tol, abs_tol=abs_tol
             ):

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -967,7 +967,7 @@ class ValueNode(SyntaxNodeBase):
             "exponent_zero_pad": 0,
             "as_int": False,
             "int_tolerance": 1e-6,
-            "is_scientific": True,
+            "is_scientific": False,
             "rel_eps": 1e-6,
             "abs_eps": 1e-9,
         },

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -959,7 +959,7 @@ class ValueNode(SyntaxNodeBase):
     _FORMATTERS = {
         float: {
             "value_length": 0,
-            "precision": 5,
+            "precision": 15,
             "zero_padding": 0,
             "sign": "-",
             "divider": "e",

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -1304,6 +1304,10 @@ class ValueNode(SyntaxNodeBase):
         ):
             precision += 1
         self._formatter["precision"] = precision
+        # add in significant digits before the decimal  to be consistent with `g` format.
+        if not self._formatter["is_scientific"] and not self._is_reversed:
+            exp = math.floor(math.log10(abs(self.value)))
+            self._formatter["precision"] += exp + 1
 
     def format(self):
         if not self._value_changed:

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -959,6 +959,8 @@ class CommentNode(SyntaxNodeBase):
         This allows searching a comment by its text, e.g.
         ``"important" in comment``.
 
+        .. versionadded:: 1.5.0
+
         Parameters
         ----------
         value : str

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -829,21 +829,14 @@ class CommentNode(SyntaxNodeBase):
     Examples
     --------
 
-    Searching within a comment
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    The ``in`` operator searches the comment's text — its ``contents``
+    without the ``c``/``$`` delimiter:
 
-    You can check whether a substring appears in a comment's text with the
-    ``in`` operator. This works for both ``c`` style and ``$`` (dollar)
-    comments, and searches the comment's ``contents`` (the text without the
-    comment delimiter).
+    .. doctest::
 
-    .. testcode::
-
-        from montepy.input_parser.syntax_node import CommentNode
-
-        comment = CommentNode("c the important fuel region")
-        assert "important" in comment
-        assert "coolant" not in comment
+        >>> from montepy.input_parser.syntax_node import CommentNode
+        >>> "important" in CommentNode("c the important fuel region")
+        True
     """
 
     _MATCHER = re.compile(

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -1054,17 +1054,42 @@ class ValueNode(SyntaxNodeBase):
         if self._type not in {float, int}:
             raise ValueError(f"ValueNode must be a float to convert to int")
         self._type = int
+
+        def convert_token_to_int():
+            try:
+                return int(self._token)
+            except ValueError as e:
+                parts = self._token.split(".")
+                if len(parts) > 1 and int(parts[1]) == 0:
+                    return int(parts[0])
+                raise e
+
         if self._token is not None and not isinstance(
             self._token, input_parser.mcnp_input.Jump
         ):
             try:
-                self._value = int(self._token)
-            except ValueError as e:
-                parts = self._token.split(".")
-                if len(parts) > 1 and int(parts[1]) == 0:
-                    self._value = int(parts[0])
+                token_value = fortran_float(self._token)
+            except ValueError:
+                token_value = None
+            if self._value is not None and token_value is not None:
+                current_value = float(self._value)
+                if not math.isclose(
+                    current_value, token_value, rel_tol=rel_tol, abs_tol=abs_tol
+                ):
+                    if not math.isclose(
+                        current_value,
+                        int(current_value),
+                        rel_tol=rel_tol,
+                        abs_tol=abs_tol,
+                    ):
+                        raise ValueError(
+                            "ValueNode must hold an integer value to convert to int"
+                        )
+                    self._value = int(current_value)
                 else:
-                    raise e
+                    self._value = convert_token_to_int()
+            else:
+                self._value = convert_token_to_int()
         self._formatter = self._FORMATTERS[int].copy()
 
     def convert_to_enum(

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -821,6 +821,10 @@ class PaddingNode(SyntaxNodeBase):
 class CommentNode(SyntaxNodeBase):
     """Object to represent a comment in an MCNP problem.
 
+    .. versionchanged:: 1.5.0
+
+        A comment's text can now be searched with the ``in`` operator.
+
     Parameters
     ----------
     input : sly.lex.Token

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -937,6 +937,24 @@ class CommentNode(SyntaxNodeBase):
     def __eq__(self, other):
         return str(self) == str(other)
 
+    def __contains__(self, value):
+        """Checks if a string is found in the contents of this comment.
+
+        This allows searching a comment by its text, e.g.
+        ``"important" in comment``.
+
+        Parameters
+        ----------
+        value : str
+            the string to search for.
+
+        Returns
+        -------
+        bool
+            True iff ``value`` is a substring of this comment's ``contents``.
+        """
+        return value in self.contents
+
 
 class ValueNode(SyntaxNodeBase):
     """A syntax node to represent the leaf node.

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import ABC, ABCMeta, abstractmethod
 import copy
 import functools
-import itertools as it
 import textwrap
 from typing import TypeAlias, Union, Type
 import warnings
@@ -335,23 +334,17 @@ The new input was:\n\n"""
     def leading_comments(self, comments):
         if not isinstance(comments, (list, tuple, CommentNode, CommentCollection)):
             raise TypeError(
-                f"Comments must be a CommentNode, or a list of Comments. {comments} given."
+                f"Comments must be a CommentNode, CommentCollection, or list/tuple of CommentNodes. {comments} given."
             )
         if isinstance(comments, CommentNode):
             comments = [comments]
-        if isinstance(comments, (list, tuple, CommentCollection)):
-            for comment in comments:
-                if not isinstance(comment, CommentNode):
-                    raise TypeError(
-                        f"Comments must be a CommentNode, or a list of Comments. {comment} given."
-                    )
 
         for i, comment in enumerate(comments):
             if not isinstance(comment, CommentNode):
                 raise TypeError(
                     f"Comment must be a CommentNode. {comment} given at index {i}."
                 )
-        new_nodes = list(*zip(comments, it.cycle(["\n"])))
+        new_nodes = [node for comment in comments for node in (comment, "\n")]
         if self._tree["start_pad"] is None:
             self._tree["start_pad"] = PaddingNode(" ")
         self._tree["start_pad"]._nodes = new_nodes

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -306,7 +306,7 @@ The new input was:\n\n"""
         Returns
         -------
         CommentCollection
-            a list of the comments associated with this comment, which also
+            a list of the comments associated with this object, which also
             supports searching the comments' text (e.g. ``"foo" in
             obj.comments``).
         """

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -144,11 +144,10 @@ class MCNP_Object(ABC, metaclass=_ExceptionContextAdder):
 
     def __setattr__(self, key, value):
         # handle properties first
-        if hasattr(type(self), key):
-            descriptor = getattr(type(self), key)
-            if isinstance(descriptor, property):
-                descriptor.__set__(self, value)
-                return
+        descriptor = getattr(type(self), key, None)
+        if isinstance(descriptor, property):
+            descriptor.__set__(self, value)
+            return
         # handle _private second
         if key.startswith("_"):
             super().__setattr__(key, value)

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -306,9 +306,8 @@ The new input was:\n\n"""
         Returns
         -------
         CommentCollection
-            a list of the comments associated with this object, which also
-            supports searching the comments' text (e.g. ``"foo" in
-            obj.comments``).
+            the comments associated with this object; supports searching
+            the comments' text, e.g. ``"foo" in obj.comments``.
         """
         return CommentCollection(self._tree.comments)
 
@@ -319,8 +318,8 @@ The new input was:\n\n"""
         Returns
         -------
         CommentCollection
-            the leading comments, which also support searching the comments'
-            text (e.g. ``"foo" in obj.leading_comments``).
+            the leading comments; supports searching the comments' text,
+            e.g. ``"foo" in obj.leading_comments``.
         """
         return CommentCollection(self._tree["start_pad"].comments)
 

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -325,13 +325,13 @@ The new input was:\n\n"""
 
     @leading_comments.setter
     def leading_comments(self, comments):
-        if not isinstance(comments, (list, tuple, CommentNode)):
+        if not isinstance(comments, (list, tuple, CommentNode, CommentCollection)):
             raise TypeError(
                 f"Comments must be a CommentNode, or a list of Comments. {comments} given."
             )
         if isinstance(comments, CommentNode):
             comments = [comments]
-        if isinstance(comments, (list, tuple)):
+        if isinstance(comments, (list, tuple, CommentCollection)):
             for comment in comments:
                 if not isinstance(comment, CommentNode):
                     raise TypeError(

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -64,8 +64,9 @@ class _ExceptionContextAdder(ABCMeta):
         """
         new_attrs = {}
         for key, value in attributes.items():
-            if key.startswith("_"):
+            if key.startswith("_") and key != "__init__":
                 new_attrs[key] = value
+                continue
             if callable(value):
                 new_attrs[key] = _ExceptionContextAdder._wrap_attr_call(value)
             elif isinstance(value, property):

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -298,7 +298,7 @@ The new input was:\n\n"""
 
     @property
     def comments(self) -> CommentCollection:
-        """The comments associated with this input if any.
+        """The comments associated with this object if any.
 
         This includes all ``C`` comments before this card that aren't part of another card,
         and any comments that are inside this card.

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -9,6 +9,7 @@ from typing import TypeAlias, Union, Type
 import warnings
 import weakref
 
+from montepy.comments import CommentCollection
 from montepy.exceptions import *
 from montepy.constants import (
     BLANK_SPACE_CONTINUE,
@@ -296,7 +297,7 @@ The new input was:\n\n"""
             warnings.warn(warning, stacklevel=4)
 
     @property
-    def comments(self) -> list[PaddingNode]:
+    def comments(self) -> CommentCollection:
         """The comments associated with this input if any.
 
         This includes all ``C`` comments before this card that aren't part of another card,
@@ -304,21 +305,24 @@ The new input was:\n\n"""
 
         Returns
         -------
-        list
-            a list of the comments associated with this comment.
+        CommentCollection
+            a list of the comments associated with this comment, which also
+            supports searching the comments' text (e.g. ``"foo" in
+            obj.comments``).
         """
-        return list(self._tree.comments)
+        return CommentCollection(self._tree.comments)
 
     @property
-    def leading_comments(self) -> list[PaddingNode]:
+    def leading_comments(self) -> CommentCollection:
         """Any comments that come before the beginning of the input proper.
 
         Returns
         -------
-        list
-            the leading comments.
+        CommentCollection
+            the leading comments, which also support searching the comments'
+            text (e.g. ``"foo" in obj.leading_comments``).
         """
-        return list(self._tree["start_pad"].comments)
+        return CommentCollection(self._tree["start_pad"].comments)
 
     @leading_comments.setter
     def leading_comments(self, comments):

--- a/montepy/mcnp_object.py
+++ b/montepy/mcnp_object.py
@@ -303,6 +303,10 @@ The new input was:\n\n"""
         This includes all ``C`` comments before this card that aren't part of another card,
         and any comments that are inside this card.
 
+        .. versionchanged:: 1.5.0
+
+            Returns a :class:`~montepy.comments.CommentCollection` instead of a list.
+
         Returns
         -------
         CommentCollection
@@ -314,6 +318,10 @@ The new input was:\n\n"""
     @property
     def leading_comments(self) -> CommentCollection:
         """Any comments that come before the beginning of the input proper.
+
+        .. versionchanged:: 1.5.0
+
+            Returns a :class:`~montepy.comments.CommentCollection` instead of a list.
 
         Returns
         -------

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -264,7 +264,8 @@ class HalfSpace:
         Raises
         ------
         TypeError
-            if either argument is not a Surface or Cell.
+            if either argument is not a Surface or Cell, or if they are not the
+            same kind (e.g. one is a Surface and the other is a Cell).
         ValueError
             if old_divider is not found in the geometry tree.
         """
@@ -280,9 +281,26 @@ class HalfSpace:
             raise TypeError(
                 f"new_divider must be a Surface or Cell. {new_divider} given."
             )
+        if isinstance(old_divider, montepy.Cell) != isinstance(
+            new_divider, montepy.Cell
+        ):
+            raise TypeError(
+                f"old_divider and new_divider must both be Surfaces or both be Cells. "
+                f"Got {type(old_divider).__name__} and {type(new_divider).__name__}."
+            )
         replaced = self._replace_recursive(old_divider, new_divider)
         if not replaced:
-            raise ValueError(f"{old_divider} not found in geometry tree.")
+            raise ValueError(
+                f"{old_divider} (number: {old_divider.number}) not found in geometry tree."
+            )
+        if self._cell is not None:
+            container = (
+                self._cell.complements
+                if isinstance(old_divider, montepy.Cell)
+                else self._cell.surfaces
+            )
+            if old_divider in container:
+                container.remove(old_divider)
 
     def _replace_recursive(self, old_divider, new_divider) -> bool:
         replaced = self.left._replace_recursive(old_divider, new_divider)
@@ -743,10 +761,10 @@ class UnitHalfSpace(HalfSpace):
         self._node.is_negative = not self.side
 
     def _replace_recursive(self, old_divider, new_divider) -> bool:
-        replaced = self.left._replace_recursive(old_divider, new_divider)
-        if self.right is not None:
-            replaced |= self.right._replace_recursive(old_divider, new_divider)
-        return replaced
+        if self._divider is old_divider:
+            self.divider = new_divider
+            return True
+        return False
 
     def _get_leaf_objects(self):
         if isinstance(

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -828,10 +828,9 @@ class UnitHalfSpace(HalfSpace):
             if isinstance(self.divider, ValueNode) or type(new_obj) == type(
                 self.divider
             ):
-                # Bypass the divider setter to avoid triggering container.append;
-                # remove_duplicate_surfaces is only remapping references, not
-                # adding new surfaces — the clone process handles that separately.
-                self._divider = new_obj
+                # Use the divider setter so any parent cell bookkeeping stays
+                # synchronized with the remapped geometry.
+                self.divider = new_obj
 
     def __len__(self):
         return 1

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -439,6 +439,23 @@ class HalfSpace:
             length += len(self.right)
         return length
 
+    def __iter__(self):
+        """Iterate over all :class:`UnitHalfSpace` leaves in depth-first order.
+
+        This allows you to walk every leaf of the geometry tree, for example::
+
+            for unit in cell.geometry:
+                print(unit.divider, unit.side)
+
+        Yields
+        ------
+        UnitHalfSpace
+            each leaf node in the tree, left subtree before right.
+        """
+        yield from iter(self.left)
+        if self.right is not None:
+            yield from iter(self.right)
+
     def __eq__(self, other):
         # don't allow subclassing on right side
         if type(self) != type(other):
@@ -745,6 +762,16 @@ class UnitHalfSpace(HalfSpace):
     def __len__(self):
         return 1
 
+    def __iter__(self):
+        """Iterate over this leaf node.
+
+        Yields
+        ------
+        UnitHalfSpace
+            this leaf itself.
+        """
+        yield self
+
     def __eq__(self, other):
         if not isinstance(other, UnitHalfSpace):
             raise TypeError("UnitHalfSpace can't be equal to other type")
@@ -753,3 +780,4 @@ class UnitHalfSpace(HalfSpace):
             and self.divider is other.divider
             and self.side == other.side
         )
+    

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -247,6 +247,49 @@ class HalfSpace:
             if self.right is not None:
                 self.right.remove_duplicate_surfaces(new_deleting_dict)
 
+    def replace(
+        self,
+        old_divider: montepy.surfaces.surface.Surface | montepy.Cell,
+        new_divider: montepy.surfaces.surface.Surface | montepy.Cell,
+    ) -> None:
+        """Replace all occurrences of a divider in this geometry tree.
+
+        Parameters
+        ----------
+        old_divider : Surface, Cell
+            the divider to be replaced.
+        new_divider : Surface, Cell
+            the divider to replace it with.
+
+        Raises
+        ------
+        TypeError
+            if either argument is not a Surface or Cell.
+        ValueError
+            if old_divider is not found in the geometry tree.
+        """
+        if not isinstance(
+            old_divider, (montepy.surfaces.surface.Surface, montepy.Cell)
+        ):
+            raise TypeError(
+                f"old_divider must be a Surface or Cell. {old_divider} given."
+            )
+        if not isinstance(
+            new_divider, (montepy.surfaces.surface.Surface, montepy.Cell)
+        ):
+            raise TypeError(
+                f"new_divider must be a Surface or Cell. {new_divider} given."
+            )
+        replaced = self._replace_recursive(old_divider, new_divider)
+        if not replaced:
+            raise ValueError(f"{old_divider} not found in geometry tree.")
+
+    def _replace_recursive(self, old_divider, new_divider) -> bool:
+        replaced = self.left._replace_recursive(old_divider, new_divider)
+        if self.right is not None:
+            replaced |= self.right._replace_recursive(old_divider, new_divider)
+        return replaced
+
     def _get_leaf_objects(self):
         """Get all of the leaf objects for this tree.
 
@@ -699,6 +742,12 @@ class UnitHalfSpace(HalfSpace):
             self._node.value = self.divider.number
         self._node.is_negative = not self.side
 
+    def _replace_recursive(self, old_divider, new_divider) -> bool:
+        replaced = self.left._replace_recursive(old_divider, new_divider)
+        if self.right is not None:
+            replaced |= self.right._replace_recursive(old_divider, new_divider)
+        return replaced
+
     def _get_leaf_objects(self):
         if isinstance(
             self._divider, (montepy.cell.Cell, montepy.surfaces.surface.Surface)
@@ -780,4 +829,3 @@ class UnitHalfSpace(HalfSpace):
             and self.divider is other.divider
             and self.side == other.side
         )
-    

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -293,14 +293,18 @@ class HalfSpace:
             raise ValueError(
                 f"{old_divider} (number: {old_divider.number}) not found in geometry tree."
             )
-        if self._cell is not None:
-            container = (
-                self._cell.complements
-                if isinstance(old_divider, montepy.Cell)
-                else self._cell.surfaces
-            )
-            if old_divider in container:
-                container.remove(old_divider)
+        # _cell is only set on UnitHalfSpace leaves, not on internal HalfSpace nodes.
+        # Find the parent cell via any leaf and remove the old divider from its collection.
+        for leaf in self:
+            if leaf._cell is not None:
+                container = (
+                    leaf._cell.complements
+                    if isinstance(old_divider, montepy.Cell)
+                    else leaf._cell.surfaces
+                )
+                if old_divider in container:
+                    container.remove(old_divider)
+                break
 
     def _replace_recursive(self, old_divider, new_divider) -> bool:
         replaced = self.left._replace_recursive(old_divider, new_divider)
@@ -824,7 +828,10 @@ class UnitHalfSpace(HalfSpace):
             if isinstance(self.divider, ValueNode) or type(new_obj) == type(
                 self.divider
             ):
-                self.divider = new_obj
+                # Bypass the divider setter to avoid triggering container.append;
+                # remove_duplicate_surfaces is only remapping references, not
+                # adding new surfaces — the clone process handles that separately.
+                self._divider = new_obj
 
     def __len__(self):
         return 1

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -252,27 +252,6 @@ class HalfSpace:
         old_divider: montepy.Surface | montepy.Cell,
         new_divider: montepy.Surface | montepy.Cell,
     ) -> None:
-        """Replace all occurrences of a divider in this geometry tree.
-
-        Parameters
-        ----------
-        old_divider : Surface or Cell
-            the divider to be replaced.
-        new_divider : Surface or Cell
-            the divider to replace it with.
-
-        Raises
-        ------
-        TypeError
-            if either argument is not a Surface or Cell, or if they are not the
-            same kind (e.g. one is a Surface and the other is a Cell).
-        ValueError
-            if old_divider is not found in the geometry tree, or if
-            old_divider and new_divider are the same object.
-        IllegalState
-            if the geometry tree has not been linked via update_pointers()
-            (i.e. leaf dividers are still integers from parsing).
-        """
         if not isinstance(
             old_divider, (montepy.surfaces.surface.Surface, montepy.Cell)
         ):
@@ -296,21 +275,22 @@ class HalfSpace:
             raise ValueError(
                 "new_divider and old_divider are the same object; nothing to replace."
             )
-        # Validate the tree is fully linked before touching anything.
         for leaf in self:
             if isinstance(leaf._divider, Integral):
                 raise IllegalState(
                     "Geometry tree has not been linked to objects yet. "
                     "Run Cell.update_pointers() before calling replace()."
                 )
-        # Remove old_divider from the parent cell's container before calling
-        # _replace_recursive so replacing with a different object that reuses the
-        # same number does not trip the collection's conflict checks.
+
+        # Find parent cell
         cell = None
         for leaf in self:
             if leaf._cell is not None:
                 cell = leaf._cell
                 break
+
+        # Remove old_divider from parent cell's container only if present
+        removed_from_container = False
         if cell is not None:
             container = (
                 cell.complements
@@ -319,12 +299,13 @@ class HalfSpace:
             )
             if old_divider in container:
                 container.remove(old_divider)
+                removed_from_container = True
+
         replaced = self._replace_recursive(old_divider, new_divider)
         if not replaced:
-            # Replacement failed, so restore the original divider to keep the
-            # parent cell's collection consistent.
-            if cell is not None:
-                container.append(old_divider)
+            # old_divider was never in the geometry tree.
+            # Per Micah: don't add it back (it was never legitimately there),
+            # but still raise ValueError.
             raise ValueError(
                 f"{old_divider} (number: {old_divider.number}) not found in geometry tree."
             )

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -303,11 +303,9 @@ class HalfSpace:
                     "Geometry tree has not been linked to objects yet. "
                     "Run Cell.update_pointers() before calling replace()."
                 )
-        # Remove old_divider from the parent cell's container BEFORE calling
-        # _replace_recursive. The divider setter appends new_divider when it
-        # runs; if old_divider is still present at that point and shares a number
-        # with new_divider, the collection can raise NumberConflictError or skip
-        # the append, leaving bookkeeping in an inconsistent state.
+        # Remove old_divider from the parent cell's container before calling
+        # _replace_recursive so replacing with a different object that reuses the
+        # same number does not trip the collection's conflict checks.
         cell = None
         for leaf in self:
             if leaf._cell is not None:
@@ -323,18 +321,13 @@ class HalfSpace:
                 container.remove(old_divider)
         replaced = self._replace_recursive(old_divider, new_divider)
         if not replaced:
-            # Replacement failed — restore old_divider so the cell stays consistent.
-            if cell is not None and not any(s is old_divider for s in container):
+            # Replacement failed, so restore the original divider to keep the
+            # parent cell's collection consistent.
+            if cell is not None:
                 container.append(old_divider)
             raise ValueError(
                 f"{old_divider} (number: {old_divider.number}) not found in geometry tree."
             )
-        # The UnitHalfSpace.divider setter may silently skip appending new_divider
-        # if an object with the same number already appears in the container (e.g.
-        # when new_divider.number == old_divider.number and old_divider was just
-        # removed). Explicitly ensure new_divider is present by identity.
-        if cell is not None and not any(s is new_divider for s in container):
-            container.append(new_divider)
 
     def _replace_recursive(self, old_divider, new_divider) -> bool:
         replaced = self.left._replace_recursive(old_divider, new_divider)

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -324,11 +324,17 @@ class HalfSpace:
         replaced = self._replace_recursive(old_divider, new_divider)
         if not replaced:
             # Replacement failed — restore old_divider so the cell stays consistent.
-            if cell is not None and old_divider not in container:
+            if cell is not None and not any(s is old_divider for s in container):
                 container.append(old_divider)
             raise ValueError(
                 f"{old_divider} (number: {old_divider.number}) not found in geometry tree."
             )
+        # The UnitHalfSpace.divider setter may silently skip appending new_divider
+        # if an object with the same number already appears in the container (e.g.
+        # when new_divider.number == old_divider.number and old_divider was just
+        # removed). Explicitly ensure new_divider is present by identity.
+        if cell is not None and not any(s is new_divider for s in container):
+            container.append(new_divider)
 
     def _replace_recursive(self, old_divider, new_divider) -> bool:
         replaced = self.left._replace_recursive(old_divider, new_divider)

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -643,7 +643,9 @@ class UnitHalfSpace(HalfSpace):
                 container = self._cell.complements
             else:
                 container = self._cell.surfaces
-            if div not in container:
+            try:
+                container[div.number]
+            except KeyError:
                 container.append(div)
 
     @make_prop_pointer("_is_cell", bool)

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -296,29 +296,39 @@ class HalfSpace:
             raise ValueError(
                 "new_divider and old_divider are the same object; nothing to replace."
             )
+        # Validate the tree is fully linked before touching anything.
         for leaf in self:
             if isinstance(leaf._divider, Integral):
                 raise IllegalState(
                     "Geometry tree has not been linked to objects yet. "
                     "Run Cell.update_pointers() before calling replace()."
                 )
+        # Remove old_divider from the parent cell's container BEFORE calling
+        # _replace_recursive. The divider setter appends new_divider when it
+        # runs; if old_divider is still present at that point and shares a number
+        # with new_divider, the collection can raise NumberConflictError or skip
+        # the append, leaving bookkeeping in an inconsistent state.
+        cell = None
+        for leaf in self:
+            if leaf._cell is not None:
+                cell = leaf._cell
+                break
+        if cell is not None:
+            container = (
+                cell.complements
+                if isinstance(old_divider, montepy.Cell)
+                else cell.surfaces
+            )
+            if old_divider in container:
+                container.remove(old_divider)
         replaced = self._replace_recursive(old_divider, new_divider)
         if not replaced:
+            # Replacement failed — restore old_divider so the cell stays consistent.
+            if cell is not None and old_divider not in container:
+                container.append(old_divider)
             raise ValueError(
                 f"{old_divider} (number: {old_divider.number}) not found in geometry tree."
             )
-        # _cell is only set on UnitHalfSpace leaves, not on internal HalfSpace nodes.
-        # Find the parent cell via any leaf and remove the old divider from its collection.
-        for leaf in self:
-            if leaf._cell is not None:
-                container = (
-                    leaf._cell.complements
-                    if isinstance(old_divider, montepy.Cell)
-                    else leaf._cell.surfaces
-                )
-                if old_divider in container:
-                    container.remove(old_divider)
-                break
 
     def _replace_recursive(self, old_divider, new_divider) -> bool:
         replaced = self.left._replace_recursive(old_divider, new_divider)

--- a/montepy/surfaces/half_space.py
+++ b/montepy/surfaces/half_space.py
@@ -249,16 +249,16 @@ class HalfSpace:
 
     def replace(
         self,
-        old_divider: montepy.surfaces.surface.Surface | montepy.Cell,
-        new_divider: montepy.surfaces.surface.Surface | montepy.Cell,
+        old_divider: montepy.Surface | montepy.Cell,
+        new_divider: montepy.Surface | montepy.Cell,
     ) -> None:
         """Replace all occurrences of a divider in this geometry tree.
 
         Parameters
         ----------
-        old_divider : Surface, Cell
+        old_divider : Surface or Cell
             the divider to be replaced.
-        new_divider : Surface, Cell
+        new_divider : Surface or Cell
             the divider to replace it with.
 
         Raises
@@ -267,7 +267,11 @@ class HalfSpace:
             if either argument is not a Surface or Cell, or if they are not the
             same kind (e.g. one is a Surface and the other is a Cell).
         ValueError
-            if old_divider is not found in the geometry tree.
+            if old_divider is not found in the geometry tree, or if
+            old_divider and new_divider are the same object.
+        IllegalState
+            if the geometry tree has not been linked via update_pointers()
+            (i.e. leaf dividers are still integers from parsing).
         """
         if not isinstance(
             old_divider, (montepy.surfaces.surface.Surface, montepy.Cell)
@@ -288,6 +292,16 @@ class HalfSpace:
                 f"old_divider and new_divider must both be Surfaces or both be Cells. "
                 f"Got {type(old_divider).__name__} and {type(new_divider).__name__}."
             )
+        if new_divider is old_divider:
+            raise ValueError(
+                "new_divider and old_divider are the same object; nothing to replace."
+            )
+        for leaf in self:
+            if isinstance(leaf._divider, Integral):
+                raise IllegalState(
+                    "Geometry tree has not been linked to objects yet. "
+                    "Run Cell.update_pointers() before calling replace()."
+                )
         replaced = self._replace_recursive(old_divider, new_divider)
         if not replaced:
             raise ValueError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ coverage = "https://coveralls.io/github/idaholab/MontePy"
 "change_to_ascii" = "montepy._scripts.change_to_ascii:main"
 
 [build-system]
-requires = ["setuptools>=80.0.0", "setuptools_scm>=8,<10.0"]
+requires = ["setuptools>=80.0.0", "setuptools_scm>=8,<11.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ authors = [
 	{name = "Paul Ferney", email="Paul.Ferney@inl.gov"},
 	{name = "Digvijay Yeware", email="yewaredigvijay@gmail.com"},
 	{name = "Harsh Dayal", email="harshdayal13@gmail.com"},
+	{name = "Yusra Rasool", email = "ryusra9@gmail.com"},
 ]
 keywords = ["MCNP", "neutronics", "imcnp", "input file", "monte carlo", "radiation transport"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ doc = [
   	"sphinx_autodoc_typehints",
 	"autodocsumm",
 	"jupyterlite-sphinx",
-	"jupyterlite-pyodide-kernel"
+	"jupyterlite-pyodide-kernel",
+	"sphinx-sitemap",
 ]
 format = ["black>=26.1,<27.0"]
 develop = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ test = [
 ]
 build = [
 	"build",
-	"setuptools>=64.0.0",
-	"setuptools-scm>=8",
+	"setuptools>=80.0.0",
+	"setuptools-scm>=8,<10.0",
 ]
 doc = [
 	"montepy[build]",
@@ -90,7 +90,7 @@ coverage = "https://coveralls.io/github/idaholab/MontePy"
 "change_to_ascii" = "montepy._scripts.change_to_ascii:main"
 
 [build-system]
-requires = ["setuptools>=77.0.0", "setuptools_scm>=8"]
+requires = ["setuptools>=80.0.0", "setuptools_scm>=8,<10.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
 build = [
 	"build",
 	"setuptools>=80.0.0",
-	"setuptools-scm>=8,<10.0",
+	"setuptools-scm>=8,<11.0",
 ]
 doc = [
 	"montepy[build]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,14 +55,14 @@ build = [
 ]
 doc = [
 	"montepy[build]",
-	"sphinx~=8.0", 
+	"sphinx>=8.0.0,<9.0.0", 
 	"sphinxcontrib-apidoc", 
 	"pydata_sphinx_theme",
 	"sphinx-favicon",
 	"sphinx-copybutton",
   	"sphinx_autodoc_typehints",
 	"autodocsumm",
-	"jupyterlite-sphinx",
+	"jupyterlite-sphinx>=0.22",
 	"jupyterlite-pyodide-kernel",
 	"sphinx-sitemap",
 ]

--- a/tests/test_cell_problem.py
+++ b/tests/test_cell_problem.py
@@ -70,7 +70,7 @@ def test_cell_is_mass_dens():
     assert cell.is_mass_dens is True
     assert cell.is_mass_dens == (not cell.is_atom_dens)
     # atom density set
-    cell.atom_density = 1.6
+    cell.atom_density = 0.016
     assert cell.is_mass_dens is False
     assert cell.is_mass_dens == (not cell.is_atom_dens)
 

--- a/tests/test_cell_problem.py
+++ b/tests/test_cell_problem.py
@@ -60,6 +60,21 @@ def test_cell_density_setter():
         cell.mass_density = -5
 
 
+def test_cell_is_mass_dens():
+    # no density set yet
+    cell = Cell()
+    assert cell.is_mass_dens is None
+    assert cell.is_atom_dens is None
+    # mass density set
+    cell.mass_density = 1.5
+    assert cell.is_mass_dens is True
+    assert cell.is_mass_dens == (not cell.is_atom_dens)
+    # atom density set
+    cell.atom_density = 1.6
+    assert cell.is_mass_dens is False
+    assert cell.is_mass_dens == (not cell.is_atom_dens)
+
+
 def test_cell_density_deleter():
     in_str = "1 1 0.5 2"
     cell = Cell(in_str)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -120,7 +120,9 @@ def test_geometry_comments():
       :(-11536    97  -401 )  $ C 3 Lower water
       :(-11546    97  -401 )  $ C 4 Lower water
       :(-11556    97  -401 )  $ C 5 Lower water
-      :(-11576    97  -401 ) imp:n=1 $ C 7 Lower water""".split("\n")
+      :(-11576    97  -401 ) imp:n=1 $ C 7 Lower water""".split(
+        "\n"
+    )
     input_obj = montepy.input_parser.mcnp_input.Input(
         in_strs, montepy.input_parser.block_type.BlockType.CELL
     )

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -120,9 +120,7 @@ def test_geometry_comments():
       :(-11536    97  -401 )  $ C 3 Lower water
       :(-11546    97  -401 )  $ C 4 Lower water
       :(-11556    97  -401 )  $ C 5 Lower water
-      :(-11576    97  -401 ) imp:n=1 $ C 7 Lower water""".split(
-        "\n"
-    )
+      :(-11576    97  -401 ) imp:n=1 $ C 7 Lower water""".split("\n")
     input_obj = montepy.input_parser.mcnp_input.Input(
         in_strs, montepy.input_parser.block_type.BlockType.CELL
     )

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -552,19 +552,21 @@ def test_update_operators_in_node():
 
 
 def _make_linked_geometry(*surfs):
-    """Helper: build a parent cell whose geometry is already linked via update_pointers.
+    """Helper: build a parent cell whose geometry is already linked.
 
     Returns (parent_cell, half_space) where every UnitHalfSpace leaf has
     self._cell set so the old-divider cleanup path in replace() is exercised.
     """
     parent = montepy.Cell()
     parent.number = 99
+    # Populate parent.surfaces up front so all surfaces are present before replace()
+    for surf in surfs:
+        parent.surfaces.append(surf)
     half_space = None
     for surf in surfs:
         leaf = +surf
-        # wire the leaf to the parent cell so _cell is set
-        surf_col = montepy.surface_collection.Surfaces(list(parent.surfaces) + [surf])
-        leaf.update_pointers(montepy.cells.Cells(), surf_col, parent)
+        # Wire _cell directly since dividers are already resolved objects, not ints
+        leaf._cell = parent
         half_space = leaf if half_space is None else half_space & leaf
     return parent, half_space
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -546,3 +546,158 @@ def test_update_operators_in_node():
     half_space.operator = Operator.UNION
     half_space._update_values()
     assert half_space.node.format() == "-1 : 1"
+
+
+# ── replace() tests ───────────────────────────────────────────────────────────
+
+
+def _make_linked_geometry(*surfs):
+    """Helper: build a parent cell whose geometry is already linked via update_pointers.
+
+    Returns (parent_cell, half_space) where every UnitHalfSpace leaf has
+    self._cell set so the old-divider cleanup path in replace() is exercised.
+    """
+    parent = montepy.Cell()
+    parent.number = 99
+    half_space = None
+    for surf in surfs:
+        leaf = +surf
+        # wire the leaf to the parent cell so _cell is set
+        surf_col = montepy.surface_collection.Surfaces(list(parent.surfaces) + [surf])
+        leaf.update_pointers(montepy.cells.Cells(), surf_col, parent)
+        half_space = leaf if half_space is None else half_space & leaf
+    return parent, half_space
+
+
+def test_replace_surface_basic():
+    """replace() swaps old surface for new one throughout the tree."""
+    surf1 = montepy.CylinderOnAxis()
+    surf2 = montepy.CylinderOnAxis()
+    surf3 = montepy.CylinderOnAxis()
+    surf1.number = 1
+    surf2.number = 2
+    surf3.number = 3
+    half_space = +surf1 & -surf2
+    half_space.replace(surf1, surf3)
+    # surf3 should now appear in place of surf1
+    leaves = list(half_space)
+    dividers = [leaf.divider for leaf in leaves]
+    assert surf3 in dividers
+    assert surf1 not in dividers
+    assert surf2 in dividers
+
+
+def test_replace_surface_updates_cell_surfaces():
+    """After replace(), old surface is removed from cell.surfaces and new one is present."""
+    surf1 = montepy.CylinderOnAxis()
+    surf2 = montepy.CylinderOnAxis()
+    surf3 = montepy.CylinderOnAxis()
+    surf1.number = 1
+    surf2.number = 2
+    surf3.number = 3
+    parent, half_space = _make_linked_geometry(surf1, surf2)
+    half_space.replace(surf1, surf3)
+    assert surf3 in parent.surfaces
+    assert surf1 not in parent.surfaces
+    assert surf2 in parent.surfaces  # untouched
+
+
+def test_replace_on_leaf():
+    """replace() called directly on a UnitHalfSpace (leaf) works correctly."""
+    surf1 = montepy.CylinderOnAxis()
+    surf2 = montepy.CylinderOnAxis()
+    surf1.number = 1
+    surf2.number = 2
+    leaf = +surf1
+    leaf.replace(surf1, surf2)
+    assert leaf.divider is surf2
+
+
+def test_replace_not_found_raises():
+    """replace() raises ValueError when old_divider is absent from the tree."""
+    surf1 = montepy.CylinderOnAxis()
+    surf2 = montepy.CylinderOnAxis()
+    surf3 = montepy.CylinderOnAxis()
+    surf1.number = 1
+    surf2.number = 2
+    surf3.number = 3
+    half_space = +surf1 & -surf2
+    with pytest.raises(ValueError):
+        half_space.replace(surf3, surf1)
+
+
+def test_replace_wrong_kind_raises():
+    """replace() raises TypeError when mixing Surface and Cell arguments."""
+    surf = montepy.CylinderOnAxis()
+    surf.number = 1
+    cell = montepy.Cell()
+    cell.number = 2
+    half_space = +surf
+    with pytest.raises(TypeError):
+        half_space.replace(surf, cell)
+
+
+def test_replace_invalid_type_raises():
+    """replace() raises TypeError when either argument is not a Surface or Cell."""
+    surf = montepy.CylinderOnAxis()
+    surf.number = 1
+    half_space = +surf
+    with pytest.raises(TypeError):
+        half_space.replace("not a surface", surf)
+    with pytest.raises(TypeError):
+        half_space.replace(surf, 42)
+
+
+def test_replace_subclass_surface():
+    """replace() accepts any Surface subclass for either argument (no false type errors)."""
+    surf1 = montepy.CylinderOnAxis()  # subclass of Surface
+    surf2 = montepy.AxisPlane()  # different subclass of Surface
+    surf1.number = 1
+    surf2.number = 2
+    half_space = +surf1 & -surf1
+    # Should not raise — both are Surfaces regardless of subclass
+    half_space.replace(surf1, surf2)
+    for leaf in half_space:
+        assert leaf.divider is surf2
+
+
+# ── __iter__ tests ────────────────────────────────────────────────────────────
+
+
+def test_halfspace_iter_leaves_in_order():
+    """HalfSpace.__iter__ yields all UnitHalfSpace leaves depth-first left-to-right."""
+    surf1 = montepy.CylinderOnAxis()
+    surf2 = montepy.CylinderOnAxis()
+    surf3 = montepy.CylinderOnAxis()
+    surf1.number = 1
+    surf2.number = 2
+    surf3.number = 3
+    half_space = (+surf1 & -surf2) | +surf3
+    leaves = list(half_space)
+    assert len(leaves) == 3
+    assert all(isinstance(leaf, UnitHalfSpace) for leaf in leaves)
+    assert leaves[0].divider is surf1
+    assert leaves[1].divider is surf2
+    assert leaves[2].divider is surf3
+
+
+def test_halfspace_iter_count_matches_len():
+    """len(half_space) equals the number of leaves yielded by iteration."""
+    surf1 = montepy.CylinderOnAxis()
+    surf2 = montepy.CylinderOnAxis()
+    surf3 = montepy.CylinderOnAxis()
+    surf1.number = 1
+    surf2.number = 2
+    surf3.number = 3
+    half_space = +surf1 & -surf2 & +surf3
+    assert len(list(half_space)) == len(half_space)
+
+
+def test_unit_halfspace_iter():
+    """UnitHalfSpace.__iter__ yields exactly itself."""
+    surf = montepy.CylinderOnAxis()
+    surf.number = 1
+    leaf = +surf
+    leaves = list(leaf)
+    assert len(leaves) == 1
+    assert leaves[0] is leaf

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -720,9 +720,12 @@ def test_replace_same_number_different_object(make_linked_geometry):
     parent, half_space = make_linked_geometry(surf1, surf2)
     # Should not raise NumberConflictError or leave the collection in a broken state
     half_space.replace(surf1, surf3)
-    assert surf3 in parent.surfaces
-    assert surf1 not in parent.surfaces
-    assert surf2 in parent.surfaces  # untouched
+    # Numbered_object_collection.__contains__ is number-based, so use identity checks
+    # to distinguish surf1 and surf3 which share the same number.
+    surfaces = list(parent.surfaces)
+    assert any(s is surf3 for s in surfaces)
+    assert not any(s is surf1 for s in surfaces)
+    assert any(s is surf2 for s in surfaces)  # untouched
 
 
 def test_replace_unlinked_raises():
@@ -779,3 +782,4 @@ def test_unit_halfspace_iter():
     leaves = list(leaf)
     assert len(leaves) == 1
     assert leaves[0] is leaf
+    

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -551,34 +551,37 @@ def test_update_operators_in_node():
 # ── replace() tests ───────────────────────────────────────────────────────────
 
 
-def _make_linked_geometry(*surfs):
-    """Helper: build a parent cell whose geometry is already linked.
+@pytest.fixture
+def make_linked_geometry():
+    """Fixture factory: build a parent cell whose geometry is already linked.
 
-    Returns (parent_cell, half_space) where every UnitHalfSpace leaf has
-    self._cell set so the old-divider cleanup path in replace() is exercised.
+    Returns a callable that accepts surfaces/cells and produces
+    (parent_cell, half_space) where every UnitHalfSpace leaf has
+    _cell set so the old-divider cleanup path in replace() is exercised.
     """
-    parent = montepy.Cell()
-    parent.number = 99
-    # Populate parent.surfaces up front so all surfaces are present before replace()
-    for surf in surfs:
-        parent.surfaces.append(surf)
-    half_space = None
-    for surf in surfs:
-        leaf = +surf
-        # Wire _cell directly since dividers are already resolved objects, not ints
-        leaf._cell = parent
-        half_space = leaf if half_space is None else half_space & leaf
-    return parent, half_space
+
+    def _factory(*surfs):
+        parent = montepy.Cell()
+        parent.number = 99
+        # Populate parent.surfaces up front so all surfaces are present before replace()
+        for surf in surfs:
+            parent.surfaces.append(surf)
+        half_space = None
+        for surf in surfs:
+            leaf = +surf
+            # Wire _cell directly since dividers are already resolved objects, not ints
+            leaf._cell = parent
+            half_space = leaf if half_space is None else half_space & leaf
+        return parent, half_space
+
+    return _factory
 
 
 def test_replace_surface_basic():
     """replace() swaps old surface for new one throughout the tree."""
-    surf1 = montepy.CylinderOnAxis()
-    surf2 = montepy.CylinderOnAxis()
-    surf3 = montepy.CylinderOnAxis()
-    surf1.number = 1
-    surf2.number = 2
-    surf3.number = 3
+    surf1 = montepy.CylinderOnAxis(number=1)
+    surf2 = montepy.CylinderOnAxis(number=2)
+    surf3 = montepy.CylinderOnAxis(number=3)
     half_space = +surf1 & -surf2
     half_space.replace(surf1, surf3)
     # surf3 should now appear in place of surf1
@@ -589,7 +592,7 @@ def test_replace_surface_basic():
     assert surf2 in dividers
 
 
-def test_replace_surface_updates_cell_surfaces():
+def test_replace_surface_updates_cell_surfaces(make_linked_geometry):
     """After replace(), old surface is removed from cell.surfaces and new one is present."""
     surf1 = montepy.CylinderOnAxis()
     surf2 = montepy.CylinderOnAxis()
@@ -597,7 +600,7 @@ def test_replace_surface_updates_cell_surfaces():
     surf1.number = 1
     surf2.number = 2
     surf3.number = 3
-    parent, half_space = _make_linked_geometry(surf1, surf2)
+    parent, half_space = make_linked_geometry(surf1, surf2)
     half_space.replace(surf1, surf3)
     assert surf3 in parent.surfaces
     assert surf1 not in parent.surfaces
@@ -663,6 +666,79 @@ def test_replace_subclass_surface():
         assert leaf.divider is surf2
 
 
+def test_replace_cell_complement(make_linked_geometry):
+    """replace() works on Cell complement dividers and updates cell.complements."""
+    cell1 = montepy.Cell()
+    cell2 = montepy.Cell()
+    cell3 = montepy.Cell()
+    cell1.number = 1
+    cell2.number = 2
+    cell3.number = 3
+
+    parent = montepy.Cell()
+    parent.number = 99
+    parent.complements.append(cell1)
+    parent.complements.append(cell2)
+
+    # ~cell produces HalfSpace(UnitHalfSpace(cell, True, True), COMPLEMENT, None)
+    hs1 = ~cell1
+    hs2 = ~cell2
+    for leaf in hs1:
+        leaf._cell = parent
+    for leaf in hs2:
+        leaf._cell = parent
+    half_space = hs1 & hs2
+
+    half_space.replace(cell1, cell3)
+
+    dividers = [leaf.divider for leaf in half_space]
+    assert cell3 in dividers
+    assert cell1 not in dividers
+    assert cell2 in dividers  # untouched
+    assert cell3 in parent.complements
+    assert cell1 not in parent.complements
+
+
+def test_replace_same_object_raises():
+    """replace() raises ValueError when old_divider and new_divider are the same object."""
+    surf = montepy.CylinderOnAxis()
+    surf.number = 1
+    half_space = +surf
+    with pytest.raises(ValueError):
+        half_space.replace(surf, surf)
+
+
+def test_replace_same_number_different_object(make_linked_geometry):
+    """replace() with a new surface sharing the same number as old must not corrupt cell.surfaces."""
+    surf1 = montepy.CylinderOnAxis()
+    surf2 = montepy.CylinderOnAxis()
+    surf3 = montepy.CylinderOnAxis()
+    surf1.number = 1
+    surf2.number = 2
+    # surf3 intentionally gets the same number as surf1
+    surf3.number = 1
+    parent, half_space = make_linked_geometry(surf1, surf2)
+    # Should not raise NumberConflictError or leave the collection in a broken state
+    half_space.replace(surf1, surf3)
+    assert surf3 in parent.surfaces
+    assert surf1 not in parent.surfaces
+    assert surf2 in parent.surfaces  # untouched
+
+
+def test_replace_unlinked_raises():
+    """replace() raises IllegalState when the geometry tree has not been linked."""
+    from montepy.exceptions import IllegalState
+
+    surf1 = montepy.CylinderOnAxis()
+    surf2 = montepy.CylinderOnAxis()
+    surf1.number = 1
+    surf2.number = 2
+    # Build a tree with integer dividers (as if freshly parsed, not update_pointers'd)
+    leaf = UnitHalfSpace(1, True, False)  # integer divider
+    with pytest.raises(IllegalState):
+        leaf.replace(surf1, surf2)
+
+
 # ── __iter__ tests ────────────────────────────────────────────────────────────
 
 
@@ -692,7 +768,7 @@ def test_halfspace_iter_count_matches_len():
     surf2.number = 2
     surf3.number = 3
     half_space = +surf1 & -surf2 & +surf3
-    assert len(list(half_space)) == len(half_space)
+    assert len(half_space) == 3
 
 
 def test_unit_halfspace_iter():

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -782,4 +782,3 @@ def test_unit_halfspace_iter():
     leaves = list(leaf)
     assert len(leaves) == 1
     assert leaves[0] is leaf
-    

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -4,6 +4,7 @@ import montepy
 from montepy.geometry_operators import Operator
 from montepy.input_parser import syntax_node
 from montepy.surfaces.half_space import HalfSpace, UnitHalfSpace
+from tests.test_cell_problem import verify_export as verify_cell_export
 
 
 def test_halfspace_init():
@@ -726,6 +727,25 @@ def test_replace_same_number_different_object(make_linked_geometry):
     assert any(s is surf3 for s in surfaces)
     assert not any(s is surf1 for s in surfaces)
     assert any(s is surf2 for s in surfaces)  # untouched
+
+
+def test_replace_same_number_different_object_verify_export():
+    """Replacing with a same-number surface still exports and re-parses cleanly."""
+    surf1 = montepy.CylinderOnAxis(number=1)
+    surf2 = montepy.CylinderOnAxis(number=2)
+    surf3 = montepy.CylinderOnAxis(number=1)
+    parent = montepy.Cell(number=99)
+    parent.geometry = +surf1 & -surf2
+    parent.importance.neutron = 1.0
+    for leaf in parent.geometry:
+        leaf._cell = parent
+
+    parent.geometry.replace(surf1, surf3)
+
+    surfaces = list(parent.surfaces)
+    assert any(s is surf3 for s in surfaces)
+    assert not any(s is surf1 for s in surfaces)
+    verify_cell_export(parent)
 
 
 def test_replace_unlinked_raises():

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -762,6 +762,40 @@ def test_replace_unlinked_raises():
         leaf.replace(surf1, surf2)
 
 
+def test_ensure_has_parens_right_union():
+    """_ensure_has_parens wraps the RIGHT side in GROUP when it's a union under intersection."""
+    surf1 = montepy.CylinderOnAxis()
+    surf2 = montepy.CylinderOnAxis()
+    surf3 = montepy.CylinderOnAxis()
+    surf1.number = 1
+    surf2.number = 2
+    surf3.number = 3
+    # left is a leaf, right is a union → right must be wrapped in GROUP
+    half_space = +surf1 & (+surf2 | -surf3)
+    half_space._ensure_has_nodes()
+    assert half_space.right.operator == Operator.GROUP
+    assert half_space.node.format() == "1 (2 : -3)"
+
+
+def test_replace_not_found_restores_nothing(make_linked_geometry):
+    """replace() raises ValueError and does NOT restore old_divider when it was
+    present in cell.surfaces but absent from the geometry tree."""
+    surf1 = montepy.CylinderOnAxis()
+    surf2 = montepy.CylinderOnAxis()
+    surf3 = montepy.CylinderOnAxis()
+    surf1.number = 1
+    surf2.number = 2
+    surf3.number = 3
+    # geometry only contains surf1; surf2 is in cell.surfaces but not the tree
+    parent, half_space = make_linked_geometry(surf1)
+    # manually add surf2 to cell.surfaces so removed_from_container=True path is hit
+    parent.surfaces.append(surf2)
+    with pytest.raises(ValueError):
+        half_space.replace(surf2, surf3)
+    # surf2 must NOT be restored — Micah's directive
+    assert surf2 not in parent.surfaces
+
+
 # ── __iter__ tests ────────────────────────────────────────────────────────────
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -241,8 +241,11 @@ def _user_facing_objects(problem: montepy.MCNP_Problem) -> Iterator[object]:
     yield from problem.data_inputs
     # cell-block modifier objects
     for cell in problem.cells:
-        yield cell.importance
-        yield cell.fill
+        yield cell.geometry
+        yield cell.leading_comments
+        yield from (
+            getattr(cell, attr) for attr, _ in cell._INPUTS_TO_PROPERTY.values()
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -218,6 +218,54 @@ def test_problem_str(simple_problem):
     assert "MCNP problem for: tests/inputs/test.imcnp" in output
 
 
+def _user_facing_objects(problem):
+    """Yield a problem's user-facing objects: the problem, its top-level
+    members, every collection and its members, the data-block inputs, and the
+    cell-block modifiers."""
+    yield problem
+    # top-level objects a user can print directly (``message`` may be ``None``)
+    for obj in (problem.input_file, problem.message, problem.title, problem.mode):
+        if obj is not None:
+            yield obj
+    for collection in (
+        problem.cells,
+        problem.surfaces,
+        problem.materials,
+        problem.universes,
+        problem.transforms,
+    ):
+        yield collection
+        yield from collection
+    # data-block inputs, e.g. ``Volume``, ``Mode`` (see the original report)
+    yield from problem.data_inputs
+    # cell-block modifier objects
+    for cell in problem.cells:
+        yield cell.importance
+        yield cell.fill
+
+
+@pytest.mark.parametrize(
+    "problem_fixture",
+    [
+        "simple_problem",
+        "importance_problem",
+        "universe_problem",
+        "data_universe_problem",
+    ],
+)
+def test_str_and_repr_do_not_raise(request, problem_fixture):
+    """``str`` and ``repr`` of user-facing objects must never raise (:issue:`152`).
+
+    Some attributes are not populated in every context (e.g. a ``Volume`` in
+    the data block), which used to make ``__repr__`` raise ``AttributeError``.
+    """
+    problem = request.getfixturevalue(problem_fixture)
+    for obj in _user_facing_objects(problem):
+        for func in (str, repr):
+            # an empty string is a valid result; the requirement is "never raises"
+            assert isinstance(func(obj), str)
+
+
 def test_write_to_file(simple_problem):
     out = "foo.imcnp"
     try:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
+from collections.abc import Iterator
 import copy
 import io
 from pathlib import Path
@@ -218,7 +219,7 @@ def test_problem_str(simple_problem):
     assert "MCNP problem for: tests/inputs/test.imcnp" in output
 
 
-def _user_facing_objects(problem):
+def _user_facing_objects(problem: montepy.MCNP_Problem) -> Iterator[object]:
     """Yield a problem's user-facing objects: the problem, its top-level
     members, every collection and its members, the data-block inputs, and the
     cell-block modifiers."""
@@ -254,10 +255,10 @@ def _user_facing_objects(problem):
     ],
 )
 def test_str_and_repr_do_not_raise(request, problem_fixture):
-    """``str`` and ``repr`` of user-facing objects must never raise (:issue:`152`).
+    """str and repr of user-facing objects must never raise (#152).
 
-    Some attributes are not populated in every context (e.g. a ``Volume`` in
-    the data block), which used to make ``__repr__`` raise ``AttributeError``.
+    Some attributes are not populated in every context (e.g. a Volume in
+    the data block), which used to make __repr__ raise AttributeError.
     """
     problem = request.getfixturevalue(problem_fixture)
     for obj in _user_facing_objects(problem):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -558,6 +558,17 @@ def test_comments_setter(simple_problem):
         cell.leading_comments = 5
 
 
+def test_comments_setter_multiple_comments(simple_problem):
+    cell = copy.deepcopy(simple_problem.cells[1])
+    comment = simple_problem.surfaces[1000].comments[0]
+    comments = [comment, copy.deepcopy(comment)]
+    cell.leading_comments = comments
+    assert len(cell.leading_comments) == 2
+    assert [comment.contents for comment in cell.leading_comments] == [
+        comment.contents for comment in comments
+    ]
+
+
 def test_problem_linker():
     cell = montepy.Cell()
     with pytest.raises(TypeError):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,6 +2,7 @@
 import copy
 import io
 from pathlib import Path
+import re
 
 import pytest
 import os
@@ -567,6 +568,18 @@ def test_comments_setter_multiple_comments(simple_problem):
     assert [comment.contents for comment in cell.leading_comments] == [
         comment.contents for comment in comments
     ]
+
+
+def test_object_comments_are_collection(simple_problem):
+    cell = simple_problem.cells[1]
+    assert isinstance(cell.comments, montepy.CommentCollection)
+    assert isinstance(cell.leading_comments, montepy.CommentCollection)
+    # an object can be found by its comment text (#185)
+    assert "hidden vertical" in cell.comments
+    assert "not actually in there" not in cell.comments
+    # both search pattern types work against an object's comments
+    assert len(cell.comments.search("hidden")) == 1
+    assert len(cell.comments.search(re.compile(r"(?i)HIDDEN"))) == 1
 
 
 def test_problem_linker():

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -47,8 +47,7 @@ class TestMaterial:
 
     @pytest.fixture
     def parsed_material(_):
-        return Material(
-            """M1   1001.00c   0.05
+        return Material("""M1   1001.00c   0.05
       1001.04c   0.05
       1001.80c   0.05
       1001.04p   0.05
@@ -64,8 +63,7 @@ class TestMaterial:
       95242      0.05
       27560.50c  0.05
       94239      0.05
-      28000.60c  0.05"""
-        )
+      28000.60c  0.05""")
 
     @pytest.fixture
     def materials(_, big_material, parsed_material):

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -47,7 +47,8 @@ class TestMaterial:
 
     @pytest.fixture
     def parsed_material(_):
-        return Material("""M1   1001.00c   0.05
+        return Material(
+            """M1   1001.00c   0.05
       1001.04c   0.05
       1001.80c   0.05
       1001.04p   0.05
@@ -63,7 +64,8 @@ class TestMaterial:
       95242      0.05
       27560.50c  0.05
       94239      0.05
-      28000.60c  0.05""")
+      28000.60c  0.05"""
+        )
 
     @pytest.fixture
     def materials(_, big_material, parsed_material):

--- a/tests/test_numbered_collection.py
+++ b/tests/test_numbered_collection.py
@@ -13,7 +13,8 @@ import os
 
 class TestNumberedObjectCollection:
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture
+    @classmethod
     def read_simple_problem(_):
         return montepy.read_input(os.path.join("tests", "inputs", "test.imcnp"))
 
@@ -825,7 +826,8 @@ class TestNumberedObjectCollection:
 
 class TestMaterials:
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture
+    @classmethod
     def m0_prob(_):
         return montepy.read_input(
             os.path.join("tests", "inputs", "test_importance.imcnp")

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -64,6 +64,42 @@ class TestValueNode:
             node = syntax_node.ValueNode("1.23", float)
             node.convert_to_int()
 
+    def test_valuenode_convert_to_int_multiply_non_integer(self):
+        # Simulate a multiply-expanded node where _value differs from
+        # _token and the expanded value is not integer-like.
+        node = syntax_node.ValueNode("1.1", float)
+        node._value = 5.5  # 1.1 * 5 via multiply shortcut
+        with pytest.raises(ValueError, match="integer value"):
+            node.convert_to_int()
+
+    def test_valuenode_convert_to_int_value_none(self):
+        # When _value is None but _token is a valid number string,
+        # convert_to_int should fall back to parsing the token.
+        node = syntax_node.ValueNode("5", float)
+        node._value = None
+        node.convert_to_int()
+        assert node.type == int
+        assert node.value == 5
+
+    def test_valuenode_convert_to_int_unparseable_token(self):
+        # When _token becomes unparseable as a float (defensive path),
+        # convert_to_int falls back to convert_token_to_int which may
+        # raise if the token is also not int-parseable.
+        node = syntax_node.ValueNode("5", float)
+        node._token = "invalid"
+        node._value = 3.0
+        with pytest.raises(ValueError):
+            node.convert_to_int()
+
+    def test_valuenode_convert_to_int_multiply_integer(self):
+        # Simulate a multiply-expanded node where _value differs from
+        # _token but the expanded value is still integer-like.
+        node = syntax_node.ValueNode("1", float)
+        node._value = 10.0  # 1 * 10 via multiply shortcut
+        node.convert_to_int()
+        assert node.type == int
+        assert node.value == 10
+
     def test_valuenode_convert_to_enum(self):
         node = syntax_node.ValueNode("1", float)
         lat = montepy.data_inputs.lattice.LatticeType

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -1,7 +1,6 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
 import copy
 from io import StringIO
-import os
 import re
 import pytest
 
@@ -657,16 +656,23 @@ class TestPaddingNode:
         with pytest.raises(TypeError):
             comments.search(re.compile(b"fuel"))
 
-
-def test_object_comments_are_collection():
-    problem = montepy.read_input(os.path.join("tests", "inputs", "test.imcnp"))
-    cell = problem.cells[1]
-    assert isinstance(cell.comments, montepy.CommentCollection)
-    assert isinstance(cell.leading_comments, montepy.CommentCollection)
-    # an object can be found by its comment text (#185)
-    assert "hidden vertical" in cell.comments
-    assert "not actually in there" not in cell.comments
-    assert len(cell.comments.search(re.compile(r"(?i)HIDDEN"))) == 1
+    def test_comment_collection_sequence(self):
+        c1 = syntax_node.CommentNode("c the fuel region")
+        c2 = syntax_node.CommentNode("$ moderator notes")
+        comments = montepy.CommentCollection([c1, c2])
+        # indexing, slicing, iteration, and length
+        assert len(comments) == 2
+        assert comments[0] is c1
+        assert comments[-1] is c2
+        sliced = comments[0:1]
+        assert isinstance(sliced, montepy.CommentCollection)
+        assert list(sliced) == [c1]
+        assert [c.contents for c in comments] == ["the fuel region", "moderator notes"]
+        # Sequence mixins
+        assert list(reversed(comments)) == [c2, c1]
+        assert comments.index(c2) == 1
+        assert comments.count(c1) == 1
+        assert "CommentCollection" in repr(comments)
 
 
 def test_graveyard_comment():

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -651,9 +651,14 @@ class TestPaddingNode:
         assert isinstance(matches, montepy.CommentCollection)
         # compiled patterns are always treated as regular expressions
         assert len(comments.search(re.compile("notes"))) == 1
-        # non-string patterns are rejected
+        # non-string patterns are rejected, with or without regex
         with pytest.raises(TypeError):
             comments.search(5)
+        with pytest.raises(TypeError):
+            comments.search(5, regex=True)
+        # bytes patterns cannot search the str contents
+        with pytest.raises(TypeError):
+            comments.search(re.compile(b"fuel"))
 
 
 def test_object_comments_are_collection():

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -1,6 +1,8 @@
 # Copyright 2024, Battelle Energy Alliance, LLC All Rights Reserved.
 import copy
 from io import StringIO
+import os
+import re
 import pytest
 
 import montepy
@@ -616,6 +618,53 @@ class TestPaddingNode:
         # non-string operands are rejected like normal str containment
         with pytest.raises(TypeError):
             5 in comment
+
+    def test_comment_collection_contains(self):
+        comments = montepy.CommentCollection(
+            [
+                syntax_node.CommentNode("c the fuel region"),
+                syntax_node.CommentNode("$ moderator notes"),
+            ]
+        )
+        # strings search the text of all comments
+        assert "fuel" in comments
+        assert "notes" in comments
+        assert "graphite" not in comments
+        # anything else keeps normal list membership behavior
+        assert comments[0] in comments
+        assert syntax_node.CommentNode("c not in there") not in comments
+        assert 5 not in comments
+
+    def test_comment_collection_search(self):
+        comments = montepy.CommentCollection(
+            [
+                syntax_node.CommentNode("c the fuel region"),
+                syntax_node.CommentNode("$ moderator notes"),
+            ]
+        )
+        # substring search
+        assert [c.contents for c in comments.search("fuel")] == ["the fuel region"]
+        assert len(comments.search("graphite")) == 0
+        # regex search
+        matches = comments.search(r"(?i)FUEL|MODERATOR", regex=True)
+        assert len(matches) == 2
+        assert isinstance(matches, montepy.CommentCollection)
+        # compiled patterns are always treated as regular expressions
+        assert len(comments.search(re.compile("notes"))) == 1
+        # non-string patterns are rejected
+        with pytest.raises(TypeError):
+            comments.search(5)
+
+
+def test_object_comments_are_collection():
+    problem = montepy.read_input(os.path.join("tests", "inputs", "test.imcnp"))
+    cell = problem.cells[1]
+    assert isinstance(cell.comments, montepy.CommentCollection)
+    assert isinstance(cell.leading_comments, montepy.CommentCollection)
+    # an object can be found by its comment text (#185)
+    assert "hidden vertical" in cell.comments
+    assert "not actually in there" not in cell.comments
+    assert len(cell.comments.search(r"(?i)HIDDEN", regex=True)) == 1
 
 
 def test_graveyard_comment():

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -239,8 +239,8 @@ class TestValueNode:
             (None, float, 1.23, "1.23 ", False),
             (None, float, 1.23456789, "1.23456789 ", False),
             # max precision: 15
-            (None, float, 1.012345678912345, "1.0123456789012345 ", False),
-            (None, float, 1.0123456789123456, "1.0123456789012346 ", False),
+            (None, float, 1.012345678954321, "1.012345678954321 ", False),
+            (None, float, 1.0123456789123451, "1.012345678912345 ", False),
         ],
     )
     def test_value_float_format(_, input, val_type, val, answer, expand):

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -234,6 +234,13 @@ class TestValueNode:
             ("0.5", float, 0, "0.0", False),
             ("hi", str, "foo", "foo", True),
             ("hi", str, None, "", False),
+            # default rounding
+            (None, float, 1.0, "1 ", False),
+            (None, float, 1.23, "1.23 ", False),
+            (None, float, 1.23456789, "1.23456789 ", False),
+            # max precision: 15
+            (None, float, 1.012345678912345, "1.0123456789012345 ", False),
+            (None, float, 1.0123456789123456, "1.0123456789012346 ", False),
         ],
     )
     def test_value_float_format(_, input, val_type, val, answer, expand):

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -642,20 +642,17 @@ class TestPaddingNode:
                 syntax_node.CommentNode("$ moderator notes"),
             ]
         )
-        # substring search
+        # substring search, incl. regex metacharacters taken literally
         assert [c.contents for c in comments.search("fuel")] == ["the fuel region"]
         assert len(comments.search("graphite")) == 0
-        # regex search
-        matches = comments.search(r"(?i)FUEL|MODERATOR", regex=True)
+        assert len(comments.search("fuel|moderator")) == 0
+        # compiled patterns are treated as regular expressions
+        matches = comments.search(re.compile(r"(?i)FUEL|MODERATOR"))
         assert len(matches) == 2
         assert isinstance(matches, montepy.CommentCollection)
-        # compiled patterns are always treated as regular expressions
-        assert len(comments.search(re.compile("notes"))) == 1
-        # non-string patterns are rejected, with or without regex
+        # non-string patterns are rejected
         with pytest.raises(TypeError):
             comments.search(5)
-        with pytest.raises(TypeError):
-            comments.search(5, regex=True)
         # bytes patterns cannot search the str contents
         with pytest.raises(TypeError):
             comments.search(re.compile(b"fuel"))
@@ -669,7 +666,7 @@ def test_object_comments_are_collection():
     # an object can be found by its comment text (#185)
     assert "hidden vertical" in cell.comments
     assert "not actually in there" not in cell.comments
-    assert len(cell.comments.search(r"(?i)HIDDEN", regex=True)) == 1
+    assert len(cell.comments.search(re.compile(r"(?i)HIDDEN"))) == 1
 
 
 def test_graveyard_comment():

--- a/tests/test_syntax_parsing.py
+++ b/tests/test_syntax_parsing.py
@@ -603,6 +603,20 @@ class TestPaddingNode:
         assert len(list(comment.comments)) == 1
         assert len(comment.contents) == 0
 
+    def test_comment_contains(self):
+        comment = syntax_node.CommentNode("c hello world")
+        assert "hello" in comment
+        assert "goodbye" not in comment
+        # the delimiter itself is not part of the contents
+        assert "c " not in comment
+        # works for dollar comments and across appended lines
+        comment.append("c second line")
+        assert "second" in comment
+        assert "note" in syntax_node.CommentNode("$ note here")
+        # non-string operands are rejected like normal str containment
+        with pytest.raises(TypeError):
+            5 in comment
+
 
 def test_graveyard_comment():
     padding = syntax_node.PaddingNode(" ")

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -86,6 +86,53 @@ class TestUniverseInput:
         input_obj = Input(["U -2"], BlockType.DATA)
         UniverseInput(input_obj)
 
+    def test_universe_data_card_multiply_shortcut(self, tmp_path):
+        input_file = tmp_path / "test_universe_m_shortcut.imcnp"
+        input_file.write_text("""MCNP Test Model
+C Cells
+C Graveyard
+99    0 +1010
+C Seven spheres within a sphere
+1 1 -10 -1001
+2 1 -10 -1002
+3 1 -10 -1003
+4 1 -10 -1004
+5 1 -10 -1005
+6 1 -10 -1006
+7 1 -10 -1007
+8     0 -1010  1001  1002  1003  1004  1005  1006  1007
+
+C surfaces
+1001 SO      0.1
+1002 SX -1.1 0.1
+1003 SX +1.1 0.1
+1004 SY -1.1 0.1
+1005 SY +1.1 0.1
+1006 SZ -1.1 0.1
+1007 SZ +1.1 0.1
+1010 SO 3
+
+C data
+C mX fails to parse
+C     _ 1  2 10 _ 3 21 21
+U     J 1 2M 5M J 3 7M 1M
+C materials
+C UO2 5 atpt enriched
+m1        92235.80c           5
+          92238.80c          95
+C execution
+ksrc 0 0 0
+kcode 100000 1.000 50 1050
+mode n p
+""")
+        problem = montepy.read_input(input_file)
+        universe_numbers = [
+            cell.universe.number if cell.universe is not None else None
+            for cell in problem.cells
+        ]
+
+        assert universe_numbers == [0, 1, 2, 10, 0, 3, 21, 21, 0]
+
     def test_str(self):
         universe_input = copy.deepcopy(self.universe)
         uni = Universe(5)

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -489,8 +489,8 @@ class TestFill:
             fill1.merge(fill2)
 
     @given(
-        indices=st.lists(st.integers(), min_size=3, max_size=3),
-        width=st.lists(st.integers(1), min_size=3, max_size=3),
+        indices=st.lists(st.integers(-1_000_000, 1_000_000), min_size=3, max_size=3),
+        width=st.lists(st.integers(1, 1_000_000), min_size=3, max_size=3),
     )
     def test_fill_index_setter(self, indices, width):
         fill = self.simple_fill.clone()

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -86,52 +86,11 @@ class TestUniverseInput:
         input_obj = Input(["U -2"], BlockType.DATA)
         UniverseInput(input_obj)
 
-    def test_universe_data_card_multiply_shortcut(self, tmp_path):
-        input_file = tmp_path / "test_universe_m_shortcut.imcnp"
-        input_file.write_text("""MCNP Test Model
-C Cells
-C Graveyard
-99    0 +1010
-C Seven spheres within a sphere
-1 1 -10 -1001
-2 1 -10 -1002
-3 1 -10 -1003
-4 1 -10 -1004
-5 1 -10 -1005
-6 1 -10 -1006
-7 1 -10 -1007
-8     0 -1010  1001  1002  1003  1004  1005  1006  1007
+    def test_universe_data_card_multiply_shortcut(self):
+        input_obj = Input(["U J 1 2M 5M 3M J 3 7M 1M"], BlockType.DATA)
+        uni_card = UniverseInput(input_obj)
 
-C surfaces
-1001 SO      0.1
-1002 SX -1.1 0.1
-1003 SX +1.1 0.1
-1004 SY -1.1 0.1
-1005 SY +1.1 0.1
-1006 SZ -1.1 0.1
-1007 SZ +1.1 0.1
-1010 SO 3
-
-C data
-C mX fails to parse
-C     _ 1  2 10 _ 3 21 21
-U     J 1 2M 5M J 3 7M 1M
-C materials
-C UO2 5 atpt enriched
-m1        92235.80c           5
-          92238.80c          95
-C execution
-ksrc 0 0 0
-kcode 100000 1.000 50 1050
-mode n p
-""")
-        problem = montepy.read_input(input_file)
-        universe_numbers = [
-            cell.universe.number if cell.universe is not None else None
-            for cell in problem.cells
-        ]
-
-        assert universe_numbers == [0, 1, 2, 10, 0, 3, 21, 21, 0]
+        assert uni_card.old_numbers == [None, 1, 2, 10, 30, None, 3, 21, 21]
 
     def test_str(self):
         universe_input = copy.deepcopy(self.universe)


### PR DESCRIPTION
**Features Added**

* Added `HalfSpace.replace` to swap dividers in a cell geometry tree, and `HalfSpace.__iter__` to traverse geometry leaves (#737).
* Added `montepy.Cell.is_mass_dens` as the logical complement of `montepy.Cell.is_atom_dens`, returning `None` when no density is set (#964).
* Added support for the `in` operator on comments, so a comment's text can be searched with e.g. `"keyword" in comment` (#185).
* Added `montepy.comments.CommentCollection`, now returned by `comments` and `leading_comments`, so an object can be found by its comments with e.g. `"keyword" in cell.comments`, or searched by regular expression with `cell.comments.search` (#185).

**Bugs Fixed**

* Fixed parsing of multiply shortcuts in universe data cards such as `1 8M` (#975).
* Fixed `leading_comments` crashing when set with more than one comment (#972).
* Fixed bug where values for user generated objects would be rounded off at five digits no matter what. This will now round off at 15 digits if necessary (#962).

**Performance Improvement**

* Fixed `_ExceptionContextAdder` wrapping every method and property, including private and dunder ones, in a try/except due to a missing `continue`, and reduced `MCNP_Object.__setattr__` from two class lookups to one (#990).

<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--992.org.readthedocs.build/en/992/

<!-- readthedocs-preview montepy end -->