### PR TITLE
Fix docstrings naming parameters that are not in the signature

### DIFF
--- a/montepy/data_inputs/nuclide.py
+++ b/montepy/data_inputs/nuclide.py
@@ -760,8 +760,8 @@ class Nuclide:
 
         Parameters
         ----------
-        identifier
-        idenitifer : Union[str, int, element, Nucleus, Nuclide]
+        identifier : Union[str, int, element, Nucleus, Nuclide]
+            the name to parse.
 
         Returns
         -------

--- a/montepy/input_parser/syntax_node.py
+++ b/montepy/input_parser/syntax_node.py
@@ -698,8 +698,8 @@ class PaddingNode(SyntaxNodeBase):
 
         Parameters
         ----------
-        node : str, CommentNode
-            node
+        val : str, CommentNode
+            the node to append.
         is_comment : bool
             whether or not the node is a comment.
         """
@@ -1862,8 +1862,8 @@ class ListNode(SyntaxNodeBase):
 
         Parameters
         ----------
-        node : ValueNode, ShortcutNode
-            node
+        val : ValueNode, ShortcutNode
+            the node to append.
         from_parsing : bool
             If this is being append from the parsers, and not elsewhere.
         """

--- a/montepy/numbered_object_collection.py
+++ b/montepy/numbered_object_collection.py
@@ -1068,8 +1068,8 @@ class NumberedObjectCollection(ABC):
 
         Parameters
         ----------
-        others : Self
-            the other collections to compare to.
+        other : Self
+            the other collection to compare to.
 
         Returns
         -------
@@ -1086,8 +1086,8 @@ class NumberedObjectCollection(ABC):
 
         Parameters
         ----------
-        others : Self
-            the other collections to compare to.
+        other : Self
+            the other collection to compare to.
         """
         self ^= other
         return self

--- a/montepy/surfaces/surface.py
+++ b/montepy/surfaces/surface.py
@@ -553,8 +553,8 @@ class Surface(Numbered_MCNP_Object, metaclass=_SurfaceClassFactory):
         ----------
         surfaces : Surfaces
             A Surfaces collection of the surfaces in the problem.
-        data_cards : list
-            the data_cards in the problem.
+        data_inputs : list
+            the data inputs in the problem.
         """
         if self.old_periodic_surface:
             try:


### PR DESCRIPTION
### Description

Fixes #1002.

Four docstrings name a parameter the function does not take. Details and the reasoning for each are in the issue; in short:

- `symmetric_difference` / `symmetric_difference_update` document `others` (plural, "the other collections") but take a single `other` — the text was copied from `difference(*others)` above, which really is varargs.
- `PaddingNode.append` and `ListNode.append` document `node`; both signatures are `append(self, val, ...)`.
- `Nuclide._parse_fancy_name` has two Parameters entries for one argument: a bare `identifier`, then `idenitifer` with the letters transposed.
- `Surface.update_pointers` documents `data_cards`; the signature is `data_inputs`, and `Material.update_pointers` and `ThermalScatteringLaw.update_pointers` already document it that way.

Docstrings only — no code, no behaviour change, so there is nothing for a test to assert. Say the word if you would rather have it covered some other way.

---

### General Checklist

- [x] I have performed a self-review of my own code.
- [x] The code follows the standards outlined in the [development documentation](https://www.montepy.org/en/stable/dev_standards.html).
- [x] I have formatted my code with `black` version 25 or 26.
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable) — not applicable, docstrings only.

---

### LLM Disclosure

1. Are you?

   - [x] A human user
   - [ ] A large language model (LLM), including ones acting on behalf of a human

1. Were any large language models (LLM or "AI") used in to generate any of this code?

  - [x] Yes
      - Model(s) used: Claude Opus (Claude Code)
  - [ ] No

The four were found by comparing every NumPy-style `Parameters` block in the package against the actual signature, then reading each hit to rule out decorators, `**kwargs` and the property-setter documentation style used in `fill.py` and `importance.py` (those two are deliberate and were left alone).

<details open>

<summary><h2>Documentation Checklist</h2></summary>

- [x] I have documented all added classes and methods.
- [x] I have added [type hints](https://peps.python.org/pep-0484/) to all functions as needed.
- [ ] I have marked all changes with the `.. versionchanged::` or `.. versionadded::` directives — not applicable, no API change.

</details>


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--1003.org.readthedocs.build/en/1003/

<!-- readthedocs-preview montepy end -->


<!-- readthedocs-preview montepy start -->
----
📚 Documentation preview 📚: https://montepy--1003.org.readthedocs.build/en/1003/

<!-- readthedocs-preview montepy end -->